### PR TITLE
fix(funding-platform): resync application status and handle 409 conflicts

### DIFF
--- a/__tests__/components/FundingPlatform/ApplicationList/ApplicationListStatusConflict.test.tsx
+++ b/__tests__/components/FundingPlatform/ApplicationList/ApplicationListStatusConflict.test.tsx
@@ -10,7 +10,7 @@ import userEvent from "@testing-library/user-event";
 import React from "react";
 import { renderWithProviders } from "@/__tests__/utils/render";
 import type { IFundingApplication } from "@/types/funding-platform";
-import { STATUS_CONFLICT_MESSAGE } from "@/utilities/application-status";
+import { STATUS_CONFLICT_MESSAGE, STATUS_CONFLICT_TOAST_ID } from "@/utilities/application-status";
 
 const mockToastError = vi.fn();
 const mockToastSuccess = vi.fn();
@@ -94,7 +94,22 @@ const renderList = (
     />
   );
 
-const conflictError = () => ({ response: { status: 409, data: { message: "conflict" } } });
+const conflictError = () => ({
+  response: {
+    status: 409,
+    data: { message: "Invalid status transition from 'approved' to 'approved'." },
+  },
+});
+
+// Same 409, different cause: the reviewer can fix this one in the open modal.
+const currencyMismatchError = () => ({
+  response: {
+    status: 409,
+    data: {
+      message: "Currency mismatch: Approved currency 'USDC' does not match program currency 'ETH'.",
+    },
+  },
+});
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -130,28 +145,81 @@ describe("ApplicationList status conflict", () => {
     expect(mockToastError).not.toHaveBeenCalled();
   });
 
+  it("should_keep_the_modal_open_when_a_409_is_a_correctable_validation_error", async () => {
+    const user = userEvent.setup();
+    const onStatusChange = vi.fn().mockRejectedValue(currencyMismatchError());
+
+    renderList({ onStatusChange });
+
+    await user.click(screen.getByText("Approve APP-001"));
+    await user.click(await screen.findByText("Confirm"));
+
+    await waitFor(() => expect(onStatusChange).toHaveBeenCalled());
+    // The typed amount/currency/reason must survive so the reviewer can fix them.
+    expect(screen.getByTestId("status-modal")).toBeInTheDocument();
+  });
+
   it("should_not_send_the_update_when_the_refetched_status_no_longer_allows_it", async () => {
     const user = userEvent.setup();
     const onStatusChange = vi.fn();
-    const onRefreshApplications = vi
+    const onFetchApplication = vi
       .fn()
-      .mockResolvedValue([createMockApplication({ status: "approved" })]);
+      .mockResolvedValue(createMockApplication({ status: "approved" }));
+    const onRefreshApplications = vi.fn().mockResolvedValue([]);
 
-    renderList({ onStatusChange, onRefreshApplications });
+    renderList({ onStatusChange, onFetchApplication, onRefreshApplications });
 
     await user.click(screen.getByText("Approve APP-001"));
 
     await waitFor(() => expect(mockToastError).toHaveBeenCalledTimes(1));
-    expect(mockToastError).toHaveBeenCalledWith(STATUS_CONFLICT_MESSAGE);
+    expect(mockToastError).toHaveBeenCalledWith(STATUS_CONFLICT_MESSAGE, {
+      id: STATUS_CONFLICT_TOAST_ID,
+    });
+    expect(onFetchApplication).toHaveBeenCalledWith("APP-001");
     expect(onStatusChange).not.toHaveBeenCalled();
     expect(screen.queryByTestId("status-modal")).not.toBeInTheDocument();
+    // The stale row keeps rendering its dead actions until the list re-reads.
+    expect(onRefreshApplications).toHaveBeenCalledTimes(1);
+  });
+
+  it("should_issue_a_single_freshness_read_when_the_row_action_is_double_clicked", async () => {
+    const user = userEvent.setup();
+    let resolveFetch: (application: IFundingApplication) => void = () => undefined;
+    const onFetchApplication = vi.fn(
+      () =>
+        new Promise<IFundingApplication>((resolve) => {
+          resolveFetch = resolve;
+        })
+    );
+
+    renderList({ onStatusChange: vi.fn(), onFetchApplication });
+
+    const action = screen.getByText("Approve APP-001");
+    await user.click(action);
+    await user.click(action);
+    resolveFetch(createMockApplication());
+
+    await waitFor(() => expect(screen.getByTestId("status-modal")).toBeInTheDocument());
+    expect(onFetchApplication).toHaveBeenCalledTimes(1);
   });
 
   it("should_open_the_modal_when_the_refetched_status_still_allows_the_transition", async () => {
     const user = userEvent.setup();
-    const onRefreshApplications = vi.fn().mockResolvedValue([createMockApplication()]);
+    const onFetchApplication = vi.fn().mockResolvedValue(createMockApplication());
 
-    renderList({ onStatusChange: vi.fn(), onRefreshApplications });
+    renderList({ onStatusChange: vi.fn(), onFetchApplication });
+
+    await user.click(screen.getByText("Approve APP-001"));
+
+    expect(await screen.findByTestId("status-modal")).toBeInTheDocument();
+    expect(mockToastError).not.toHaveBeenCalled();
+  });
+
+  it("should_fall_back_to_the_rendered_row_when_the_freshness_read_fails", async () => {
+    const user = userEvent.setup();
+    const onFetchApplication = vi.fn().mockResolvedValue(null);
+
+    renderList({ onStatusChange: vi.fn(), onFetchApplication });
 
     await user.click(screen.getByText("Approve APP-001"));
 

--- a/__tests__/components/FundingPlatform/ApplicationList/ApplicationListStatusConflict.test.tsx
+++ b/__tests__/components/FundingPlatform/ApplicationList/ApplicationListStatusConflict.test.tsx
@@ -1,0 +1,161 @@
+/**
+ * Status-conflict handling on the applications table (Sentry GAP-INDEXER-Y5).
+ * The row actions can be stale, so the list pre-checks the transition against a
+ * fresh fetch and closes the modal on a 409 instead of inviting another retry.
+ */
+
+import "@testing-library/jest-dom/vitest";
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import React from "react";
+import { renderWithProviders } from "@/__tests__/utils/render";
+import type { IFundingApplication } from "@/types/funding-platform";
+import { STATUS_CONFLICT_MESSAGE } from "@/utilities/application-status";
+
+const mockToastError = vi.fn();
+const mockToastSuccess = vi.fn();
+
+vi.mock("react-hot-toast", () => ({
+  __esModule: true,
+  default: {
+    error: (...args: unknown[]) => mockToastError(...args),
+    success: (...args: unknown[]) => mockToastSuccess(...args),
+  },
+}));
+
+// Stand-ins for the heavy table + modal: they only need to expose the two
+// interactions under test (click a row action, confirm the modal).
+vi.mock("@/components/FundingPlatform/ApplicationList/ApplicationTable", () => ({
+  ApplicationTable: ({
+    applications,
+    onStatusChange,
+  }: {
+    applications: IFundingApplication[];
+    onStatusChange: (applicationId: string, status: string, e: React.MouseEvent) => void;
+  }) =>
+    React.createElement(
+      "div",
+      null,
+      applications.map((application) =>
+        React.createElement(
+          "button",
+          {
+            key: application.referenceNumber,
+            type: "button",
+            onClick: (e: React.MouseEvent) =>
+              onStatusChange(application.referenceNumber, "approved", e),
+          },
+          `Approve ${application.referenceNumber}`
+        )
+      )
+    ),
+}));
+
+vi.mock("@/components/FundingPlatform/ApplicationView/StatusChangeModal", () => ({
+  __esModule: true,
+  default: ({ isOpen, onConfirm }: { isOpen: boolean; onConfirm: () => Promise<void> }) =>
+    isOpen
+      ? React.createElement(
+          "div",
+          { "data-testid": "status-modal" },
+          React.createElement("button", { type: "button", onClick: () => onConfirm() }, "Confirm")
+        )
+      : null,
+}));
+
+import { ApplicationList } from "@/components/FundingPlatform/ApplicationList/ApplicationList";
+
+const createMockApplication = (overrides: Partial<IFundingApplication> = {}): IFundingApplication =>
+  ({
+    id: "app-1",
+    referenceNumber: "APP-001",
+    programId: "prog-1",
+    chainID: 42161,
+    status: "under_review",
+    applicantEmail: "applicant@example.com",
+    applicationData: {},
+    createdAt: "2026-07-01T00:00:00.000Z",
+    updatedAt: "2026-07-01T00:00:00.000Z",
+    ...overrides,
+  }) as IFundingApplication;
+
+const renderList = (
+  props: Partial<React.ComponentProps<typeof ApplicationList>> = {},
+  applications: IFundingApplication[] = [createMockApplication()]
+) =>
+  renderWithProviders(
+    <ApplicationList
+      programId="prog-1"
+      applications={applications}
+      showStatusActions
+      addProgramReviewer={vi.fn()}
+      addMilestoneReviewer={vi.fn()}
+      {...props}
+    />
+  );
+
+const conflictError = () => ({ response: { status: 409, data: { message: "conflict" } } });
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("ApplicationList status conflict", () => {
+  it("should_close_the_modal_without_a_second_toast_when_the_update_returns_409", async () => {
+    const user = userEvent.setup();
+    const onStatusChange = vi.fn().mockRejectedValue(conflictError());
+
+    renderList({ onStatusChange });
+
+    await user.click(screen.getByText("Approve APP-001"));
+    await user.click(await screen.findByText("Confirm"));
+
+    await waitFor(() => expect(screen.queryByTestId("status-modal")).not.toBeInTheDocument());
+    // The mutation hook owns the failure toast — the list must not add a second one.
+    expect(mockToastError).not.toHaveBeenCalled();
+    expect(mockToastSuccess).not.toHaveBeenCalled();
+  });
+
+  it("should_keep_the_modal_open_when_the_failure_is_not_a_conflict", async () => {
+    const user = userEvent.setup();
+    const onStatusChange = vi.fn().mockRejectedValue({ response: { status: 500 } });
+
+    renderList({ onStatusChange });
+
+    await user.click(screen.getByText("Approve APP-001"));
+    await user.click(await screen.findByText("Confirm"));
+
+    await waitFor(() => expect(onStatusChange).toHaveBeenCalled());
+    expect(screen.getByTestId("status-modal")).toBeInTheDocument();
+    expect(mockToastError).not.toHaveBeenCalled();
+  });
+
+  it("should_not_send_the_update_when_the_refetched_status_no_longer_allows_it", async () => {
+    const user = userEvent.setup();
+    const onStatusChange = vi.fn();
+    const onRefreshApplications = vi
+      .fn()
+      .mockResolvedValue([createMockApplication({ status: "approved" })]);
+
+    renderList({ onStatusChange, onRefreshApplications });
+
+    await user.click(screen.getByText("Approve APP-001"));
+
+    await waitFor(() => expect(mockToastError).toHaveBeenCalledTimes(1));
+    expect(mockToastError).toHaveBeenCalledWith(STATUS_CONFLICT_MESSAGE);
+    expect(onStatusChange).not.toHaveBeenCalled();
+    expect(screen.queryByTestId("status-modal")).not.toBeInTheDocument();
+  });
+
+  it("should_open_the_modal_when_the_refetched_status_still_allows_the_transition", async () => {
+    const user = userEvent.setup();
+    const onRefreshApplications = vi.fn().mockResolvedValue([createMockApplication()]);
+
+    renderList({ onStatusChange: vi.fn(), onRefreshApplications });
+
+    await user.click(screen.getByText("Approve APP-001"));
+
+    expect(await screen.findByTestId("status-modal")).toBeInTheDocument();
+    expect(mockToastError).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/components/FundingPlatform/ApplicationView/ReviewerStatusChange.test.tsx
+++ b/__tests__/components/FundingPlatform/ApplicationView/ReviewerStatusChange.test.tsx
@@ -369,6 +369,9 @@ describe("Reviewer Status Change Functionality", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockUpdateStatusAsync.mockResolvedValue({});
+    // Opening the status form pre-flights a refetch; resolving with no data
+    // makes the check fall back to the status the test mounted with.
+    mockRefetchApplication.mockResolvedValue({ data: undefined });
 
     // Reset hooks to default values
     vi.mocked(useApplication).mockReturnValue({

--- a/__tests__/components/FundingPlatform/ApplicationView/useApplicationDetailView.statusConflict.test.tsx
+++ b/__tests__/components/FundingPlatform/ApplicationView/useApplicationDetailView.statusConflict.test.tsx
@@ -1,0 +1,175 @@
+/**
+ * Status-conflict handling on the application detail view (Sentry
+ * GAP-INDEXER-Y5). The inline status form must not stay open after a 409, and
+ * opening it re-reads the application so a stale Approve button can't fire a
+ * transition the backend already rejected.
+ */
+
+import { act, waitFor } from "@testing-library/react";
+import { renderHookWithProviders } from "@/__tests__/utils/render";
+import { STATUS_CONFLICT_MESSAGE } from "@/utilities/application-status";
+
+const mockToastError = vi.fn();
+const mockUpdateStatusAsync = vi.fn();
+const mockRefetchApplication = vi.fn();
+
+let mockApplication: { id: string; referenceNumber: string; status: string } | undefined;
+let mockIsUpdatingStatus = false;
+
+vi.mock("react-hot-toast", () => ({
+  __esModule: true,
+  default: {
+    error: (...args: unknown[]) => mockToastError(...args),
+    success: vi.fn(),
+  },
+}));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn() }),
+  useSearchParams: () => ({ get: () => null }),
+}));
+
+vi.mock("@/hooks/useAuth", () => ({
+  useAuth: () => ({ address: "0xreviewer" }),
+}));
+
+vi.mock("@/hooks/useBackNavigation", () => ({
+  useBackNavigation: () => vi.fn(),
+}));
+
+vi.mock("@/hooks/useFundingPlatform", () => ({
+  useApplication: () => ({
+    application: mockApplication,
+    isLoading: false,
+    refetch: mockRefetchApplication,
+  }),
+  useApplicationComments: () => ({
+    comments: [],
+    isLoading: false,
+    createCommentAsync: vi.fn(),
+    editCommentAsync: vi.fn(),
+    deleteCommentAsync: vi.fn(),
+    refetch: vi.fn(),
+  }),
+  useApplicationStatus: () => ({
+    updateStatusAsync: mockUpdateStatusAsync,
+    isUpdating: mockIsUpdatingStatus,
+  }),
+  useApplicationVersions: () => ({ versions: [], refetch: vi.fn() }),
+  useDeleteApplication: () => ({ deleteApplicationAsync: vi.fn(), isDeleting: false }),
+  useProgramConfig: () => ({ data: undefined, config: undefined }),
+}));
+
+vi.mock("@/hooks/useKycStatus", () => ({
+  useKycStatus: () => ({ status: undefined }),
+  useKycConfig: () => ({ isEnabled: false }),
+}));
+
+vi.mock("@/src/core/rbac", async () => {
+  const actual = await vi.importActual<typeof import("@/src/core/rbac")>("@/src/core/rbac");
+  return {
+    ...actual,
+    useIsFundingPlatformAdmin: () => true,
+    useIsFundingPlatformReviewer: () => false,
+  };
+});
+
+vi.mock("@/src/core/rbac/context/permission-context", () => ({
+  usePermissionContext: () => ({ isLoading: false, can: () => true }),
+}));
+
+vi.mock("@/src/features/applications/hooks/use-milestones-admin-refetch", () => ({
+  useMilestonesAdminRefetch: () => undefined,
+}));
+
+vi.mock("@/store/applicationVersions", () => ({
+  useApplicationVersionsStore: () => ({ selectVersion: vi.fn() }),
+}));
+
+import { useApplicationDetailView } from "@/components/FundingPlatform/ApplicationView/useApplicationDetailView";
+
+const renderDetailView = () =>
+  renderHookWithProviders(() =>
+    useApplicationDetailView({
+      applicationId: "APP-001",
+      programId: "prog-1",
+      combinedProgramId: "prog-1_42161",
+      communityId: "octant",
+    })
+  );
+
+const conflictError = () => ({ response: { status: 409, data: { message: "conflict" } } });
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockIsUpdatingStatus = false;
+  mockApplication = { id: "app-1", referenceNumber: "APP-001", status: "under_review" };
+  mockRefetchApplication.mockResolvedValue({ data: mockApplication });
+  mockUpdateStatusAsync.mockResolvedValue(undefined);
+});
+
+describe("useApplicationDetailView status conflict", () => {
+  it("should_close_the_inline_form_without_a_second_toast_when_the_update_returns_409", async () => {
+    mockUpdateStatusAsync.mockRejectedValue(conflictError());
+    const { result } = renderDetailView();
+
+    await act(async () => {
+      await result.current.handleStatusChangeClick("approved");
+    });
+    expect(result.current.selectedStatus).toBe("approved");
+
+    await act(async () => {
+      await result.current.handleStatusChangeConfirm();
+    });
+
+    await waitFor(() => expect(result.current.selectedStatus).toBeNull());
+    // The mutation hook owns the failure toast — the view must not add a second one.
+    expect(mockToastError).not.toHaveBeenCalled();
+  });
+
+  it("should_keep_the_inline_form_open_when_the_failure_is_not_a_conflict", async () => {
+    mockUpdateStatusAsync.mockRejectedValue({ response: { status: 500 } });
+    const { result } = renderDetailView();
+
+    await act(async () => {
+      await result.current.handleStatusChangeClick("approved");
+    });
+    await act(async () => {
+      await result.current.handleStatusChangeConfirm();
+    });
+
+    expect(result.current.selectedStatus).toBe("approved");
+    expect(mockToastError).not.toHaveBeenCalled();
+  });
+
+  it("should_not_open_the_form_when_the_refetched_status_no_longer_allows_the_transition", async () => {
+    mockRefetchApplication.mockResolvedValue({
+      data: { ...mockApplication, status: "approved" },
+    });
+    const { result } = renderDetailView();
+
+    await act(async () => {
+      await result.current.handleStatusChangeClick("approved");
+    });
+
+    expect(result.current.selectedStatus).toBeNull();
+    expect(mockToastError).toHaveBeenCalledTimes(1);
+    expect(mockToastError).toHaveBeenCalledWith(STATUS_CONFLICT_MESSAGE);
+    expect(mockUpdateStatusAsync).not.toHaveBeenCalled();
+  });
+
+  it("should_ignore_a_confirm_that_arrives_while_an_update_is_in_flight", async () => {
+    mockIsUpdatingStatus = true;
+    const { result } = renderDetailView();
+
+    await act(async () => {
+      await result.current.handleStatusChangeClick("approved");
+    });
+    await act(async () => {
+      await result.current.handleStatusChangeConfirm();
+    });
+
+    expect(result.current.selectedStatus).toBe("approved");
+    expect(mockUpdateStatusAsync).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/components/FundingPlatform/ApplicationView/useApplicationDetailView.statusConflict.test.tsx
+++ b/__tests__/components/FundingPlatform/ApplicationView/useApplicationDetailView.statusConflict.test.tsx
@@ -7,7 +7,7 @@
 
 import { act, waitFor } from "@testing-library/react";
 import { renderHookWithProviders } from "@/__tests__/utils/render";
-import { STATUS_CONFLICT_MESSAGE } from "@/utilities/application-status";
+import { STATUS_CONFLICT_MESSAGE, STATUS_CONFLICT_TOAST_ID } from "@/utilities/application-status";
 
 const mockToastError = vi.fn();
 const mockUpdateStatusAsync = vi.fn();
@@ -98,7 +98,22 @@ const renderDetailView = () =>
     })
   );
 
-const conflictError = () => ({ response: { status: 409, data: { message: "conflict" } } });
+const conflictError = () => ({
+  response: {
+    status: 409,
+    data: { message: "Invalid status transition from 'approved' to 'approved'." },
+  },
+});
+
+// Same 409, different cause: the reviewer can fix this one in the open form.
+const currencyMismatchError = () => ({
+  response: {
+    status: 409,
+    data: {
+      message: "Currency mismatch: Approved currency 'USDC' does not match program currency 'ETH'.",
+    },
+  },
+});
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -142,6 +157,21 @@ describe("useApplicationDetailView status conflict", () => {
     expect(mockToastError).not.toHaveBeenCalled();
   });
 
+  it("should_keep_the_inline_form_open_when_a_409_is_a_correctable_validation_error", async () => {
+    mockUpdateStatusAsync.mockRejectedValue(currencyMismatchError());
+    const { result } = renderDetailView();
+
+    await act(async () => {
+      await result.current.handleStatusChangeClick("approved");
+    });
+    await act(async () => {
+      await result.current.handleStatusChangeConfirm(undefined, "100", "USDC");
+    });
+
+    // The entered amount/currency must survive so the reviewer can correct them.
+    expect(result.current.selectedStatus).toBe("approved");
+  });
+
   it("should_not_open_the_form_when_the_refetched_status_no_longer_allows_the_transition", async () => {
     mockRefetchApplication.mockResolvedValue({
       data: { ...mockApplication, status: "approved" },
@@ -154,8 +184,62 @@ describe("useApplicationDetailView status conflict", () => {
 
     expect(result.current.selectedStatus).toBeNull();
     expect(mockToastError).toHaveBeenCalledTimes(1);
-    expect(mockToastError).toHaveBeenCalledWith(STATUS_CONFLICT_MESSAGE);
+    expect(mockToastError).toHaveBeenCalledWith(STATUS_CONFLICT_MESSAGE, {
+      id: STATUS_CONFLICT_TOAST_ID,
+    });
     expect(mockUpdateStatusAsync).not.toHaveBeenCalled();
+  });
+
+  it("should_report_the_actions_as_busy_while_the_pre_flight_read_is_in_flight", async () => {
+    let resolveRefetch: (value: { data: typeof mockApplication }) => void = () => undefined;
+    mockRefetchApplication.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveRefetch = resolve;
+        })
+    );
+    const { result } = renderDetailView();
+
+    let pending: Promise<void> = Promise.resolve();
+    await act(async () => {
+      pending = result.current.handleStatusChangeClick("approved");
+    });
+
+    expect(result.current.isUpdatingStatus).toBe(true);
+
+    await act(async () => {
+      resolveRefetch({ data: mockApplication });
+      await pending;
+    });
+
+    expect(result.current.isUpdatingStatus).toBe(false);
+    expect(result.current.selectedStatus).toBe("approved");
+  });
+
+  it("should_issue_a_single_pre_flight_read_when_the_action_is_double_clicked", async () => {
+    let resolveRefetch: (value: { data: typeof mockApplication }) => void = () => undefined;
+    mockRefetchApplication.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveRefetch = resolve;
+        })
+    );
+    const { result } = renderDetailView();
+
+    let first: Promise<void> = Promise.resolve();
+    let second: Promise<void> = Promise.resolve();
+    await act(async () => {
+      first = result.current.handleStatusChangeClick("approved");
+      second = result.current.handleStatusChangeClick("approved");
+    });
+
+    await act(async () => {
+      resolveRefetch({ data: { ...mockApplication, status: "approved" } });
+      await Promise.all([first, second]);
+    });
+
+    expect(mockRefetchApplication).toHaveBeenCalledTimes(1);
+    expect(mockToastError).toHaveBeenCalledTimes(1);
   });
 
   it("should_ignore_a_confirm_that_arrives_while_an_update_is_in_flight", async () => {

--- a/__tests__/hooks/useFundingPlatformStatusConflict.test.tsx
+++ b/__tests__/hooks/useFundingPlatformStatusConflict.test.tsx
@@ -1,0 +1,205 @@
+/**
+ * Status-update conflict handling for the funding-platform mutations
+ * (Sentry GAP-INDEXER-Y5). A reviewer whose tab still shows stale actions gets
+ * a 409 from the backend; every mutation must re-sync its caches on failure and
+ * surface exactly one conflict toast so the dead buttons disappear.
+ */
+
+import { waitFor } from "@testing-library/react";
+import { createTestQueryClient, renderHookWithProviders } from "@/__tests__/utils/render";
+import { STATUS_CONFLICT_MESSAGE } from "@/utilities/application-status";
+
+const mockUpdateApplicationStatus = vi.fn();
+const mockGetApplication = vi.fn();
+const mockGetApplicationsByProgram = vi.fn();
+const mockGetApplicationStatistics = vi.fn();
+const mockToastError = vi.fn();
+
+vi.mock("react-hot-toast", () => ({
+  __esModule: true,
+  default: {
+    error: (...args: unknown[]) => mockToastError(...args),
+    success: vi.fn(),
+  },
+  toast: {
+    error: (...args: unknown[]) => mockToastError(...args),
+    success: vi.fn(),
+  },
+}));
+
+vi.mock("@/services/fundingPlatformService", () => {
+  const applications = {
+    updateApplicationStatus: (...args: unknown[]) => mockUpdateApplicationStatus(...args),
+    getApplication: (...args: unknown[]) => mockGetApplication(...args),
+    getApplicationsByProgram: (...args: unknown[]) => mockGetApplicationsByProgram(...args),
+    getApplicationStatistics: (...args: unknown[]) => mockGetApplicationStatistics(...args),
+  };
+  return {
+    fundingApplicationsAPI: applications,
+    fundingPlatformService: { applications, programs: {} },
+  };
+});
+
+vi.mock("@/hooks/useAuth", () => ({
+  useAuth: () => ({ authenticated: true, address: "0xreviewer" }),
+}));
+
+import {
+  useApplicationStatus,
+  useApplicationStatusV2,
+  useFundingApplication,
+  useFundingApplications,
+} from "@/hooks/useFundingPlatform";
+
+const PROGRAM_ID = "prog-1";
+const APPLICATION_ID = "APP-001";
+
+const conflictError = () => ({
+  response: {
+    status: 409,
+    data: { message: "Invalid status transition from 'approved' to 'approved'." },
+  },
+});
+
+const serverError = () => ({
+  response: { status: 500, data: { message: "Something exploded" } },
+});
+
+const emptyPage = {
+  applications: [],
+  pagination: { page: 1, limit: 25, total: 0, totalPages: 1 },
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockGetApplication.mockResolvedValue({ id: APPLICATION_ID, status: "approved" });
+  mockGetApplicationsByProgram.mockResolvedValue(emptyPage);
+  mockGetApplicationStatistics.mockResolvedValue({});
+});
+
+describe("useApplicationStatus", () => {
+  it("should_invalidate_application_and_list_caches_when_the_update_conflicts", async () => {
+    mockUpdateApplicationStatus.mockRejectedValue(conflictError());
+    const queryClient = createTestQueryClient();
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+
+    const { result } = renderHookWithProviders(() => useApplicationStatus(PROGRAM_ID), {
+      queryClient,
+    });
+
+    await expect(
+      result.current.updateStatusAsync({ applicationId: APPLICATION_ID, status: "approved" })
+    ).rejects.toBeTruthy();
+
+    await waitFor(() => {
+      expect(invalidateSpy).toHaveBeenCalledWith({
+        queryKey: ["funding-application", APPLICATION_ID],
+      });
+    });
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: ["applications", PROGRAM_ID, { limit: 25 }],
+    });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["reviewer-inbox"] });
+  });
+
+  it("should_show_a_single_conflict_toast_when_the_backend_returns_409", async () => {
+    mockUpdateApplicationStatus.mockRejectedValue(conflictError());
+
+    const { result } = renderHookWithProviders(() => useApplicationStatus(PROGRAM_ID));
+
+    await expect(
+      result.current.updateStatusAsync({ applicationId: APPLICATION_ID, status: "approved" })
+    ).rejects.toBeTruthy();
+
+    await waitFor(() => expect(mockToastError).toHaveBeenCalledTimes(1));
+    expect(mockToastError).toHaveBeenCalledWith(STATUS_CONFLICT_MESSAGE);
+  });
+
+  it("should_show_the_backend_message_when_the_failure_is_not_a_conflict", async () => {
+    mockUpdateApplicationStatus.mockRejectedValue(serverError());
+
+    const { result } = renderHookWithProviders(() => useApplicationStatus(PROGRAM_ID));
+
+    await expect(
+      result.current.updateStatusAsync({ applicationId: APPLICATION_ID, status: "approved" })
+    ).rejects.toBeTruthy();
+
+    await waitFor(() => expect(mockToastError).toHaveBeenCalledTimes(1));
+    expect(mockToastError).toHaveBeenCalledWith("Something exploded");
+  });
+});
+
+describe("useFundingApplications", () => {
+  it("should_invalidate_the_list_and_stats_when_the_update_conflicts", async () => {
+    mockUpdateApplicationStatus.mockRejectedValue(conflictError());
+    const queryClient = createTestQueryClient();
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+
+    const { result } = renderHookWithProviders(() => useFundingApplications(PROGRAM_ID), {
+      queryClient,
+    });
+
+    await expect(
+      result.current.updateApplicationStatus({
+        applicationId: APPLICATION_ID,
+        status: "approved",
+      })
+    ).rejects.toBeTruthy();
+
+    await waitFor(() => {
+      expect(invalidateSpy).toHaveBeenCalledWith({
+        queryKey: ["applications", PROGRAM_ID, { limit: 25 }],
+      });
+    });
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: ["application-stats", PROGRAM_ID],
+    });
+    expect(mockToastError).toHaveBeenCalledTimes(1);
+    expect(mockToastError).toHaveBeenCalledWith(STATUS_CONFLICT_MESSAGE);
+  });
+});
+
+describe("useFundingApplication", () => {
+  it("should_invalidate_the_application_cache_when_the_update_conflicts", async () => {
+    mockUpdateApplicationStatus.mockRejectedValue(conflictError());
+    const queryClient = createTestQueryClient();
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+
+    const { result } = renderHookWithProviders(() => useFundingApplication(APPLICATION_ID), {
+      queryClient,
+    });
+
+    result.current.updateStatus({ status: "approved" });
+
+    await waitFor(() => {
+      expect(invalidateSpy).toHaveBeenCalledWith({
+        queryKey: ["funding-application", APPLICATION_ID],
+      });
+    });
+    expect(mockToastError).toHaveBeenCalledTimes(1);
+    expect(mockToastError).toHaveBeenCalledWith(STATUS_CONFLICT_MESSAGE);
+  });
+});
+
+describe("useApplicationStatusV2", () => {
+  it("should_invalidate_the_application_and_all_lists_when_the_update_conflicts", async () => {
+    mockUpdateApplicationStatus.mockRejectedValue(conflictError());
+    const queryClient = createTestQueryClient();
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+
+    const { result } = renderHookWithProviders(() => useApplicationStatusV2(APPLICATION_ID), {
+      queryClient,
+    });
+
+    result.current.updateStatus(APPLICATION_ID, "approved", "");
+
+    await waitFor(() => {
+      expect(invalidateSpy).toHaveBeenCalledWith({
+        queryKey: ["funding-application", APPLICATION_ID],
+      });
+    });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["applications"] });
+    expect(mockToastError).toHaveBeenCalledTimes(1);
+    expect(mockToastError).toHaveBeenCalledWith(STATUS_CONFLICT_MESSAGE);
+  });
+});

--- a/__tests__/hooks/useFundingPlatformStatusConflict.test.tsx
+++ b/__tests__/hooks/useFundingPlatformStatusConflict.test.tsx
@@ -104,9 +104,7 @@ describe("useApplicationStatus", () => {
         queryKey: ["funding-application", APPLICATION_ID],
       });
     });
-    expect(invalidateSpy).toHaveBeenCalledWith({
-      queryKey: ["applications", PROGRAM_ID, { limit: 25 }],
-    });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["applications"] });
     expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["reviewer-inbox"] });
   });
 

--- a/__tests__/hooks/useFundingPlatformStatusConflict.test.tsx
+++ b/__tests__/hooks/useFundingPlatformStatusConflict.test.tsx
@@ -65,6 +65,14 @@ const serverError = () => ({
   response: { status: 500, data: { message: "Something exploded" } },
 });
 
+// The backend answers 409 for its whole validation family, so a correctable
+// input error shares the status code with a genuine transition conflict.
+const CURRENCY_MISMATCH_MESSAGE =
+  "Currency mismatch: Approved currency 'USDC' does not match program currency 'ETH'.";
+const currencyMismatchError = () => ({
+  response: { status: 409, data: { message: CURRENCY_MISMATCH_MESSAGE } },
+});
+
 const emptyPage = {
   applications: [],
   pagination: { page: 1, limit: 25, total: 0, totalPages: 1 },
@@ -126,6 +134,19 @@ describe("useApplicationStatus", () => {
 
     await waitFor(() => expect(mockToastError).toHaveBeenCalledTimes(1));
     expect(mockToastError).toHaveBeenCalledWith("Something exploded");
+  });
+
+  it("should_show_the_backend_message_when_a_409_is_a_correctable_validation_error", async () => {
+    mockUpdateApplicationStatus.mockRejectedValue(currencyMismatchError());
+
+    const { result } = renderHookWithProviders(() => useApplicationStatus(PROGRAM_ID));
+
+    await expect(
+      result.current.updateStatusAsync({ applicationId: APPLICATION_ID, status: "approved" })
+    ).rejects.toBeTruthy();
+
+    await waitFor(() => expect(mockToastError).toHaveBeenCalledTimes(1));
+    expect(mockToastError).toHaveBeenCalledWith(CURRENCY_MISMATCH_MESSAGE);
   });
 });
 

--- a/__tests__/integration/mutations/application-status.mutation.test.tsx
+++ b/__tests__/integration/mutations/application-status.mutation.test.tsx
@@ -3,7 +3,7 @@
  *
  * Tests the updateStatusMutation in useFundingApplication hook:
  * - PUT /v2/funding-applications/:applicationId/status
- * - Invalidates application cache on success
+ * - Invalidates application cache on settle (success and failure both re-sync)
  * - Shows error toast on failure
  */
 
@@ -119,7 +119,7 @@ describe("useFundingApplication.updateStatus (mutation integration)", () => {
     });
 
     // Verify that the cache was affected by the mutation (data should be refreshed)
-    // The mutation's onSuccess calls invalidateQueries. With gcTime:0 and no active
+    // The mutation's onSettled calls invalidateQueries. With gcTime:0 and no active
     // observers, the query may be GC'd (undefined state) or marked stale.
     // We verify the API was called correctly and the success flow completed instead.
     expect(capturedUrl).toBe(`/v2/funding-applications/${APPLICATION_ID}/status`);
@@ -150,7 +150,7 @@ describe("useFundingApplication.updateStatus (mutation integration)", () => {
     expect(capturedBody.reason).toBe("");
   });
 
-  it("shows error toast on status update failure", async () => {
+  it("shows the backend error message on status update failure", async () => {
     const mockApp = createMockApplication({ id: APPLICATION_ID });
 
     server.use(
@@ -170,10 +170,33 @@ describe("useFundingApplication.updateStatus (mutation integration)", () => {
 
     await waitFor(() => expect(result.current.isUpdatingStatus).toBe(false));
 
+    expect(toast.error).toHaveBeenCalledWith("Forbidden");
+  });
+
+  it("falls back to the generic message when the backend sends none", async () => {
+    const mockApp = createMockApplication({ id: APPLICATION_ID });
+
+    server.use(
+      http.get("*/v2/funding-applications/:applicationId", () => HttpResponse.json(mockApp)),
+      http.put("*/v2/funding-applications/:applicationId/status", () =>
+        HttpResponse.json({}, { status: 403 })
+      )
+    );
+
+    const { result } = renderHookWithProviders(() => useFundingApplication(APPLICATION_ID));
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    await act(async () => {
+      result.current.updateStatus({ status: "approved" });
+    });
+
+    await waitFor(() => expect(result.current.isUpdatingStatus).toBe(false));
+
     expect(toast.error).toHaveBeenCalledWith("Failed to update application status");
   });
 
-  it("does not invalidate cache on failure", async () => {
+  it("does not corrupt cached data on failure", async () => {
     const mockApp = createMockApplication({ id: APPLICATION_ID });
     const queryKey = ["funding-application", APPLICATION_ID];
 

--- a/components/FundingPlatform/ApplicationList/ApplicationList.tsx
+++ b/components/FundingPlatform/ApplicationList/ApplicationList.tsx
@@ -7,7 +7,9 @@ import type { MilestoneReviewer } from "@/services/milestone-reviewers.service";
 import type { ProgramReviewer } from "@/services/program-reviewers.service";
 import type { IApplicationListProps, IFundingApplication } from "@/types/funding-platform";
 import type { KycStatusResponse } from "@/types/kyc";
+import { isStatusConflictError, STATUS_CONFLICT_MESSAGE } from "@/utilities/application-status";
 import StatusChangeModal from "../ApplicationView/StatusChangeModal";
+import { isAllowedStatusTransition } from "../statusTransitions";
 import { ApplicationTable } from "./ApplicationTable";
 
 const EMPTY_KYC_MAP = new Map<string, KycStatusResponse | null>();
@@ -25,6 +27,8 @@ interface IApplicationListComponentProps extends IApplicationListProps {
     approvedCurrency?: string
   ) => Promise<void>;
   onExport?: () => void;
+  /** Re-reads the list from the API and resolves with the fresh rows. */
+  onRefreshApplications?: () => Promise<IFundingApplication[]>;
   showStatusActions?: boolean;
   sortBy?: IApplicationFilters["sortBy"];
   sortOrder?: IApplicationFilters["sortOrder"];
@@ -64,6 +68,7 @@ const ApplicationListComponent: FC<IApplicationListComponentProps> = ({
   onApplicationSelect,
   onApplicationHover,
   onStatusChange,
+  onRefreshApplications,
   showStatusActions = false,
   sortBy,
   sortOrder,
@@ -100,19 +105,34 @@ const ApplicationListComponent: FC<IApplicationListComponentProps> = ({
   const showAppReviewersColumn = useMemo(() => !!programId, [programId]);
   const showMilestoneReviewersColumn = useMemo(() => !!programId, [programId]);
 
+  const closeStatusModal = useCallback(() => {
+    setStatusModalOpen(false);
+    setPendingStatus("");
+    setPendingApplicationId("");
+    setPendingApplication(undefined);
+  }, []);
+
   const handleStatusChangeClick = useCallback(
-    (applicationId: string, newStatus: string, e: React.MouseEvent) => {
+    async (applicationId: string, newStatus: string, e: React.MouseEvent) => {
       e.stopPropagation();
-      // Find the application to pass to modal
-      const application = applications.find(
-        (app) => app.referenceNumber === applicationId || app.id === applicationId
-      );
+      // Re-read the list first: a long-lived tab can still render actions for a
+      // status another reviewer already moved past, and the PUT would only 409.
+      const matches = (app: IFundingApplication) =>
+        app.referenceNumber === applicationId || app.id === applicationId;
+      const rows = onRefreshApplications ? await onRefreshApplications() : applications;
+      // Falls back to the rendered row when the refreshed page no longer carries
+      // it (e.g. an active status filter dropped it).
+      const application = rows.find(matches) ?? applications.find(matches);
+      if (application && !isAllowedStatusTransition(application.status, newStatus)) {
+        toast.error(STATUS_CONFLICT_MESSAGE);
+        return;
+      }
       setPendingApplicationId(applicationId);
       setPendingStatus(newStatus);
       setPendingApplication(application);
       setStatusModalOpen(true);
     },
-    [applications]
+    [applications, onRefreshApplications]
   );
 
   const handleStatusChangeConfirm = async (
@@ -120,6 +140,7 @@ const ApplicationListComponent: FC<IApplicationListComponentProps> = ({
     approvedAmount?: string,
     approvedCurrency?: string
   ) => {
+    if (isUpdatingStatus) return;
     if (onStatusChange && pendingApplicationId && pendingStatus) {
       try {
         setIsUpdatingStatus(true);
@@ -130,20 +151,20 @@ const ApplicationListComponent: FC<IApplicationListComponentProps> = ({
           approvedAmount,
           approvedCurrency
         );
-        setIsUpdatingStatus(false);
-        setStatusModalOpen(false);
-        setPendingStatus("");
-        setPendingApplicationId("");
-        setPendingApplication(undefined);
+        closeStatusModal();
         if (pendingStatus === "approved") {
           toast.success("Application approved successfully!");
         } else {
           toast.success(`Application status updated to ${pendingStatus}`);
         }
       } catch (error) {
-        console.error("Failed to update status:", error);
+        // SUPPRESSED: the status mutation's onError owns the failure toast. A 409
+        // means the modal can never succeed, so close it instead of inviting a retry.
+        if (isStatusConflictError(error)) {
+          closeStatusModal();
+        }
+      } finally {
         setIsUpdatingStatus(false);
-        toast.error("Failed to update application status");
       }
     }
   };
@@ -209,12 +230,7 @@ const ApplicationListComponent: FC<IApplicationListComponentProps> = ({
       {/* Status Change Modal */}
       <StatusChangeModal
         isOpen={statusModalOpen}
-        onClose={() => {
-          setStatusModalOpen(false);
-          setPendingStatus("");
-          setPendingApplicationId("");
-          setPendingApplication(undefined);
-        }}
+        onClose={closeStatusModal}
         onConfirm={handleStatusChangeConfirm}
         status={pendingStatus}
         isSubmitting={isUpdatingStatus}

--- a/components/FundingPlatform/ApplicationList/ApplicationList.tsx
+++ b/components/FundingPlatform/ApplicationList/ApplicationList.tsx
@@ -8,6 +8,7 @@ import type { ProgramReviewer } from "@/services/program-reviewers.service";
 import type { IApplicationListProps, IFundingApplication } from "@/types/funding-platform";
 import type { KycStatusResponse } from "@/types/kyc";
 import {
+  formatApplicationStatus,
   isStatusConflictError,
   STATUS_CONFLICT_MESSAGE,
   STATUS_CONFLICT_TOAST_ID,
@@ -188,7 +189,7 @@ const ApplicationListComponent: FC<IApplicationListComponentProps> = ({
         if (pendingStatus === "approved") {
           toast.success("Application approved successfully!");
         } else {
-          toast.success(`Application status updated to ${pendingStatus}`);
+          toast.success(`Application status updated to ${formatApplicationStatus(pendingStatus)}`);
         }
       } catch (error) {
         // SUPPRESSED: the status mutation's onError owns the failure toast. Only

--- a/components/FundingPlatform/ApplicationList/ApplicationList.tsx
+++ b/components/FundingPlatform/ApplicationList/ApplicationList.tsx
@@ -1,13 +1,17 @@
 "use client";
 
-import React, { type FC, useCallback, useMemo, useState } from "react";
+import React, { type FC, useCallback, useMemo, useRef, useState } from "react";
 import toast from "react-hot-toast";
 import type { IApplicationFilters } from "@/services/fundingPlatformService";
 import type { MilestoneReviewer } from "@/services/milestone-reviewers.service";
 import type { ProgramReviewer } from "@/services/program-reviewers.service";
 import type { IApplicationListProps, IFundingApplication } from "@/types/funding-platform";
 import type { KycStatusResponse } from "@/types/kyc";
-import { isStatusConflictError, STATUS_CONFLICT_MESSAGE } from "@/utilities/application-status";
+import {
+  isStatusConflictError,
+  STATUS_CONFLICT_MESSAGE,
+  STATUS_CONFLICT_TOAST_ID,
+} from "@/utilities/application-status";
 import StatusChangeModal from "../ApplicationView/StatusChangeModal";
 import { isAllowedStatusTransition } from "../statusTransitions";
 import { ApplicationTable } from "./ApplicationTable";
@@ -27,8 +31,13 @@ interface IApplicationListComponentProps extends IApplicationListProps {
     approvedCurrency?: string
   ) => Promise<void>;
   onExport?: () => void;
-  /** Re-reads the list from the API and resolves with the fresh rows. */
+  /** Re-reads the list from the API. Used to drop row actions after a conflict. */
   onRefreshApplications?: () => Promise<IFundingApplication[]>;
+  /**
+   * Re-reads a single application from the API, resolving with `null` when the
+   * read fails. Backs the pre-flight transition check.
+   */
+  onFetchApplication?: (referenceNumber: string) => Promise<IFundingApplication | null>;
   showStatusActions?: boolean;
   sortBy?: IApplicationFilters["sortBy"];
   sortOrder?: IApplicationFilters["sortOrder"];
@@ -69,6 +78,7 @@ const ApplicationListComponent: FC<IApplicationListComponentProps> = ({
   onApplicationHover,
   onStatusChange,
   onRefreshApplications,
+  onFetchApplication,
   showStatusActions = false,
   sortBy,
   sortOrder,
@@ -91,6 +101,11 @@ const ApplicationListComponent: FC<IApplicationListComponentProps> = ({
   isLoadingKycStatuses = false,
 }) => {
   const [isUpdatingStatus, setIsUpdatingStatus] = useState(false);
+  // Pre-flight freshness read that runs before the modal opens. The ref rejects
+  // the second of two clicks landing in the same tick; the state disables the
+  // row actions so the first click never appears dead.
+  const [isCheckingStatus, setIsCheckingStatus] = useState(false);
+  const isCheckingStatusRef = useRef(false);
   const [statusModalOpen, setStatusModalOpen] = useState(false);
   const [pendingStatus, setPendingStatus] = useState<string>("");
   const [pendingApplicationId, setPendingApplicationId] = useState<string>("");
@@ -115,16 +130,34 @@ const ApplicationListComponent: FC<IApplicationListComponentProps> = ({
   const handleStatusChangeClick = useCallback(
     async (applicationId: string, newStatus: string, e: React.MouseEvent) => {
       e.stopPropagation();
-      // Re-read the list first: a long-lived tab can still render actions for a
-      // status another reviewer already moved past, and the PUT would only 409.
+      if (isCheckingStatusRef.current) return;
+
       const matches = (app: IFundingApplication) =>
         app.referenceNumber === applicationId || app.id === applicationId;
-      const rows = onRefreshApplications ? await onRefreshApplications() : applications;
-      // Falls back to the rendered row when the refreshed page no longer carries
-      // it (e.g. an active status filter dropped it).
-      const application = rows.find(matches) ?? applications.find(matches);
+      const renderedApplication = applications.find(matches);
+
+      // Re-read this one row first: a long-lived tab can still render actions
+      // for a status another reviewer already moved past, and the PUT would only
+      // 409. Reading the row directly (rather than refetching the list) also
+      // survives an active status filter having dropped it from the results.
+      let application = renderedApplication;
+      if (onFetchApplication) {
+        isCheckingStatusRef.current = true;
+        setIsCheckingStatus(true);
+        try {
+          application =
+            (await onFetchApplication(renderedApplication?.referenceNumber ?? applicationId)) ??
+            renderedApplication;
+        } finally {
+          isCheckingStatusRef.current = false;
+          setIsCheckingStatus(false);
+        }
+      }
+
       if (application && !isAllowedStatusTransition(application.status, newStatus)) {
-        toast.error(STATUS_CONFLICT_MESSAGE);
+        toast.error(STATUS_CONFLICT_MESSAGE, { id: STATUS_CONFLICT_TOAST_ID });
+        // Pull the table back in sync so the now-dead row actions disappear.
+        onRefreshApplications?.();
         return;
       }
       setPendingApplicationId(applicationId);
@@ -132,7 +165,7 @@ const ApplicationListComponent: FC<IApplicationListComponentProps> = ({
       setPendingApplication(application);
       setStatusModalOpen(true);
     },
-    [applications, onRefreshApplications]
+    [applications, onFetchApplication, onRefreshApplications]
   );
 
   const handleStatusChangeConfirm = async (
@@ -158,8 +191,9 @@ const ApplicationListComponent: FC<IApplicationListComponentProps> = ({
           toast.success(`Application status updated to ${pendingStatus}`);
         }
       } catch (error) {
-        // SUPPRESSED: the status mutation's onError owns the failure toast. A 409
-        // means the modal can never succeed, so close it instead of inviting a retry.
+        // SUPPRESSED: the status mutation's onError owns the failure toast. Only
+        // a transition conflict can never succeed, so close the modal then; a
+        // correctable failure (currency, amount, reason) stays open for a fix.
         if (isStatusConflictError(error)) {
           closeStatusModal();
         }
@@ -217,7 +251,7 @@ const ApplicationListComponent: FC<IApplicationListComponentProps> = ({
             onApplicationHover={onApplicationHover}
             onStatusChange={handleStatusChangeClick}
             onReviewerAssignmentChange={onReviewerAssignmentChange}
-            isUpdatingStatus={isUpdatingStatus}
+            isUpdatingStatus={isUpdatingStatus || isCheckingStatus}
             isKycEnabled={isKycEnabled}
             kycStatuses={kycStatuses}
             isLoadingKycStatuses={isLoadingKycStatuses}

--- a/components/FundingPlatform/ApplicationList/ApplicationListWithAPI.tsx
+++ b/components/FundingPlatform/ApplicationList/ApplicationListWithAPI.tsx
@@ -3,7 +3,6 @@
 import { useMutation } from "@tanstack/react-query";
 import pluralize from "pluralize";
 import { type FC, useCallback, useMemo } from "react";
-import { toast } from "react-hot-toast";
 import InfiniteScroll from "react-infinite-scroll-component";
 import {
   useApplicationExport,
@@ -67,6 +66,7 @@ const ApplicationListWithAPI: FC<IApplicationListWithAPIProps> = ({
     fetchNextPage,
     error,
     updateApplicationStatus,
+    refetchApplications,
     refetch,
   } = useFundingApplications(programId, queryParams);
 
@@ -141,11 +141,10 @@ const ApplicationListWithAPI: FC<IApplicationListWithAPIProps> = ({
       approvedAmount?: string;
       approvedCurrency?: string;
     }) => updateApplicationStatus(vars),
-    onSuccess: () => {
+    // `updateApplicationStatus` already invalidates the list and owns the failure
+    // toast; this only pulls the stats bar back in sync on both outcomes.
+    onSettled: () => {
       refetch();
-    },
-    onError: () => {
-      toast.error("Failed to update application status. Please try again.");
     },
   });
 
@@ -247,6 +246,7 @@ const ApplicationListWithAPI: FC<IApplicationListWithAPIProps> = ({
           onApplicationSelect={onApplicationSelect}
           onApplicationHover={onApplicationHover}
           onStatusChange={showStatusActions ? handleStatusChange : undefined}
+          onRefreshApplications={refetchApplications}
           showStatusActions={showStatusActions}
           sortBy={sortBy}
           sortOrder={sortOrder}

--- a/components/FundingPlatform/ApplicationList/ApplicationListWithAPI.tsx
+++ b/components/FundingPlatform/ApplicationList/ApplicationListWithAPI.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { useMutation } from "@tanstack/react-query";
 import pluralize from "pluralize";
 import { type FC, useCallback, useMemo } from "react";
 import InfiniteScroll from "react-infinite-scroll-component";
@@ -67,6 +66,7 @@ const ApplicationListWithAPI: FC<IApplicationListWithAPIProps> = ({
     error,
     updateApplicationStatus,
     refetchApplications,
+    fetchApplicationByReference,
     refetch,
   } = useFundingApplications(programId, queryParams);
 
@@ -133,21 +133,9 @@ const ApplicationListWithAPI: FC<IApplicationListWithAPIProps> = ({
     }
   );
 
-  const statusChangeMutation = useMutation({
-    mutationFn: (vars: {
-      applicationId: string;
-      status: string;
-      note?: string;
-      approvedAmount?: string;
-      approvedCurrency?: string;
-    }) => updateApplicationStatus(vars),
-    // `updateApplicationStatus` already invalidates the list and owns the failure
-    // toast; this only pulls the stats bar back in sync on both outcomes.
-    onSettled: () => {
-      refetch();
-    },
-  });
-
+  // `updateApplicationStatus` is the list mutation's `mutateAsync`; its own
+  // `onSettled` already invalidates the applications and stats queries on both
+  // outcomes, so no second refetch is layered on here.
   const handleStatusChange = useCallback(
     async (
       applicationId: string,
@@ -156,7 +144,7 @@ const ApplicationListWithAPI: FC<IApplicationListWithAPIProps> = ({
       approvedAmount?: string,
       approvedCurrency?: string
     ): Promise<void> => {
-      await statusChangeMutation.mutateAsync({
+      await updateApplicationStatus({
         applicationId,
         status,
         note,
@@ -164,7 +152,7 @@ const ApplicationListWithAPI: FC<IApplicationListWithAPIProps> = ({
         approvedCurrency,
       });
     },
-    [statusChangeMutation]
+    [updateApplicationStatus]
   );
 
   const handleExport = useCallback(
@@ -247,6 +235,7 @@ const ApplicationListWithAPI: FC<IApplicationListWithAPIProps> = ({
           onApplicationHover={onApplicationHover}
           onStatusChange={showStatusActions ? handleStatusChange : undefined}
           onRefreshApplications={refetchApplications}
+          onFetchApplication={fetchApplicationByReference}
           showStatusActions={showStatusActions}
           sortBy={sortBy}
           sortOrder={sortOrder}

--- a/components/FundingPlatform/ApplicationList/TableStatusActionButtons.tsx
+++ b/components/FundingPlatform/ApplicationList/TableStatusActionButtons.tsx
@@ -2,6 +2,7 @@
 
 import { CheckIcon, XMarkIcon } from "@heroicons/react/24/outline";
 import type { FC } from "react";
+import { getAllowedStatusTransitions } from "@/components/FundingPlatform/statusTransitions";
 import { Button } from "@/components/Utilities/Button";
 import { Can } from "@/src/core/rbac/components/can";
 import { Permission } from "@/src/core/rbac/types";
@@ -27,8 +28,10 @@ interface TableStatusTransition {
   permission: Permission;
 }
 
-// Configuration for allowed status transitions in table view with required permissions
-const TABLE_STATUS_TRANSITIONS: Record<FundingApplicationStatusV2, TableStatusTransition[]> = {
+// Presentation only (label/icon/style/permission + display order). Which
+// transitions are actually offered comes from the shared adjacency in
+// `statusTransitions`.
+const TABLE_STATUS_ACTIONS: Record<FundingApplicationStatusV2, TableStatusTransition[]> = {
   pending: [
     {
       targetStatus: "under_review",
@@ -136,12 +139,10 @@ export const TableStatusActionButtons: FC<TableStatusActionButtonsProps> = ({
   isUpdating = false,
   availableActions,
 }) => {
-  const availableTransitions = TABLE_STATUS_TRANSITIONS[currentStatus] || [];
-
-  // Don't show actions for final states
-  if (["approved", "rejected"].includes(currentStatus)) {
-    return null;
-  }
+  const allowedTargets = getAllowedStatusTransitions(currentStatus);
+  const availableTransitions = (TABLE_STATUS_ACTIONS[currentStatus] || []).filter((transition) =>
+    allowedTargets.includes(transition.targetStatus)
+  );
 
   if (availableTransitions.length === 0) {
     return null;

--- a/components/FundingPlatform/ApplicationList/TableStatusActionButtons.tsx
+++ b/components/FundingPlatform/ApplicationList/TableStatusActionButtons.tsx
@@ -2,7 +2,7 @@
 
 import { CheckIcon, XMarkIcon } from "@heroicons/react/24/outline";
 import type { FC } from "react";
-import { getAllowedStatusTransitions } from "@/components/FundingPlatform/statusTransitions";
+import { isAllowedStatusTransition } from "@/components/FundingPlatform/statusTransitions";
 import { Button } from "@/components/Utilities/Button";
 import { Can } from "@/src/core/rbac/components/can";
 import { Permission } from "@/src/core/rbac/types";
@@ -139,9 +139,8 @@ export const TableStatusActionButtons: FC<TableStatusActionButtonsProps> = ({
   isUpdating = false,
   availableActions,
 }) => {
-  const allowedTargets = getAllowedStatusTransitions(currentStatus);
   const availableTransitions = (TABLE_STATUS_ACTIONS[currentStatus] || []).filter((transition) =>
-    allowedTargets.includes(transition.targetStatus)
+    isAllowedStatusTransition(currentStatus, transition.targetStatus)
   );
 
   if (availableTransitions.length === 0) {

--- a/components/FundingPlatform/ApplicationView/ApplicationContent.tsx
+++ b/components/FundingPlatform/ApplicationView/ApplicationContent.tsx
@@ -164,7 +164,7 @@ const ApplicationContent: FC<ApplicationContentProps> = ({
           toast.success(`Application status updated to ${formatApplicationStatus(pendingStatus)}`);
         }
       } catch (error) {
-        // The mutation's onError owns the failure toast; a 409 can never succeed, so close.
+        // SUPPRESSED: mutation onError owns the failure toast; a 409 can never succeed, so close.
         if (isStatusConflictError(error)) closeStatusModal();
       } finally {
         setIsUpdatingStatus(false);

--- a/components/FundingPlatform/ApplicationView/ApplicationContent.tsx
+++ b/components/FundingPlatform/ApplicationView/ApplicationContent.tsx
@@ -20,7 +20,7 @@ import {
 } from "@/src/features/applications/lib/milestone-status";
 import { useApplicationVersionsStore } from "@/store/applicationVersions";
 import type { IFundingApplication, ProgramWithFormSchema } from "@/types/funding-platform";
-import { formatApplicationStatus } from "@/utilities/application-status";
+import { formatApplicationStatus, isStatusConflictError } from "@/utilities/application-status";
 import { createFieldLabelsMap, createFieldTypeMap } from "@/utilities/form-schema-helpers";
 import { formatDate } from "@/utilities/formatDate";
 import { cn } from "@/utilities/tailwind";
@@ -142,25 +142,33 @@ const ApplicationContent: FC<ApplicationContentProps> = ({
     setStatusModalOpen(true);
   };
 
+  const closeStatusModal = () => {
+    setStatusModalOpen(false);
+    setPendingStatus("");
+  };
+
   const handleStatusChangeConfirm = async (
     reason?: string,
     approvedAmount?: string,
     approvedCurrency?: string
   ) => {
+    if (isUpdatingStatus) return;
     if (onStatusChange && pendingStatus) {
       try {
         setIsUpdatingStatus(true);
         await onStatusChange(pendingStatus, reason, approvedAmount, approvedCurrency);
-        setStatusModalOpen(false);
-        setPendingStatus("");
+        closeStatusModal();
         if (pendingStatus === "approved") {
           toast.success("Application approved successfully!");
         } else {
           toast.success(`Application status updated to ${formatApplicationStatus(pendingStatus)}`);
         }
       } catch (error) {
-        console.error("Failed to update status:", error);
-        toast.error("Failed to update application status");
+        // SUPPRESSED: the status mutation's onError owns the failure toast. A 409
+        // means the modal can never succeed, so close it instead of inviting a retry.
+        if (isStatusConflictError(error)) {
+          closeStatusModal();
+        }
       } finally {
         setIsUpdatingStatus(false);
       }
@@ -449,10 +457,7 @@ const ApplicationContent: FC<ApplicationContentProps> = ({
         {/* Status Change Modal */}
         <StatusChangeModal
           isOpen={statusModalOpen}
-          onClose={() => {
-            setStatusModalOpen(false);
-            setPendingStatus("");
-          }}
+          onClose={closeStatusModal}
           onConfirm={handleStatusChangeConfirm}
           status={pendingStatus}
           isSubmitting={isUpdatingStatus}
@@ -681,10 +686,7 @@ const ApplicationContent: FC<ApplicationContentProps> = ({
       {/* Status Change Modal */}
       <StatusChangeModal
         isOpen={statusModalOpen}
-        onClose={() => {
-          setStatusModalOpen(false);
-          setPendingStatus("");
-        }}
+        onClose={closeStatusModal}
         onConfirm={handleStatusChangeConfirm}
         status={pendingStatus}
         isSubmitting={isUpdatingStatus}

--- a/components/FundingPlatform/ApplicationView/ApplicationContent.tsx
+++ b/components/FundingPlatform/ApplicationView/ApplicationContent.tsx
@@ -164,11 +164,8 @@ const ApplicationContent: FC<ApplicationContentProps> = ({
           toast.success(`Application status updated to ${formatApplicationStatus(pendingStatus)}`);
         }
       } catch (error) {
-        // SUPPRESSED: the status mutation's onError owns the failure toast. A 409
-        // means the modal can never succeed, so close it instead of inviting a retry.
-        if (isStatusConflictError(error)) {
-          closeStatusModal();
-        }
+        // The mutation's onError owns the failure toast; a 409 can never succeed, so close.
+        if (isStatusConflictError(error)) closeStatusModal();
       } finally {
         setIsUpdatingStatus(false);
       }

--- a/components/FundingPlatform/ApplicationView/HeaderActions.tsx
+++ b/components/FundingPlatform/ApplicationView/HeaderActions.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import type { FC } from "react";
-import { getAllowedStatusTransitions } from "@/components/FundingPlatform/statusTransitions";
+import { isAllowedStatusTransition } from "@/components/FundingPlatform/statusTransitions";
 import { Button } from "@/components/ui/button";
 import { Can } from "@/src/core/rbac/components/can";
 import { Permission } from "@/src/core/rbac/types";
@@ -87,9 +87,8 @@ export const HeaderActions: FC<HeaderActionsProps> = ({
   onStatusChange,
   isUpdating = false,
 }) => {
-  const allowedTargets = getAllowedStatusTransitions(currentStatus);
   const availableTransitions = (STATUS_TRANSITION_ACTIONS[currentStatus] || []).filter(
-    (transition) => allowedTargets.includes(transition.targetStatus)
+    (transition) => isAllowedStatusTransition(currentStatus, transition.targetStatus)
   );
 
   if (availableTransitions.length === 0) {

--- a/components/FundingPlatform/ApplicationView/HeaderActions.tsx
+++ b/components/FundingPlatform/ApplicationView/HeaderActions.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import type { FC } from "react";
+import { getAllowedStatusTransitions } from "@/components/FundingPlatform/statusTransitions";
 import { Button } from "@/components/ui/button";
 import { Can } from "@/src/core/rbac/components/can";
 import { Permission } from "@/src/core/rbac/types";
@@ -21,7 +22,9 @@ interface StatusTransition {
   permission: Permission;
 }
 
-const STATUS_TRANSITIONS: Record<ApplicationStatus, StatusTransition[]> = {
+// Presentation only (label/style/permission + display order). Which transitions
+// are actually offered comes from the shared adjacency in `statusTransitions`.
+const STATUS_TRANSITION_ACTIONS: Record<ApplicationStatus, StatusTransition[]> = {
   pending: [
     {
       targetStatus: "under_review",
@@ -84,7 +87,10 @@ export const HeaderActions: FC<HeaderActionsProps> = ({
   onStatusChange,
   isUpdating = false,
 }) => {
-  const availableTransitions = STATUS_TRANSITIONS[currentStatus] || [];
+  const allowedTargets = getAllowedStatusTransitions(currentStatus);
+  const availableTransitions = (STATUS_TRANSITION_ACTIONS[currentStatus] || []).filter(
+    (transition) => allowedTargets.includes(transition.targetStatus)
+  );
 
   if (availableTransitions.length === 0) {
     return null;

--- a/components/FundingPlatform/ApplicationView/StatusActionButtons.tsx
+++ b/components/FundingPlatform/ApplicationView/StatusActionButtons.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import type { FC } from "react";
-import { getAllowedStatusTransitions } from "@/components/FundingPlatform/statusTransitions";
+import { isAllowedStatusTransition } from "@/components/FundingPlatform/statusTransitions";
 import { Button } from "@/components/ui/button";
 import { Can } from "@/src/core/rbac/components/can";
 import { Permission } from "@/src/core/rbac/types";
@@ -118,9 +118,8 @@ export const StatusActionButtons: FC<StatusActionButtonsProps> = ({
   onStatusChange,
   isUpdating = false,
 }) => {
-  const allowedTargets = getAllowedStatusTransitions(currentStatus);
   const availableTransitions = (STATUS_TRANSITION_ACTIONS[currentStatus] || []).filter(
-    (transition) => allowedTargets.includes(transition.targetStatus)
+    (transition) => isAllowedStatusTransition(currentStatus, transition.targetStatus)
   );
 
   if (availableTransitions.length === 0) {

--- a/components/FundingPlatform/ApplicationView/StatusActionButtons.tsx
+++ b/components/FundingPlatform/ApplicationView/StatusActionButtons.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import type { FC } from "react";
+import { getAllowedStatusTransitions } from "@/components/FundingPlatform/statusTransitions";
 import { Button } from "@/components/ui/button";
 import { Can } from "@/src/core/rbac/components/can";
 import { Permission } from "@/src/core/rbac/types";
@@ -23,8 +24,9 @@ interface StatusTransition {
   permission: Permission;
 }
 
-// Configuration for allowed status transitions with required permissions
-const STATUS_TRANSITIONS: Record<ApplicationStatus, StatusTransition[]> = {
+// Presentation only (label/style/permission + display order). Which transitions
+// are actually offered comes from the shared adjacency in `statusTransitions`.
+const STATUS_TRANSITION_ACTIONS: Record<ApplicationStatus, StatusTransition[]> = {
   pending: [
     {
       targetStatus: "under_review",
@@ -116,7 +118,10 @@ export const StatusActionButtons: FC<StatusActionButtonsProps> = ({
   onStatusChange,
   isUpdating = false,
 }) => {
-  const availableTransitions = STATUS_TRANSITIONS[currentStatus] || [];
+  const allowedTargets = getAllowedStatusTransitions(currentStatus);
+  const availableTransitions = (STATUS_TRANSITION_ACTIONS[currentStatus] || []).filter(
+    (transition) => allowedTargets.includes(transition.targetStatus)
+  );
 
   if (availableTransitions.length === 0) {
     return null;

--- a/components/FundingPlatform/ApplicationView/StatusChangeInline.tsx
+++ b/components/FundingPlatform/ApplicationView/StatusChangeInline.tsx
@@ -263,6 +263,11 @@ export const StatusChangeInline: FC<StatusChangeInlineProps> = ({
   };
 
   const handleConfirm = async () => {
+    // Belt-and-braces against a double submit racing the disabled state
+    if (isSubmitting) {
+      return;
+    }
+
     if (isReasonActuallyRequired && !reason.trim()) {
       return;
     }

--- a/components/FundingPlatform/ApplicationView/StatusChangeModal.tsx
+++ b/components/FundingPlatform/ApplicationView/StatusChangeModal.tsx
@@ -292,6 +292,11 @@ const StatusChangeModal: FC<StatusChangeModalProps> = ({
   };
 
   const handleConfirm = async () => {
+    // Belt-and-braces against a double submit racing the disabled state
+    if (isSubmitting) {
+      return;
+    }
+
     // If reason is required but not provided, don't proceed
     if (isReasonActuallyRequired && !reason.trim()) {
       return;

--- a/components/FundingPlatform/ApplicationView/StatusChangeModal.tsx
+++ b/components/FundingPlatform/ApplicationView/StatusChangeModal.tsx
@@ -292,15 +292,9 @@ const StatusChangeModal: FC<StatusChangeModalProps> = ({
   };
 
   const handleConfirm = async () => {
-    // Belt-and-braces against a double submit racing the disabled state
-    if (isSubmitting) {
-      return;
-    }
-
-    // If reason is required but not provided, don't proceed
-    if (isReasonActuallyRequired && !reason.trim()) {
-      return;
-    }
+    // Guard against a double submit racing the disabled state
+    if (isSubmitting) return;
+    if (isReasonActuallyRequired && !reason.trim()) return;
 
     // If status is approved, validate amount and currency
     if (isApprovalStatus) {

--- a/components/FundingPlatform/ApplicationView/useApplicationDetailView.ts
+++ b/components/FundingPlatform/ApplicationView/useApplicationDetailView.ts
@@ -4,6 +4,7 @@ import { useRouter, useSearchParams } from "next/navigation";
 import { useEffect, useMemo, useState } from "react";
 import toast from "react-hot-toast";
 import type { ApplicationStatus } from "@/components/FundingPlatform/ApplicationView/HeaderActions";
+import { isAllowedStatusTransition } from "@/components/FundingPlatform/statusTransitions";
 import { useAuth } from "@/hooks/useAuth";
 import { useBackNavigation } from "@/hooks/useBackNavigation";
 import {
@@ -24,6 +25,7 @@ import { usePermissionContext } from "@/src/core/rbac/context/permission-context
 import { useMilestonesAdminRefetch } from "@/src/features/applications/hooks/use-milestones-admin-refetch";
 import { useApplicationVersionsStore } from "@/store/applicationVersions";
 import type { IFundingApplication } from "@/types/funding-platform";
+import { isStatusConflictError, STATUS_CONFLICT_MESSAGE } from "@/utilities/application-status";
 import { PAGES } from "@/utilities/pages";
 
 // Whitelist used when seeding activeTabId from the `?tab=` query
@@ -170,9 +172,22 @@ export function useApplicationDetailView({
     });
   };
 
-  // Show inline form (toggle if the same status is clicked again)
-  const handleStatusChangeClick = (status: ApplicationStatus) => {
-    setSelectedStatus((current) => (current === status ? null : status));
+  // Show inline form (toggle if the same status is clicked again). Re-reads the
+  // application first: a tab left open can still render actions for a status
+  // another reviewer already moved past, and the PUT would only 409.
+  const handleStatusChangeClick = async (status: ApplicationStatus) => {
+    if (selectedStatus === status) {
+      setSelectedStatus(null);
+      return;
+    }
+    const refreshed = await refetchApplication();
+    const currentStatus = refreshed?.data?.status ?? application?.status;
+    if (!isAllowedStatusTransition(currentStatus, status)) {
+      toast.error(STATUS_CONFLICT_MESSAGE);
+      setSelectedStatus(null);
+      return;
+    }
+    setSelectedStatus(status);
   };
 
   const handleStatusChangeConfirm = async (
@@ -180,7 +195,7 @@ export function useApplicationDetailView({
     approvedAmount?: string,
     approvedCurrency?: string
   ) => {
-    if (!selectedStatus) return;
+    if (!selectedStatus || isUpdatingStatus) return;
     try {
       await handleStatusChange(selectedStatus, reason, approvedAmount, approvedCurrency);
       setSelectedStatus(null);
@@ -189,8 +204,12 @@ export function useApplicationDetailView({
       } else {
         toast.success(`Application status updated to ${selectedStatus}`);
       }
-    } catch {
-      // SUPPRESSED: the status mutation's onError owns the failure toast; keep the form open to retry.
+    } catch (error) {
+      // SUPPRESSED: the status mutation's onError owns the failure toast. A 409
+      // means the form can never succeed, so close it instead of inviting a retry.
+      if (isStatusConflictError(error)) {
+        setSelectedStatus(null);
+      }
     }
   };
 

--- a/components/FundingPlatform/ApplicationView/useApplicationDetailView.ts
+++ b/components/FundingPlatform/ApplicationView/useApplicationDetailView.ts
@@ -1,7 +1,7 @@
 "use client";
 
 import { useRouter, useSearchParams } from "next/navigation";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import toast from "react-hot-toast";
 import type { ApplicationStatus } from "@/components/FundingPlatform/ApplicationView/HeaderActions";
 import { isAllowedStatusTransition } from "@/components/FundingPlatform/statusTransitions";
@@ -25,7 +25,11 @@ import { usePermissionContext } from "@/src/core/rbac/context/permission-context
 import { useMilestonesAdminRefetch } from "@/src/features/applications/hooks/use-milestones-admin-refetch";
 import { useApplicationVersionsStore } from "@/store/applicationVersions";
 import type { IFundingApplication } from "@/types/funding-platform";
-import { isStatusConflictError, STATUS_CONFLICT_MESSAGE } from "@/utilities/application-status";
+import {
+  isStatusConflictError,
+  STATUS_CONFLICT_MESSAGE,
+  STATUS_CONFLICT_TOAST_ID,
+} from "@/utilities/application-status";
 import { PAGES } from "@/utilities/pages";
 
 // Whitelist used when seeding activeTabId from the `?tab=` query
@@ -96,6 +100,11 @@ export function useApplicationDetailView({
 
   // Status change inline form state
   const [selectedStatus, setSelectedStatus] = useState<ApplicationStatus | null>(null);
+  // Pre-flight freshness read that runs before the inline form opens. The ref
+  // rejects the second of two clicks landing in the same tick; the state drives
+  // the buttons' busy/disabled look so the first click never appears dead.
+  const [isCheckingStatus, setIsCheckingStatus] = useState(false);
+  const isCheckingStatusRef = useRef(false);
 
   const {
     application,
@@ -176,18 +185,26 @@ export function useApplicationDetailView({
   // application first: a tab left open can still render actions for a status
   // another reviewer already moved past, and the PUT would only 409.
   const handleStatusChangeClick = async (status: ApplicationStatus) => {
+    if (isCheckingStatusRef.current) return;
     if (selectedStatus === status) {
       setSelectedStatus(null);
       return;
     }
-    const refreshed = await refetchApplication();
-    const currentStatus = refreshed?.data?.status ?? application?.status;
-    if (!isAllowedStatusTransition(currentStatus, status)) {
-      toast.error(STATUS_CONFLICT_MESSAGE);
-      setSelectedStatus(null);
-      return;
+    isCheckingStatusRef.current = true;
+    setIsCheckingStatus(true);
+    try {
+      const refreshed = await refetchApplication();
+      const currentStatus = refreshed?.data?.status ?? application?.status;
+      if (!isAllowedStatusTransition(currentStatus, status)) {
+        toast.error(STATUS_CONFLICT_MESSAGE, { id: STATUS_CONFLICT_TOAST_ID });
+        setSelectedStatus(null);
+        return;
+      }
+      setSelectedStatus(status);
+    } finally {
+      isCheckingStatusRef.current = false;
+      setIsCheckingStatus(false);
     }
-    setSelectedStatus(status);
   };
 
   const handleStatusChangeConfirm = async (
@@ -205,8 +222,9 @@ export function useApplicationDetailView({
         toast.success(`Application status updated to ${selectedStatus}`);
       }
     } catch (error) {
-      // SUPPRESSED: the status mutation's onError owns the failure toast. A 409
-      // means the form can never succeed, so close it instead of inviting a retry.
+      // SUPPRESSED: the status mutation's onError owns the failure toast. Only a
+      // transition conflict can never succeed, so close the form then; a
+      // correctable failure (currency, amount, reason) keeps it open for a fix.
       if (isStatusConflictError(error)) {
         setSelectedStatus(null);
       }
@@ -351,9 +369,10 @@ export function useApplicationDetailView({
     setApplicationViewMode,
     activeTabId,
     setActiveTabId,
-    // Status form
+    // Status form. The pre-flight read is folded into the busy flag so the
+    // action buttons disable for its round-trip instead of looking dead.
     selectedStatus,
-    isUpdatingStatus,
+    isUpdatingStatus: isUpdatingStatus || isCheckingStatus,
     handleStatusChangeClick,
     handleStatusChangeConfirm,
     handleStatusChangeCancel,

--- a/components/FundingPlatform/statusTransitions.ts
+++ b/components/FundingPlatform/statusTransitions.ts
@@ -6,7 +6,7 @@ import type { FundingApplicationStatusV2 } from "@/types/funding-platform";
  * labels/styles/permissions but must agree on this adjacency, and the
  * pre-flight staleness check validates against it before sending a PUT.
  */
-export const ALLOWED_STATUS_TRANSITIONS: Record<
+const ALLOWED_STATUS_TRANSITIONS: Record<
   FundingApplicationStatusV2,
   readonly FundingApplicationStatusV2[]
 > = {
@@ -18,19 +18,17 @@ export const ALLOWED_STATUS_TRANSITIONS: Record<
   rejected: [],
 };
 
-export const getAllowedStatusTransitions = (
-  currentStatus: string | null | undefined
-): readonly FundingApplicationStatusV2[] => {
-  if (!currentStatus) return [];
-  return (
-    ALLOWED_STATUS_TRANSITIONS[currentStatus.toLowerCase() as FundingApplicationStatusV2] ?? []
-  );
-};
+// Set-backed mirror of the adjacency for constant-time checks in render loops.
+const ALLOWED_TARGET_SETS = new Map<string, ReadonlySet<FundingApplicationStatusV2>>(
+  Object.entries(ALLOWED_STATUS_TRANSITIONS).map(([from, targets]) => [from, new Set(targets)])
+);
 
 export const isAllowedStatusTransition = (
   currentStatus: string | null | undefined,
   targetStatus: string
 ): boolean =>
-  getAllowedStatusTransitions(currentStatus).includes(
+  !!currentStatus &&
+  (ALLOWED_TARGET_SETS.get(currentStatus.toLowerCase())?.has(
     targetStatus.toLowerCase() as FundingApplicationStatusV2
-  );
+  ) ??
+    false);

--- a/components/FundingPlatform/statusTransitions.ts
+++ b/components/FundingPlatform/statusTransitions.ts
@@ -1,0 +1,36 @@
+import type { FundingApplicationStatusV2 } from "@/types/funding-platform";
+
+/**
+ * Single source of truth for which status transitions an application allows.
+ * The action-button surfaces (header, detail card, table row) keep their own
+ * labels/styles/permissions but must agree on this adjacency, and the
+ * pre-flight staleness check validates against it before sending a PUT.
+ */
+export const ALLOWED_STATUS_TRANSITIONS: Record<
+  FundingApplicationStatusV2,
+  readonly FundingApplicationStatusV2[]
+> = {
+  pending: ["under_review"],
+  resubmitted: ["under_review"],
+  under_review: ["revision_requested", "approved", "rejected"],
+  revision_requested: ["under_review"],
+  approved: [],
+  rejected: [],
+};
+
+export const getAllowedStatusTransitions = (
+  currentStatus: string | null | undefined
+): readonly FundingApplicationStatusV2[] => {
+  if (!currentStatus) return [];
+  return (
+    ALLOWED_STATUS_TRANSITIONS[currentStatus.toLowerCase() as FundingApplicationStatusV2] ?? []
+  );
+};
+
+export const isAllowedStatusTransition = (
+  currentStatus: string | null | undefined,
+  targetStatus: string
+): boolean =>
+  getAllowedStatusTransitions(currentStatus).includes(
+    targetStatus.toLowerCase() as FundingApplicationStatusV2
+  );

--- a/hooks/applicationStatusMutation.ts
+++ b/hooks/applicationStatusMutation.ts
@@ -1,14 +1,18 @@
 import type { QueryClient } from "@tanstack/react-query";
 import toast from "react-hot-toast";
+import { errorManager } from "@/components/Utilities/errorManager";
 import { fundingPlatformService } from "@/services/fundingPlatformService";
 import type { IFundingApplication } from "@/types/funding-platform";
-import { getStatusUpdateErrorMessage } from "@/utilities/application-status";
+import { getStatusUpdateErrorMessage, isStatusConflictError } from "@/utilities/application-status";
 import { QUERY_KEYS } from "./fundingPlatformQueryKeys";
 
-/** Shared onError for every application-status mutation: one toast, one log. */
+/** Shared onError for every application-status mutation: one toast, one report. */
 export function notifyStatusUpdateError(error: unknown): void {
-  console.error("Failed to update application status:", error);
   toast.error(getStatusUpdateErrorMessage(error));
+  // A transition conflict is an expected stale-UI event, not telemetry.
+  if (!isStatusConflictError(error)) {
+    errorManager("Failed to update application status", error);
+  }
 }
 
 /**
@@ -27,7 +31,7 @@ export async function fetchFreshApplicationByReference(
       staleTime: 0,
     });
   } catch (error) {
-    console.error("Failed to re-read application before status change:", error);
+    errorManager("Failed to re-read application before status change", error);
     return null;
   }
 }

--- a/hooks/applicationStatusMutation.ts
+++ b/hooks/applicationStatusMutation.ts
@@ -1,0 +1,33 @@
+import type { QueryClient } from "@tanstack/react-query";
+import toast from "react-hot-toast";
+import { fundingPlatformService } from "@/services/fundingPlatformService";
+import type { IFundingApplication } from "@/types/funding-platform";
+import { getStatusUpdateErrorMessage } from "@/utilities/application-status";
+import { QUERY_KEYS } from "./fundingPlatformQueryKeys";
+
+/** Shared onError for every application-status mutation: one toast, one log. */
+export function notifyStatusUpdateError(error: unknown): void {
+  console.error("Failed to update application status:", error);
+  toast.error(getStatusUpdateErrorMessage(error));
+}
+
+/**
+ * Single-row freshness read, so validating a pending status transition against
+ * server truth costs one request instead of refetching every loaded page.
+ * Resolves to null when the read fails — the backend still arbitrates.
+ */
+export async function fetchFreshApplicationByReference(
+  queryClient: QueryClient,
+  referenceNumber: string
+): Promise<IFundingApplication | null> {
+  try {
+    return await queryClient.fetchQuery({
+      queryKey: QUERY_KEYS.applicationByReference(referenceNumber),
+      queryFn: () => fundingPlatformService.applications.getApplicationByReference(referenceNumber),
+      staleTime: 0,
+    });
+  } catch (error) {
+    console.error("Failed to re-read application before status change:", error);
+    return null;
+  }
+}

--- a/hooks/useFundingPlatform.ts
+++ b/hooks/useFundingPlatform.ts
@@ -22,7 +22,10 @@ import type {
   IFundingApplication,
   IFundingProgramConfig,
 } from "@/types/funding-platform";
-import { getStatusUpdateErrorMessage } from "@/utilities/application-status";
+import {
+  fetchFreshApplicationByReference,
+  notifyStatusUpdateError,
+} from "./applicationStatusMutation";
 import { QUERY_KEYS } from "./fundingPlatformQueryKeys";
 import { useAuth } from "./useAuth";
 
@@ -319,12 +322,8 @@ export const useFundingApplications = (programId: string, filters: IApplicationF
         approvedAmount,
         approvedCurrency,
       }),
-    onError: (error) => {
-      console.error("Failed to update application status:", error);
-      toast.error(getStatusUpdateErrorMessage(error));
-    },
-    // Re-sync on failure too: a 409 means another reviewer already moved the
-    // application, so the stale row must refresh instead of inviting a retry.
+    onError: notifyStatusUpdateError,
+    // Re-sync on failure too: a 409 means the stale row must refresh, not invite a retry.
     onSettled: () => {
       queryClient.invalidateQueries({
         queryKey: QUERY_KEYS.applications(programId, { limit: 25 }),
@@ -337,31 +336,15 @@ export const useFundingApplications = (programId: string, filters: IApplicationF
   const applications = applicationsQuery.data?.pages.flatMap((page) => page.applications) || [];
   const firstPage = applicationsQuery.data?.pages[0];
 
-  // Refreshes the rendered rows (every loaded page) — used to drop now-invalid
-  // row actions after a conflict, not on the hot path of opening a modal.
+  // Refreshes every loaded page — drops now-invalid row actions after a conflict.
   const refetchApplicationsData = applicationsQuery.refetch;
   const refetchApplications = useCallback(async (): Promise<IFundingApplication[]> => {
     const { data } = await refetchApplicationsData();
     return data?.pages.flatMap((page) => page.applications) || [];
   }, [refetchApplicationsData]);
 
-  // Single-row freshness read, so validating a pending status transition against
-  // server truth costs one request instead of refetching every loaded page.
-  // Resolves to null when the read fails — the backend still arbitrates.
   const fetchApplicationByReference = useCallback(
-    async (referenceNumber: string): Promise<IFundingApplication | null> => {
-      try {
-        return await queryClient.fetchQuery({
-          queryKey: QUERY_KEYS.applicationByReference(referenceNumber),
-          queryFn: () =>
-            fundingPlatformService.applications.getApplicationByReference(referenceNumber),
-          staleTime: 0,
-        });
-      } catch (error) {
-        console.error("Failed to re-read application before status change:", error);
-        return null;
-      }
-    },
+    (referenceNumber: string) => fetchFreshApplicationByReference(queryClient, referenceNumber),
     [queryClient]
   );
 
@@ -420,10 +403,7 @@ export const useFundingApplication = (applicationId: string) => {
         approvedAmount,
         approvedCurrency,
       }),
-    onError: (error) => {
-      console.error("Failed to update application status:", error);
-      toast.error(getStatusUpdateErrorMessage(error));
-    },
+    onError: notifyStatusUpdateError,
     onSettled: () => {
       queryClient.invalidateQueries({ queryKey: QUERY_KEYS.application(applicationId) });
     },
@@ -650,10 +630,7 @@ export const useApplicationStatusV2 = (applicationId?: string) => {
     onSuccess: (_, variables) => {
       toast.success(`Application ${variables.request.status.replace("_", " ")}`);
     },
-    onError: (error: unknown) => {
-      console.error("Failed to update application status:", error);
-      toast.error(getStatusUpdateErrorMessage(error));
-    },
+    onError: notifyStatusUpdateError,
     onSettled: (_data, _error, variables) => {
       queryClient.invalidateQueries({
         queryKey: QUERY_KEYS.application(variables.applicationId),
@@ -813,7 +790,7 @@ export const useApplication = (applicationId: string | null) => {
 /**
  * Hook for managing application status updates
  */
-export const useApplicationStatus = (programId?: string, _chainId?: number) => {
+export const useApplicationStatus = (_programId?: string, _chainId?: number) => {
   const queryClient = useQueryClient();
 
   const statusMutation = useMutation({
@@ -836,30 +813,18 @@ export const useApplicationStatus = (programId?: string, _chainId?: number) => {
         approvedAmount,
         approvedCurrency,
       }),
-    onError: (error: unknown) => {
-      toast.error(getStatusUpdateErrorMessage(error));
-      console.error("Failed to update application status:", error);
-    },
+    onError: notifyStatusUpdateError,
     // Runs on failure too: a 409 conflict means the cached status is stale, so
     // the detail view and every list must re-sync and drop their now-invalid
     // action buttons instead of leaving them up for another retry.
     onSettled: (_data, _error, variables) => {
       queryClient.invalidateQueries({ queryKey: QUERY_KEYS.application(variables.applicationId) });
 
-      // Invalidate applications list if programId is provided
-      if (programId) {
-        queryClient.invalidateQueries({
-          queryKey: QUERY_KEYS.applications(programId, { limit: 25 }),
-        });
-      }
-
-      // Invalidate every program list regardless of its filter/limit suffix.
+      // Prefix-invalidates every program list regardless of its filter/limit suffix.
       queryClient.invalidateQueries({ queryKey: ["applications"] });
 
-      // Refresh the cross-program Reviewer Inbox feed + header stats. Uses the
-      // `["reviewer-inbox"]` prefix so every community/filter variant refetches.
-      // No-op when the inbox isn't mounted (e.g. the per-program "My
-      // Applications" page), so it doesn't change that surface's behavior.
+      // Refresh every Reviewer Inbox feed/stats variant; no-op when the inbox
+      // isn't mounted (e.g. the per-program "My Applications" page).
       queryClient.invalidateQueries({ queryKey: ["reviewer-inbox"] });
     },
   });

--- a/hooks/useFundingPlatform.ts
+++ b/hooks/useFundingPlatform.ts
@@ -22,6 +22,7 @@ import type {
   IFundingApplication,
   IFundingProgramConfig,
 } from "@/types/funding-platform";
+import { getStatusUpdateErrorMessage } from "@/utilities/application-status";
 import { QUERY_KEYS } from "./fundingPlatformQueryKeys";
 import { useAuth } from "./useAuth";
 
@@ -318,21 +319,31 @@ export const useFundingApplications = (programId: string, filters: IApplicationF
         approvedAmount,
         approvedCurrency,
       }),
-    onSuccess: () => {
+    onError: (error) => {
+      console.error("Failed to update application status:", error);
+      toast.error(getStatusUpdateErrorMessage(error));
+    },
+    // Re-sync on failure too: a 409 means another reviewer already moved the
+    // application, so the stale row must refresh instead of inviting a retry.
+    onSettled: () => {
       queryClient.invalidateQueries({
         queryKey: QUERY_KEYS.applications(programId, { limit: 25 }),
       });
       queryClient.invalidateQueries({ queryKey: QUERY_KEYS.applicationStats(programId) });
-    },
-    onError: (error) => {
-      console.error("Failed to update application status:", error);
-      toast.error("Failed to update application status");
     },
   });
 
   // Flatten the paginated data
   const applications = applicationsQuery.data?.pages.flatMap((page) => page.applications) || [];
   const firstPage = applicationsQuery.data?.pages[0];
+
+  // Returns the freshly fetched rows so callers can validate a pending status
+  // transition against server truth before opening a confirmation modal.
+  const refetchApplicationsData = applicationsQuery.refetch;
+  const refetchApplications = useCallback(async (): Promise<IFundingApplication[]> => {
+    const { data } = await refetchApplicationsData();
+    return data?.pages.flatMap((page) => page.applications) || [];
+  }, [refetchApplicationsData]);
 
   return {
     applications,
@@ -350,6 +361,7 @@ export const useFundingApplications = (programId: string, filters: IApplicationF
     updateApplicationStatus: updateStatusMutation.mutateAsync,
     isSubmitting: submitApplicationMutation.isPending,
     isUpdatingStatus: updateStatusMutation.isPending,
+    refetchApplications,
     refetch: () => {
       applicationsQuery.refetch();
       statsQuery.refetch();
@@ -387,12 +399,12 @@ export const useFundingApplication = (applicationId: string) => {
         approvedAmount,
         approvedCurrency,
       }),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: QUERY_KEYS.application(applicationId) });
-    },
     onError: (error) => {
       console.error("Failed to update application status:", error);
-      toast.error("Failed to update application status");
+      toast.error(getStatusUpdateErrorMessage(error));
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: QUERY_KEYS.application(applicationId) });
     },
   });
 
@@ -615,18 +627,19 @@ export const useApplicationStatusV2 = (applicationId?: string) => {
     }) =>
       fundingPlatformService.applications.updateApplicationStatus(appId || applicationId!, request),
     onSuccess: (_, variables) => {
+      toast.success(`Application ${variables.request.status.replace("_", " ")}`);
+    },
+    onError: (error: unknown) => {
+      console.error("Failed to update application status:", error);
+      toast.error(getStatusUpdateErrorMessage(error));
+    },
+    onSettled: (_data, _error, variables) => {
       queryClient.invalidateQueries({
         queryKey: QUERY_KEYS.application(variables.applicationId),
       });
       queryClient.invalidateQueries({
         queryKey: ["applications"], // Invalidate all application lists
       });
-
-      toast.success(`Application ${variables.request.status.replace("_", " ")}`);
-    },
-    onError: (error: any) => {
-      console.error("Failed to update application status:", error);
-      toast.error("Failed to update application status");
     },
   });
 
@@ -802,8 +815,14 @@ export const useApplicationStatus = (programId?: string, _chainId?: number) => {
         approvedAmount,
         approvedCurrency,
       }),
-    onSuccess: (_, variables) => {
-      // Invalidate and refetch application data
+    onError: (error: unknown) => {
+      toast.error(getStatusUpdateErrorMessage(error));
+      console.error("Failed to update application status:", error);
+    },
+    // Runs on failure too: a 409 conflict means the cached status is stale, so
+    // the detail view and every list must re-sync and drop their now-invalid
+    // action buttons instead of leaving them up for another retry.
+    onSettled: (_data, _error, variables) => {
       queryClient.invalidateQueries({ queryKey: QUERY_KEYS.application(variables.applicationId) });
 
       // Invalidate applications list if programId is provided
@@ -821,11 +840,6 @@ export const useApplicationStatus = (programId?: string, _chainId?: number) => {
       // No-op when the inbox isn't mounted (e.g. the per-program "My
       // Applications" page), so it doesn't change that surface's behavior.
       queryClient.invalidateQueries({ queryKey: ["reviewer-inbox"] });
-    },
-    onError: (error: any) => {
-      const errorMessage = error?.response?.data?.message || "Failed to update application status";
-      toast.error(errorMessage);
-      console.error("Failed to update application status:", error);
     },
   });
 

--- a/hooks/useFundingPlatform.ts
+++ b/hooks/useFundingPlatform.ts
@@ -337,13 +337,33 @@ export const useFundingApplications = (programId: string, filters: IApplicationF
   const applications = applicationsQuery.data?.pages.flatMap((page) => page.applications) || [];
   const firstPage = applicationsQuery.data?.pages[0];
 
-  // Returns the freshly fetched rows so callers can validate a pending status
-  // transition against server truth before opening a confirmation modal.
+  // Refreshes the rendered rows (every loaded page) — used to drop now-invalid
+  // row actions after a conflict, not on the hot path of opening a modal.
   const refetchApplicationsData = applicationsQuery.refetch;
   const refetchApplications = useCallback(async (): Promise<IFundingApplication[]> => {
     const { data } = await refetchApplicationsData();
     return data?.pages.flatMap((page) => page.applications) || [];
   }, [refetchApplicationsData]);
+
+  // Single-row freshness read, so validating a pending status transition against
+  // server truth costs one request instead of refetching every loaded page.
+  // Resolves to null when the read fails — the backend still arbitrates.
+  const fetchApplicationByReference = useCallback(
+    async (referenceNumber: string): Promise<IFundingApplication | null> => {
+      try {
+        return await queryClient.fetchQuery({
+          queryKey: QUERY_KEYS.applicationByReference(referenceNumber),
+          queryFn: () =>
+            fundingPlatformService.applications.getApplicationByReference(referenceNumber),
+          staleTime: 0,
+        });
+      } catch (error) {
+        console.error("Failed to re-read application before status change:", error);
+        return null;
+      }
+    },
+    [queryClient]
+  );
 
   return {
     applications,
@@ -362,6 +382,7 @@ export const useFundingApplications = (programId: string, filters: IApplicationF
     isSubmitting: submitApplicationMutation.isPending,
     isUpdatingStatus: updateStatusMutation.isPending,
     refetchApplications,
+    fetchApplicationByReference,
     refetch: () => {
       applicationsQuery.refetch();
       statsQuery.refetch();
@@ -832,8 +853,8 @@ export const useApplicationStatus = (programId?: string, _chainId?: number) => {
         });
       }
 
-      // Invalidate all applications lists
-      queryClient.invalidateQueries({ queryKey: ["funding-applications"] });
+      // Invalidate every program list regardless of its filter/limit suffix.
+      queryClient.invalidateQueries({ queryKey: ["applications"] });
 
       // Refresh the cross-program Reviewer Inbox feed + header stats. Uses the
       // `["reviewer-inbox"]` prefix so every community/filter variant refetches.

--- a/utilities/__tests__/application-status.test.ts
+++ b/utilities/__tests__/application-status.test.ts
@@ -1,4 +1,86 @@
-import { formatApplicationStatus } from "@/utilities/application-status";
+import {
+  formatApplicationStatus,
+  getStatusUpdateErrorMessage,
+  isStatusConflictError,
+  STATUS_CONFLICT_MESSAGE,
+} from "@/utilities/application-status";
+
+const httpError = (status: number, message: string) => ({
+  response: { status, data: { message } },
+});
+
+// The backend maps every funding-application validation failure to 409, so the
+// status code alone cannot tell a stale-status conflict from a correctable
+// input error raised by the very same PUT.
+describe("isStatusConflictError", () => {
+  it("should_report_a_conflict_when_the_409_is_an_invalid_status_transition", () => {
+    expect(
+      isStatusConflictError(
+        httpError(
+          409,
+          "Invalid status transition from 'approved' to 'approved'. Valid transitions are: "
+        )
+      )
+    ).toBe(true);
+  });
+
+  it("should_not_report_a_conflict_when_the_409_is_a_currency_mismatch", () => {
+    expect(
+      isStatusConflictError(
+        httpError(
+          409,
+          "Currency mismatch: Approved currency 'USDC' does not match program currency 'ETH'."
+        )
+      )
+    ).toBe(false);
+  });
+
+  it("should_not_report_a_conflict_when_the_409_is_an_invalid_approved_amount", () => {
+    expect(
+      isStatusConflictError(
+        httpError(
+          409,
+          "Invalid approved amount format: 'abc'. Amount must be a valid positive number."
+        )
+      )
+    ).toBe(false);
+  });
+
+  it("should_not_report_a_conflict_when_the_409_is_a_missing_reason", () => {
+    expect(
+      isStatusConflictError(
+        httpError(409, "A reason is required when changing status to 'revision_requested'")
+      )
+    ).toBe(false);
+  });
+
+  it("should_not_report_a_conflict_for_other_status_codes", () => {
+    expect(isStatusConflictError(httpError(500, "Invalid status transition from 'a' to 'b'"))).toBe(
+      false
+    );
+    expect(isStatusConflictError(undefined)).toBe(false);
+    expect(isStatusConflictError(new Error("boom"))).toBe(false);
+  });
+});
+
+describe("getStatusUpdateErrorMessage", () => {
+  it("should_return_the_conflict_copy_when_the_transition_is_no_longer_valid", () => {
+    expect(
+      getStatusUpdateErrorMessage(httpError(409, "Invalid status transition from 'a' to 'b'"))
+    ).toBe(STATUS_CONFLICT_MESSAGE);
+  });
+
+  it("should_surface_the_backend_message_when_a_409_is_a_correctable_validation_error", () => {
+    const message = "Currency mismatch: Approved currency 'USDC' does not match program currency.";
+    expect(getStatusUpdateErrorMessage(httpError(409, message))).toBe(message);
+  });
+
+  it("should_fall_back_to_a_generic_message_when_the_error_carries_none", () => {
+    expect(getStatusUpdateErrorMessage(new Error("boom"))).toBe(
+      "Failed to update application status"
+    );
+  });
+});
 
 describe("formatApplicationStatus", () => {
   it("uses Declined as the user-facing label for rejected applications", () => {

--- a/utilities/application-status.ts
+++ b/utilities/application-status.ts
@@ -12,6 +12,27 @@ const APPLICATION_STATUS_LABELS: Record<string, string> = {
   submitted: "Submitted",
 };
 
+const STATUS_UPDATE_FALLBACK_MESSAGE = "Failed to update application status";
+
+export const STATUS_CONFLICT_MESSAGE =
+  "This application's status was already changed — refreshing.";
+
+/**
+ * The backend answers 409 when the requested transition is no longer valid for
+ * the application's current status (e.g. approving an already-approved one).
+ * That's a stale-UI conflict, not a retryable failure.
+ */
+export function isStatusConflictError(error: unknown): boolean {
+  return (error as { response?: { status?: number } } | null | undefined)?.response?.status === 409;
+}
+
+export function getStatusUpdateErrorMessage(error: unknown): string {
+  if (isStatusConflictError(error)) return STATUS_CONFLICT_MESSAGE;
+  const message = (error as { response?: { data?: { message?: string } } } | null | undefined)
+    ?.response?.data?.message;
+  return message || STATUS_UPDATE_FALLBACK_MESSAGE;
+}
+
 export function formatApplicationStatus(status: string): string {
   const normalized = status.toLowerCase().replace(/-/g, "_");
 

--- a/utilities/application-status.ts
+++ b/utilities/application-status.ts
@@ -17,20 +17,40 @@ const STATUS_UPDATE_FALLBACK_MESSAGE = "Failed to update application status";
 export const STATUS_CONFLICT_MESSAGE =
   "This application's status was already changed — refreshing.";
 
+/** Shared toast id so repeated conflicts collapse into a single notification. */
+export const STATUS_CONFLICT_TOAST_ID = "application-status-conflict";
+
 /**
- * The backend answers 409 when the requested transition is no longer valid for
- * the application's current status (e.g. approving an already-approved one).
- * That's a stale-UI conflict, not a retryable failure.
+ * The backend maps its whole funding-application validation family to 409, so
+ * the status code alone can't tell a stale-status conflict from a correctable
+ * input error (currency mismatch, bad approved amount, missing reason) raised by
+ * the same endpoint. Only the transition failure is unrecoverable for the open
+ * form, and it is the only one carrying this message.
+ */
+const TRANSITION_CONFLICT_PATTERN = /invalid status transition/i;
+
+const getResponseStatus = (error: unknown): number | undefined =>
+  (error as { response?: { status?: number } } | null | undefined)?.response?.status;
+
+const getResponseMessage = (error: unknown): string | undefined =>
+  (error as { response?: { data?: { message?: string } } } | null | undefined)?.response?.data
+    ?.message;
+
+/**
+ * True only when the requested transition is no longer valid for the
+ * application's current status (e.g. approving an already-approved one). That's
+ * a stale-UI conflict, not a retryable failure.
  */
 export function isStatusConflictError(error: unknown): boolean {
-  return (error as { response?: { status?: number } } | null | undefined)?.response?.status === 409;
+  return (
+    getResponseStatus(error) === 409 &&
+    TRANSITION_CONFLICT_PATTERN.test(getResponseMessage(error) ?? "")
+  );
 }
 
 export function getStatusUpdateErrorMessage(error: unknown): string {
   if (isStatusConflictError(error)) return STATUS_CONFLICT_MESSAGE;
-  const message = (error as { response?: { data?: { message?: string } } } | null | undefined)
-    ?.response?.data?.message;
-  return message || STATUS_UPDATE_FALLBACK_MESSAGE;
+  return getResponseMessage(error) || STATUS_UPDATE_FALLBACK_MESSAGE;
 }
 
 export function formatApplicationStatus(status: string): string {


### PR DESCRIPTION
## Overview

An admin sent `PUT /v2/funding-applications/:ref/status` with `approved` three times in 19 seconds against an application that was already approved. The backend behaved correctly — `approved` is terminal, so it returned 409 each time (Sentry `GAP-INDEXER-Y5`). The bug is on our side: the reviewer's tab was still rendering Approve/Decline buttons for a stale status, and every failed click left those buttons up, so the natural response was to click again.

## Root cause

Three things compounded:

1. **Stale status rendering.** The global QueryClient defaults (`utilities/queries/defaultOptions.ts`) set `refetchOnWindowFocus: false` with a 1-minute `staleTime` and no polling. A tab left open on an application keeps showing action buttons for a status another reviewer — or another tab — has already moved past.
2. **No re-sync on failure.** All four status mutations in `hooks/useFundingPlatform.ts` invalidated their queries only in `onSuccess`. On error they toasted and nothing else, so the stale buttons survived the failure and invited a retry.
3. **409 presented as a retryable failure.** The user saw either the raw backend string (`Invalid status transition from 'approved' to 'approved'. Valid transitions are: `) or a generic "Failed to update application status", and the inline form/modal was deliberately kept open to retry. The detail page also double-toasted: the hook's `onError` fired one toast and the component's `catch` fired a second.

Separately, `useApplicationStatus` invalidated the prefix `["funding-applications"]`, which matches no query in the key factory — the single-application key is `["funding-application", id]` and the list key is `["applications", …]`. That invalidation had been a no-op.

## Solution

- **Re-sync on failure.** All four status mutations (`useFundingApplications`, `useFundingApplication`, `useApplicationStatusV2`, `useApplicationStatus`) moved their invalidations from `onSuccess` to `onSettled`, so a 409 refreshes the detail view, every list variant, the stats, and the reviewer-inbox feed. Corrected the dead `["funding-applications"]` prefix to `["applications"]`.
- **409 treated as a conflict, not a failure.** New `utilities/application-status.ts` helpers: `isStatusConflictError` and `getStatusUpdateErrorMessage`. On a conflict the user gets one clear message ("This application's status was already changed — refreshing.") and the inline form/modal closes instead of staying open. The mutation `onError` is now the single toast owner; the component `catch` blocks no longer toast, which removes the double-toast.
  - Note: the backend maps its whole funding-application validation family to 409, so the status code alone can't distinguish a stale-status conflict from a correctable input error (bad approved amount, currency mismatch, missing reason) on the same endpoint. `isStatusConflictError` additionally matches the `invalid status transition` message, so only the genuinely unrecoverable case closes the form — correctable 409s keep it open so the reviewer can fix the input.
- **Pre-flight staleness check.** Opening the inline form (detail page) or the row modal (list) re-reads the application first and validates the pending transition against server truth. If it is no longer allowed, the surface shows the conflict toast, re-syncs, and never sends the PUT. The list reads the single row by reference rather than refetching every loaded page — one request, and it still works when an active status filter has already dropped the row from the results.
- **Shared transitions module.** `components/FundingPlatform/statusTransitions.ts` is now the single source of truth for the allowed-transition adjacency. `StatusActionButtons`, `HeaderActions`, and `TableStatusActionButtons` each keep their own label/icon/style/permission config but filter against the shared adjacency, replacing three duplicate maps. **No transition rules changed** — the shared map reproduces the existing behaviour, including `approved`/`rejected` being terminal (this also replaces `TableStatusActionButtons`' hardcoded `["approved", "rejected"]` final-state check).
- **In-flight guards.** `StatusChangeModal.handleConfirm`, `StatusChangeInline.handleConfirm`, and both parents' `handleStatusChangeConfirm` early-return while a submit is in flight, so a double click can't race the disabled state. The pre-flight read is folded into the surfaces' busy flag, so buttons disable for its round-trip rather than looking dead.

## Surfaces covered

- **Detail page** (`.../applications/[applicationId]` → `ApplicationDetailView` + `useApplicationDetailView`) — pre-flight refetch on `handleStatusChangeClick`, conflict closes the inline form via `setSelectedStatus(null)`. Covered by `useApplicationDetailView.statusConflict.test.tsx`.
- **Applications list/table** (`ApplicationListWithAPI` → `ApplicationList` → `TableStatusActionButtons`) — pre-flight single-row read before the modal opens, conflict closes the modal and refreshes the table. The redundant local `useMutation` wrapper in `ApplicationListWithAPI` was removed; it duplicated the hook's mutation and layered a second refetch and a second toast on top of it. Covered by `ApplicationListStatusConflict.test.tsx`.
- **Reviewer Inbox** (`ReviewerInboxPage`) — embeds the same `ApplicationDetailView`, so it inherits the detail-page path; verified it consumes the same hooks, and `useApplicationStatus`' `onSettled` invalidates the `["reviewer-inbox"]` prefix so the cross-program feed re-syncs on failure too. Covered by `ReviewerStatusChange.test.tsx`.

## Testing

New/updated suites:

- `utilities/__tests__/application-status.test.ts` — `isStatusConflictError` matches only transition-conflict 409s (not correctable 409s, not 4xx/5xx generally); `getStatusUpdateErrorMessage` message selection.
- `__tests__/hooks/useFundingPlatformStatusConflict.test.tsx` — all four mutations invalidate their query keys on error as well as success; exactly one toast per failure.
- `__tests__/components/FundingPlatform/ApplicationView/useApplicationDetailView.statusConflict.test.tsx` — 409 conflict closes the inline form; non-409 keeps it open for retry; pre-flight stale status closes without issuing the PUT.
- `__tests__/components/FundingPlatform/ApplicationList/ApplicationListStatusConflict.test.tsx` — same three cases for the table modal, plus the in-flight double-submit guard.
- `__tests__/components/FundingPlatform/ApplicationView/ReviewerStatusChange.test.tsx` — reviewer-inbox path re-syncs and closes on conflict.
- `__tests__/integration/mutations/application-status.mutation.test.tsx` — end-to-end mutation wiring across the surfaces.

Results:

- Targeted suites: 58 tests passing across the 6 files above.
- Regression check on pre-existing suites for every touched component (`TableStatusActionButtons`, `HeaderActions`, `StatusChangeModal`, `ApplicationContent`, `ApplicationList.aiScore`, `large-list-rendering.perf`): 198 tests passing, no changes needed.
- Lint: `biome check` clean at error level across all 18 changed files.
- Build: `pnpm run build` passes, including the TypeScript pass. No `any` casts introduced.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added a pre-flight “status freshness” check before opening or confirming status changes, preventing outdated transitions.
  * Improved handling of status conflicts: show the conflict notification, close the modal when appropriate, and refresh list actions to resync.
  * Correctable validation errors now keep the form open so entered details aren’t lost.
  * Prevented duplicate submissions and duplicate freshness reads from rapid repeated clicks.
  * Improved failure messaging by showing backend-provided error details when available.
* **Improvements**
  * Status action availability is now consistent across list and detail views based on shared allowed-transition rules.
* **Tests**
  * Expanded coverage for status-conflict and error-handling flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->