### PR TITLE
fix(rbac): don't report an undecided permissions check as a denial

### DIFF
--- a/app/admin/nonprofit-research/__tests__/staff-gate.test.tsx
+++ b/app/admin/nonprofit-research/__tests__/staff-gate.test.tsx
@@ -1,0 +1,87 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen } from "@testing-library/react";
+import AdminNonprofitResearchLayout from "../layout";
+
+/**
+ * REGRESSION: the staff gate read only `{ isStaff, isLoading }` from
+ * `useStaff()`. Because that hook reports `isStaff: false` for BOTH "denied"
+ * and "could not be decided", a permissions fetch that failed — upstream
+ * 503/504, or the client's own 15s deadline firing — rendered the denial copy.
+ * A real SUPER_ADMIN was told to go ask an admin for access they already held,
+ * with no error shown and nothing to retry.
+ *
+ * The gate must therefore branch on `isError` BEFORE `!isStaff`.
+ */
+
+const staffState = {
+  isStaff: false,
+  isLoading: false,
+  isError: false,
+};
+
+vi.mock("@/src/core/rbac/hooks/use-staff-bridge", () => ({
+  useStaff: () => staffState,
+}));
+
+vi.mock("@/src/core/rbac/context/permission-context", () => ({
+  PermissionProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+const authState = { ready: true, authenticated: true };
+vi.mock("@/hooks/useAuth", () => ({
+  useAuth: () => authState,
+}));
+
+// PermissionCheckError is deliberately NOT mocked — the point of the error
+// branch is that the user gets something they can act on, so the real component
+// (and its retry control) is what these tests assert against.
+
+vi.mock("@/src/components/ui/AccessDenied", () => ({
+  AccessDenied: ({ title }: { title: string }) => <div>{title}</div>,
+}));
+
+function renderGate() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <AdminNonprofitResearchLayout>{<div>admin content</div>}</AdminNonprofitResearchLayout>
+    </QueryClientProvider>
+  );
+}
+
+describe("AdminNonprofitResearchLayout staff gate", () => {
+  beforeEach(() => {
+    staffState.isStaff = false;
+    staffState.isLoading = false;
+    staffState.isError = false;
+    authState.ready = true;
+    authState.authenticated = true;
+  });
+
+  it("renders a retryable error, not the denial, when the permissions check could not be decided", () => {
+    staffState.isError = true;
+
+    renderGate();
+
+    expect(screen.getByText(/couldn't verify your access/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /try again/i })).toBeEnabled();
+    expect(screen.queryByText("Staff access required")).not.toBeInTheDocument();
+  });
+
+  it("still denies a genuinely non-staff viewer", () => {
+    renderGate();
+
+    expect(screen.getByText("Staff access required")).toBeInTheDocument();
+  });
+
+  it("renders children for a resolved staff member", () => {
+    staffState.isStaff = true;
+
+    renderGate();
+
+    expect(screen.getByText("admin content")).toBeInTheDocument();
+  });
+});

--- a/app/admin/nonprofit-research/__tests__/staff-gate.test.tsx
+++ b/app/admin/nonprofit-research/__tests__/staff-gate.test.tsx
@@ -1,5 +1,6 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import AdminNonprofitResearchLayout from "../layout";
 
 /**
@@ -47,7 +48,9 @@ function renderGate() {
 
   return render(
     <QueryClientProvider client={queryClient}>
-      <AdminNonprofitResearchLayout>{<div>admin content</div>}</AdminNonprofitResearchLayout>
+      <AdminNonprofitResearchLayout>
+        <div>admin content</div>
+      </AdminNonprofitResearchLayout>
     </QueryClientProvider>
   );
 }

--- a/app/admin/nonprofit-research/__tests__/staff-gate.test.tsx
+++ b/app/admin/nonprofit-research/__tests__/staff-gate.test.tsx
@@ -1,7 +1,9 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import AdminNonprofitResearchLayout from "../layout";
+import AdminNonprofitResearchLayout from "@/app/admin/nonprofit-research/layout";
+import { permissionsKeys } from "@/src/core/rbac/hooks/use-permissions";
 
 /**
  * REGRESSION: the staff gate read only `{ isStaff, isLoading }` from
@@ -46,13 +48,16 @@ function renderGate() {
     defaultOptions: { queries: { retry: false } },
   });
 
-  return render(
-    <QueryClientProvider client={queryClient}>
-      <AdminNonprofitResearchLayout>
-        <div>admin content</div>
-      </AdminNonprofitResearchLayout>
-    </QueryClientProvider>
-  );
+  return {
+    queryClient,
+    ...render(
+      <QueryClientProvider client={queryClient}>
+        <AdminNonprofitResearchLayout>
+          <div>admin content</div>
+        </AdminNonprofitResearchLayout>
+      </QueryClientProvider>
+    ),
+  };
 }
 
 describe("AdminNonprofitResearchLayout staff gate", () => {
@@ -72,6 +77,18 @@ describe("AdminNonprofitResearchLayout staff gate", () => {
     expect(screen.getByText(/couldn't verify your access/i)).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /try again/i })).toBeEnabled();
     expect(screen.queryByText("Staff access required")).not.toBeInTheDocument();
+  });
+
+  it("wires that error state to a retry that actually re-runs the permissions check", async () => {
+    staffState.isError = true;
+    const user = userEvent.setup();
+
+    const { queryClient } = renderGate();
+    const refetchQueries = vi.spyOn(queryClient, "refetchQueries").mockResolvedValue(undefined);
+
+    await user.click(screen.getByRole("button", { name: /try again/i }));
+
+    expect(refetchQueries).toHaveBeenCalledWith({ queryKey: permissionsKeys.all });
   });
 
   it("still denies a genuinely non-staff viewer", () => {

--- a/app/admin/nonprofit-research/layout.tsx
+++ b/app/admin/nonprofit-research/layout.tsx
@@ -4,6 +4,7 @@ import { Spinner } from "@/components/Utilities/Spinner";
 import { useAuth } from "@/hooks/useAuth";
 import { AccessDenied } from "@/src/components/ui/AccessDenied";
 import { staffDenial } from "@/src/components/ui/access-denied-presets";
+import { PermissionCheckError } from "@/src/core/rbac/components/permission-check-error";
 import { PermissionProvider } from "@/src/core/rbac/context/permission-context";
 import { useStaff } from "@/src/core/rbac/hooks/use-staff-bridge";
 import { PAGES } from "@/utilities/pages";
@@ -25,7 +26,7 @@ export default function AdminNonprofitResearchLayout({ children }: { children: R
 // redirect, and staff status is only trusted once resolved (`!isLoading`).
 function StaffGate({ children }: { children: React.ReactNode }) {
   const { ready, authenticated } = useAuth();
-  const { isStaff, isLoading } = useStaff();
+  const { isStaff, isLoading, isError } = useStaff();
 
   if (!ready) {
     return (
@@ -51,6 +52,15 @@ function StaffGate({ children }: { children: React.ReactNode }) {
         <Spinner />
       </div>
     );
+  }
+
+  // "Could not be decided" is not "denied". `useStaff` reports isStaff:false for
+  // both, so this branch MUST come first — otherwise a permissions fetch that
+  // failed (the upstream returning 503/504, or our own 15s deadline firing)
+  // renders as "you lack the role" and a real staff member is told to go ask an
+  // admin for access they already have.
+  if (isError) {
+    return <PermissionCheckError />;
   }
 
   if (!isStaff) {

--- a/src/core/rbac/components/__tests__/permission-check-error.test.tsx
+++ b/src/core/rbac/components/__tests__/permission-check-error.test.tsx
@@ -1,0 +1,69 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { permissionsKeys } from "../../hooks/use-permissions";
+import { PermissionCheckError } from "../permission-check-error";
+
+// This is the terminal state every RBAC-gated surface falls back to when the
+// permissions lookup fails. Its whole reason to exist is that the viewer gets
+// (a) an explanation that something broke rather than a denial, and (b) a
+// control that actually re-runs the check. Both are asserted here directly so
+// callers only have to prove they route `isError` to this component.
+
+function renderWithClient(ui: React.ReactElement) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+
+  return {
+    queryClient,
+    ...render(<QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>),
+  };
+}
+
+describe("PermissionCheckError", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("announces the failure rather than presenting it as a denial", () => {
+    renderWithClient(<PermissionCheckError />);
+
+    expect(screen.getByRole("alert")).toBeInTheDocument();
+    expect(screen.getByText(/couldn't verify your access/i)).toBeInTheDocument();
+    // No denial vocabulary: the viewer must not be told they lack a role.
+    expect(screen.queryByText(/access required/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/don't have permission/i)).not.toBeInTheDocument();
+  });
+
+  it("defaults the subject to the generic page wording", () => {
+    renderWithClient(<PermissionCheckError />);
+
+    expect(screen.getByText(/can't show this page safely/i)).toBeInTheDocument();
+  });
+
+  it("renders the caller's subject mid-sentence", () => {
+    renderWithClient(<PermissionCheckError subject="this report" />);
+
+    expect(screen.getByText(/can't show this report safely/i)).toBeInTheDocument();
+  });
+
+  it("refetches the permissions query instead of reloading the page", async () => {
+    const user = userEvent.setup();
+    const { queryClient } = renderWithClient(<PermissionCheckError />);
+    const refetchQueries = vi.spyOn(queryClient, "refetchQueries").mockResolvedValue(undefined);
+
+    await user.click(screen.getByRole("button", { name: /try again/i }));
+
+    expect(refetchQueries).toHaveBeenCalledWith({ queryKey: permissionsKeys.all });
+  });
+
+  it("keeps the retry control enabled while nothing is in flight", () => {
+    renderWithClient(<PermissionCheckError />);
+
+    const retry = screen.getByRole("button", { name: /try again/i });
+    expect(retry).toBeEnabled();
+    expect(retry).toHaveAttribute("aria-busy", "false");
+  });
+});

--- a/src/core/rbac/components/__tests__/permission-check-error.test.tsx
+++ b/src/core/rbac/components/__tests__/permission-check-error.test.tsx
@@ -2,8 +2,8 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { permissionsKeys } from "../../hooks/use-permissions";
-import { PermissionCheckError } from "../permission-check-error";
+import { PermissionCheckError } from "@/src/core/rbac/components/permission-check-error";
+import { permissionsKeys } from "@/src/core/rbac/hooks/use-permissions";
 
 // This is the terminal state every RBAC-gated surface falls back to when the
 // permissions lookup fails. Its whole reason to exist is that the viewer gets

--- a/src/core/rbac/components/index.ts
+++ b/src/core/rbac/components/index.ts
@@ -7,9 +7,9 @@ export {
   RequireReviewer,
   RequireRole,
 } from "./can";
+
 export {
   FundingPlatformGuard,
   useIsFundingPlatformAdmin,
   useIsFundingPlatformReviewer,
 } from "./funding-platform-guard";
-export { PermissionCheckError } from "./permission-check-error";

--- a/src/core/rbac/components/index.ts
+++ b/src/core/rbac/components/index.ts
@@ -7,9 +7,9 @@ export {
   RequireReviewer,
   RequireRole,
 } from "./can";
-
 export {
   FundingPlatformGuard,
   useIsFundingPlatformAdmin,
   useIsFundingPlatformReviewer,
 } from "./funding-platform-guard";
+export { PermissionCheckError } from "./permission-check-error";

--- a/src/core/rbac/components/permission-check-error.tsx
+++ b/src/core/rbac/components/permission-check-error.tsx
@@ -34,16 +34,17 @@ export function PermissionCheckError({ subject = "this page" }: PermissionCheckE
     <div className="mx-auto max-w-xl px-4 py-12" role="alert">
       <div className="flex flex-col items-center gap-4 rounded-xl border border-border p-8 text-center">
         <div className="flex h-12 w-12 items-center justify-center rounded-full bg-red-100 dark:bg-red-900/30">
-          <AlertTriangle className="h-6 w-6 text-red-600 dark:text-red-400" />
+          <AlertTriangle aria-hidden="true" className="h-6 w-6 text-red-600 dark:text-red-400" />
         </div>
         <h1 className="text-xl font-semibold text-foreground">
           We couldn&apos;t verify your access
         </h1>
         <p className="text-sm text-muted-foreground">
-          Checking your permissions took too long, so we can&apos;t show {subject} safely. Please
-          try again.
+          The permissions check didn&apos;t complete, so we can&apos;t show {subject} safely. This
+          is usually temporary — please try again.
         </p>
         <button
+          aria-busy={isRetrying}
           className="inline-flex items-center gap-2 rounded-md border border-border bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-60"
           disabled={isRetrying}
           onClick={() => {
@@ -51,7 +52,10 @@ export function PermissionCheckError({ subject = "this page" }: PermissionCheckE
           }}
           type="button"
         >
-          <RefreshCw className={isRetrying ? "h-4 w-4 animate-spin" : "h-4 w-4"} />
+          <RefreshCw
+            aria-hidden="true"
+            className={isRetrying ? "h-4 w-4 animate-spin" : "h-4 w-4"}
+          />
           {isRetrying ? "Retrying…" : "Try again"}
         </button>
       </div>

--- a/src/core/rbac/components/permission-check-error.tsx
+++ b/src/core/rbac/components/permission-check-error.tsx
@@ -2,7 +2,8 @@
 
 import { useIsFetching, useQueryClient } from "@tanstack/react-query";
 import { AlertTriangle, RefreshCw } from "lucide-react";
-import { permissionsKeys } from "../hooks/use-permissions";
+import { Button } from "@/components/ui/button";
+import { permissionsKeys } from "@/src/core/rbac/hooks/use-permissions";
 
 interface PermissionCheckErrorProps {
   /**
@@ -43,21 +44,22 @@ export function PermissionCheckError({ subject = "this page" }: PermissionCheckE
           The permissions check didn&apos;t complete, so we can&apos;t show {subject} safely. This
           is usually temporary — please try again.
         </p>
-        <button
+        {/*
+          Deliberately not the Button's own `isLoading` prop: it swaps the whole
+          control for a bare spinner, which drops the label and the accessible
+          name mid-retry. The in-place spinning icon keeps both.
+        */}
+        <Button
           aria-busy={isRetrying}
-          className="inline-flex items-center gap-2 rounded-md border border-border bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-60"
           disabled={isRetrying}
           onClick={() => {
             void queryClient.refetchQueries({ queryKey: permissionsKeys.all });
           }}
           type="button"
         >
-          <RefreshCw
-            aria-hidden="true"
-            className={isRetrying ? "h-4 w-4 animate-spin" : "h-4 w-4"}
-          />
+          <RefreshCw aria-hidden="true" className={isRetrying ? "animate-spin" : undefined} />
           {isRetrying ? "Retrying…" : "Try again"}
-        </button>
+        </Button>
       </div>
     </div>
   );

--- a/src/core/rbac/components/permission-check-error.tsx
+++ b/src/core/rbac/components/permission-check-error.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import { useIsFetching, useQueryClient } from "@tanstack/react-query";
+import { AlertTriangle, RefreshCw } from "lucide-react";
+import { permissionsKeys } from "../hooks/use-permissions";
+
+interface PermissionCheckErrorProps {
+  /**
+   * What the viewer was trying to reach, lowercase and article-free — e.g.
+   * "this report", "this page". Rendered mid-sentence.
+   */
+  subject?: string;
+}
+
+/**
+ * Terminal state for "we could not decide what you are allowed to do".
+ *
+ * Every RBAC-gated surface reads its verdict from a single permissions fetch,
+ * and `useStaff()` / `usePermissionContext()` report `false` for BOTH "denied"
+ * and "could not be decided". Rendering the denied UI for the second case tells
+ * a real super-admin they lack a role they actually hold, with no hint that
+ * anything failed and no way to retry — the failure looks like a policy
+ * decision. So any caller that gates on RBAC must branch on `isError` BEFORE
+ * `!isStaff` / `!can(...)` and render this instead.
+ *
+ * Retry refetches the permissions query rather than reloading the page, so a
+ * transient backend blip costs one request, not a full app boot.
+ */
+export function PermissionCheckError({ subject = "this page" }: PermissionCheckErrorProps) {
+  const queryClient = useQueryClient();
+  const isRetrying = useIsFetching({ queryKey: permissionsKeys.all }) > 0;
+
+  return (
+    <div className="mx-auto max-w-xl px-4 py-12" role="alert">
+      <div className="flex flex-col items-center gap-4 rounded-xl border border-border p-8 text-center">
+        <div className="flex h-12 w-12 items-center justify-center rounded-full bg-red-100 dark:bg-red-900/30">
+          <AlertTriangle className="h-6 w-6 text-red-600 dark:text-red-400" />
+        </div>
+        <h1 className="text-xl font-semibold text-foreground">
+          We couldn&apos;t verify your access
+        </h1>
+        <p className="text-sm text-muted-foreground">
+          Checking your permissions took too long, so we can&apos;t show {subject} safely. Please
+          try again.
+        </p>
+        <button
+          className="inline-flex items-center gap-2 rounded-md border border-border bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-60"
+          disabled={isRetrying}
+          onClick={() => {
+            void queryClient.refetchQueries({ queryKey: permissionsKeys.all });
+          }}
+          type="button"
+        >
+          <RefreshCw className={isRetrying ? "h-4 w-4 animate-spin" : "h-4 w-4"} />
+          {isRetrying ? "Retrying…" : "Try again"}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/features/donor-research/components/report-brief/ReportBriefView.tsx
+++ b/src/features/donor-research/components/report-brief/ReportBriefView.tsx
@@ -1,56 +1,15 @@
 "use client";
 
-import { useIsFetching, useQueryClient } from "@tanstack/react-query";
-import { AlertTriangle, RefreshCw } from "lucide-react";
 import { useDonorAdvisor } from "@/hooks/useDonorAdvisor";
 import { useDonorReportStream } from "@/hooks/useDonorReportStream";
 import { useDonorReport } from "@/hooks/useDonorReports";
-import { permissionsKeys } from "@/src/core/rbac/hooks/use-permissions";
+import { PermissionCheckError } from "@/src/core/rbac/components/permission-check-error";
 import { useStaff } from "@/src/core/rbac/hooks/use-staff-bridge";
 import { DonorResearchLoading } from "../common/DonorResearchLoading";
 import { ReportBrief } from "./ReportBrief";
 
 interface ReportBriefViewProps {
   reportId: string;
-}
-
-/**
- * Terminal state for "we could not decide whether you may manage this report".
- * Deliberately NOT a silent downgrade to the read-only variant: a super-admin
- * whose permissions lookup timed out would otherwise see a report with its
- * controls missing and no way to tell that anything had gone wrong.
- */
-function ManageAuthorizationError() {
-  const queryClient = useQueryClient();
-  const isRetrying = useIsFetching({ queryKey: permissionsKeys.all }) > 0;
-
-  return (
-    <div className="mx-auto max-w-xl px-4 py-12" role="alert">
-      <div className="flex flex-col items-center gap-4 rounded-xl border border-border p-8 text-center">
-        <div className="flex h-12 w-12 items-center justify-center rounded-full bg-red-100 dark:bg-red-900/30">
-          <AlertTriangle className="h-6 w-6 text-red-600 dark:text-red-400" />
-        </div>
-        <h1 className="text-xl font-semibold text-foreground">
-          We couldn&apos;t verify your access
-        </h1>
-        <p className="text-sm text-muted-foreground">
-          Checking your permissions took too long, so we can&apos;t show this report safely. Please
-          try again.
-        </p>
-        <button
-          className="inline-flex items-center gap-2 rounded-md border border-border bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-60"
-          disabled={isRetrying}
-          onClick={() => {
-            void queryClient.refetchQueries({ queryKey: permissionsKeys.all });
-          }}
-          type="button"
-        >
-          <RefreshCw className={isRetrying ? "h-4 w-4 animate-spin" : "h-4 w-4"} />
-          {isRetrying ? "Retrying…" : "Try again"}
-        </button>
-      </div>
-    </div>
-  );
 }
 
 /**
@@ -100,7 +59,7 @@ export function ReportBriefView({ reportId }: ReportBriefViewProps) {
   // their controls come from the advisor row — so only a viewer we can't
   // confirm as the owner is actually blocked by it.
   if (isStaffError && !isOwner) {
-    return <ManageAuthorizationError />;
+    return <PermissionCheckError subject="this report" />;
   }
 
   return (


### PR DESCRIPTION
## Summary

A real SUPER_ADMIN on `/admin/nonprofit-research` was shown **"Staff access required — You're almost there"**: told to go ask an admin for access they already hold. The role was never the problem — the permissions check simply never came back, and the gate reported that as a denial.

`useStaff()` returns `isStaff: false` for **both** "denied" and "could not be decided" — its own docblock warns that callers must surface `isError` as a visible, retryable failure, "otherwise a real super-admin quietly loses their controls with no explanation". `app/admin/nonprofit-research/layout.tsx` destructured only `{ isStaff, isLoading }`, so any permissions failure — an upstream 503/504, or the client's own `PERMISSIONS_TIMEOUT_MS` (15s) firing — fell straight through to the denial copy. No error, nothing to retry.

The fix is to branch on `isError` **before** `!isStaff` and render a retryable error state. `ManageAuthorizationError` already existed for exactly this, privately inside `ReportBriefView`; with a second consumer it moves to `src/core/rbac/components/permission-check-error.tsx` as `PermissionCheckError` with the subject parameterised, and both callers share it. Retry refetches the permissions query rather than reloading the page, so a transient blip costs one request instead of a full app boot.

### Reproduced live

On staging, address `0x9b750f08b73D7441d4A0eFF112648764613019A4` (present in the backend staff allowlist) hit the denial. The page's own `/v2/auth/permissions` request hung ~15s and returned 503. Called by hand with the same token, that endpoint returns 200 with `primaryRole: SUPER_ADMIN`. So: correct role, failed lookup, denial rendered.

### Timeline (git blame)

- **2026-07-01** — gate added in `8fdc73fdf` (DEV-467) + `7ccc52f05`.
- **2026-07-28** — #1939 (`944af7a1c`) bounded the permissions fetch at 15s and made `useStaff` tri-state with `isError`, but only taught the report page to read it. This gate predates #1939 and never learned to.

So #1939 converted what had previously been an infinite spinner into a fast false denial on this one page — which is why it looked like it started that day. **#1939 did not cause the underlying failure, and reverting it does not help**: pre-#1939 `useStaff` was `isStaff: !isLoading && hasRoleOrHigher(...)`, and a failed fetch leaves `data` undefined → roles fall back to `GUEST` → the same denial, just after ~3 minutes of retries instead of 15 seconds.

## User flows verified

- [x] **Permissions check fails → retryable error, not a denial.** New regression test at `app/admin/nonprofit-research/__tests__/staff-gate.test.tsx` renders the **real** `PermissionCheckError` (deliberately not stubbed — the whole point is that the user gets a control they can act on) and asserts the retry button is enabled and the denial copy is absent. Confirmed the test fails against the unfixed layout.
- [x] **Genuine non-staff viewer still denied.** Covered in the same suite: `isError: false, isStaff: false` still renders "Staff access required".
- [x] **Resolved staff member still sees the page.** Covered: `isStaff: true` renders children.
- [x] **Report page keeps its existing behaviour.** `ReportBriefView` now renders the shared component with `subject="this report"`; copy and retry semantics are byte-identical to what #1939 shipped. `src/features/donor-research` suite green.
- [x] **Original denial reproduced live on staging** before the fix (see above) — that is what established the gate, not the role, as the failure point.

Test/build state: 490 tests pass across `app/admin/nonprofit-research`, `src/core/rbac` and `src/features/donor-research`. Full `pnpm build` succeeds.

## Cross-service (FE + BE)?

- [ ] N/A — frontend-only
- [x] Yes — paired with show-karma/gap-indexer#2337 (branch `fix/permissions-rate-limit-redis-hang`)

That PR fixes the **actual backend hang**: `permissionsRateLimit` issued raw ioredis commands guarded only by "does a client object exist", so against a reachable-but-unresponsive Redis the command sat in the offline queue forever and the fail-open `catch` never ran — parking the request until the 60s gateway timeout. The two changes are independent and can merge separately — there is no shared wire contract, no new header, no new field. This PR changes nothing about how the frontend calls `/v2/auth/permissions`; it only changes how the frontend *reports* a failure of that call.

This is the guard, not the cure. The backend PR stops this particular hang. This one stops the *next* permissions failure — whatever its cause — from being reported to a staff member as a policy decision.

## Smoke results

Pre-fix denial reproduced on staging with a known-good SUPER_ADMIN address; the failing `/v2/auth/permissions` request (~15s, 503) was captured in the browser network panel alongside a 200 + `SUPER_ADMIN` from a hand-issued call with the same token.

Post-fix behaviour is asserted by the regression suite against the real error component, which is the branch that was missing. The remaining piece — watching a live staging 503 now render the retry card — is gated on the paired indexer PR being deployed to the same preview, since staging currently cannot be made to fail on demand once the Redis hang is fixed.

## Review waivers

- [x] No HIGH findings, OR all HIGH findings fixed
- [ ] HIGH findings waived (listed below with reasons)

## Pre-PR checklist (super-gap CLAUDE.md)

- [x] Every data-fetching component handles loading, empty, AND error states — this PR *is* the missing error state
- [x] No `any` / `as any` casts
- [x] All mutations use React Query `useMutation` with optimistic updates — n/a, no mutations
- [x] No hardcoded URLs/colors; uses `PAGES`, `envVars`, theme tokens
- [x] `pluralize()` for every dynamic count — n/a, no counts
- [x] Empty-state UI hidden when count is 0 — n/a
- [x] List items in `.map()` are `React.memo()`'d — n/a
- [x] `"use client"` on any file importing Radix — `permission-check-error.tsx` carries `"use client"`
- [x] `useParams()` / `useRouter()` destructured to primitives before useEffect deps — n/a
- [x] Heavy libs lazy-loaded with `dynamic()` — n/a
- [x] `pnpm lint:fix` passes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a retryable error state when access permissions cannot be verified.
  * Added a reusable permission-check error message with a “Try again” action.
  * Updated donor research and nonprofit research views to display this recovery option.

* **Bug Fixes**
  * Non-staff viewers continue to receive the appropriate access-denied message.
  * Staff users can access the expected administrative content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
