### PR TITLE
feat(kyc): admin-settable Not applicable status on the KYC badge

### DIFF
--- a/app/community/[communityId]/(whitelabel)/applications/[applicationId]/components/ApplicationKycCard.tsx
+++ b/app/community/[communityId]/(whitelabel)/applications/[applicationId]/components/ApplicationKycCard.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { getEffectiveKycStatus, KycStatusBadge } from "@/components/KycStatusIcon";
+import { KycStatusBadge } from "@/components/KycStatusIcon";
+import { getEffectiveKycStatus } from "@/components/kyc-status-badge.helpers";
 import { useKycConfig, useKycStatus } from "@/hooks/useKycStatus";
 import { kycStatusDescriptions } from "@/src/features/kyc/lib/status-config";
 

--- a/components/FundingPlatform/ApplicationList/ApplicationTableRow.tsx
+++ b/components/FundingPlatform/ApplicationList/ApplicationTableRow.tsx
@@ -2,7 +2,7 @@
 
 import { ClipboardDocumentCheckIcon } from "@heroicons/react/24/solid";
 import React, { type FC, useState } from "react";
-import { KycStatusBadge } from "@/components/KycStatusIcon";
+import { KycStatusBadgeWithActions } from "@/components/KycStatusBadgeWithActions";
 import { Spinner } from "@/components/Utilities/Spinner";
 import { ReviewerType } from "@/hooks/useReviewerAssignment";
 import type { MilestoneReviewer } from "@/services/milestone-reviewers.service";
@@ -150,7 +150,14 @@ const ApplicationTableRowComponent: FC<ApplicationTableRowProps> = ({
             {isLoadingKycStatus ? (
               <Spinner className="w-4 h-4" />
             ) : (
-              <KycStatusBadge status={kycStatus ?? null} showValidityInLabel={false} />
+              /* biome-ignore lint/a11y/noStaticElementInteractions: This div only stops event propagation so the badge menu doesn't trigger the row's new-tab navigation */
+              <div onClick={(e) => e.stopPropagation()} onKeyDown={(e) => e.stopPropagation()}>
+                <KycStatusBadgeWithActions
+                  status={kycStatus ?? null}
+                  applicationReference={application.referenceNumber}
+                  showValidityInLabel={false}
+                />
+              </div>
             )}
           </td>
         )}

--- a/components/FundingPlatform/ApplicationView/ApplicationHeader.tsx
+++ b/components/FundingPlatform/ApplicationView/ApplicationHeader.tsx
@@ -7,7 +7,7 @@ import {
   XMarkIcon,
 } from "@heroicons/react/24/outline";
 import type { FC, ReactNode } from "react";
-import { KycStatusBadge } from "@/components/KycStatusIcon";
+import { KycStatusBadgeWithActions } from "@/components/KycStatusBadgeWithActions";
 import type { IFundingApplication, ProgramWithFormSchema } from "@/types/funding-platform";
 import type { KycStatusResponse } from "@/types/kyc";
 import { formatApplicationStatus } from "@/utilities/application-status";
@@ -127,7 +127,10 @@ export const ApplicationHeader: FC<ApplicationHeaderProps> = ({
           {isKycEnabled && (
             <div className="flex items-center gap-1.5">
               <span className="text-gray-500 dark:text-gray-500">KYC/KYB:</span>
-              <KycStatusBadge status={kycStatus ?? null} />
+              <KycStatusBadgeWithActions
+                status={kycStatus ?? null}
+                applicationReference={application.referenceNumber}
+              />
             </div>
           )}
         </div>

--- a/components/KycStatusBadgeWithActions.tsx
+++ b/components/KycStatusBadgeWithActions.tsx
@@ -2,15 +2,13 @@
 
 import { ArrowUturnLeftIcon, ChevronDownIcon, NoSymbolIcon } from "@heroicons/react/24/solid";
 import React, { useState } from "react";
+import { KycStatusBadge, KycStatusIcon, KycTooltipContent } from "@/components/KycStatusIcon";
 import {
   getEffectiveKycStatus,
   getKycBadgeLabel,
   KYC_BADGE_BASE,
-  KycStatusBadge,
-  KycStatusIcon,
-  KycTooltipContent,
   kycBadgeColors,
-} from "@/components/KycStatusIcon";
+} from "@/components/kyc-status-badge.helpers";
 import {
   DropdownMenu,
   DropdownMenuContent,

--- a/components/KycStatusBadgeWithActions.tsx
+++ b/components/KycStatusBadgeWithActions.tsx
@@ -1,0 +1,158 @@
+"use client";
+
+import { ArrowUturnLeftIcon, ChevronDownIcon, NoSymbolIcon } from "@heroicons/react/24/solid";
+import React, { useState } from "react";
+import {
+  getEffectiveKycStatus,
+  getKycBadgeLabel,
+  KYC_BADGE_BASE,
+  KycStatusBadge,
+  KycStatusIcon,
+  KycTooltipContent,
+  kycBadgeColors,
+} from "@/components/KycStatusIcon";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+import { useSetKycApplicability } from "@/hooks/useKycStatus";
+import { useHasRoleOrHigher } from "@/src/core/rbac/context/permission-context";
+import { Role } from "@/src/core/rbac/types/role";
+import { type KycStatusResponse, KycVerificationStatus, KycVerificationType } from "@/types/kyc";
+import { cn } from "@/utilities/tailwind";
+
+/**
+ * The applicability toggle is available only while no verification signal
+ * exists — any real Treova status (PENDING/OUTREACH/VERIFIED/REJECTED/EXPIRED)
+ * renders the plain read-only badge, so the UI never offers an action the
+ * server would reject.
+ */
+const TOGGLEABLE_STATUSES = new Set<KycVerificationStatus>([
+  KycVerificationStatus.NOT_STARTED,
+  KycVerificationStatus.NOT_APPLICABLE,
+]);
+
+const INTERACTIVE_BADGE_CLASSES = [
+  "group cursor-pointer transition-shadow duration-150 motion-reduce:transition-none",
+  "hover:ring-1 hover:ring-inset hover:ring-black/10 dark:hover:ring-white/20",
+  "data-[state=open]:ring-1 data-[state=open]:ring-inset data-[state=open]:ring-black/20 dark:data-[state=open]:ring-white/30",
+  "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-1 dark:focus-visible:ring-offset-zinc-900",
+  "disabled:opacity-70 disabled:pointer-events-none",
+].join(" ");
+
+interface KycStatusBadgeWithActionsProps {
+  status: KycStatusResponse | null;
+  /** The application's reference number (APP-...) — the endpoint's only key. */
+  applicationReference: string;
+  className?: string;
+  showValidityInLabel?: boolean;
+}
+
+/**
+ * KYC status badge that lets community admins toggle an application between
+ * "Not started" and "Not applicable" from a one-item menu on the pill itself.
+ *
+ * Fail-closed: non-admins, viewers whose permissions are still resolving, and
+ * statuses outside the toggle pair all get the plain read-only KycStatusBadge.
+ */
+function KycStatusBadgeWithActionsComponent({
+  status,
+  applicationReference,
+  className,
+  showValidityInLabel = true,
+}: KycStatusBadgeWithActionsProps) {
+  // Returns false while permissions resolve — read-only badge, no flash
+  const isCommunityAdmin = useHasRoleOrHigher(Role.COMMUNITY_ADMIN);
+  const [menuOpen, setMenuOpen] = useState(false);
+  const [tooltipOpen, setTooltipOpen] = useState(false);
+  const { mutate, isPending } = useSetKycApplicability();
+
+  const effectiveStatus = getEffectiveKycStatus(status);
+  const canToggle = TOGGLEABLE_STATUSES.has(effectiveStatus);
+
+  if (!isCommunityAdmin || !canToggle) {
+    return (
+      <KycStatusBadge
+        status={status}
+        className={className}
+        showValidityInLabel={showValidityInLabel}
+      />
+    );
+  }
+
+  const badgeLabel = getKycBadgeLabel(status, effectiveStatus, showValidityInLabel);
+  const isNotApplicable = effectiveStatus === KycVerificationStatus.NOT_APPLICABLE;
+
+  const handleToggleApplicability = () => {
+    mutate({
+      applicationReference,
+      // Advisory only — the server preserves the existing row's type
+      verificationType: status?.verificationType ?? KycVerificationType.KYC,
+      status: isNotApplicable
+        ? KycVerificationStatus.NOT_STARTED
+        : KycVerificationStatus.NOT_APPLICABLE,
+    });
+  };
+
+  return (
+    <DropdownMenu open={menuOpen} onOpenChange={setMenuOpen}>
+      <TooltipProvider>
+        {/* Fully controlled so the tooltip stays suppressed while the menu is
+            open and doesn't re-fire when Radix returns focus on menu close */}
+        <Tooltip open={tooltipOpen && !menuOpen} onOpenChange={setTooltipOpen}>
+          <TooltipTrigger asChild>
+            <DropdownMenuTrigger asChild>
+              <button
+                type="button"
+                disabled={isPending}
+                aria-busy={isPending || undefined}
+                aria-haspopup="menu"
+                aria-label={`Change ${badgeLabel} status`}
+                className={cn(
+                  KYC_BADGE_BASE,
+                  kycBadgeColors[effectiveStatus],
+                  INTERACTIVE_BADGE_CLASSES,
+                  className
+                )}
+              >
+                <KycStatusIcon status={status} size="sm" showTooltip={false} />
+                <span>{badgeLabel}</span>
+                <ChevronDownIcon
+                  className="h-3 w-3 opacity-50 transition-transform duration-150 motion-reduce:transition-none group-data-[state=open]:rotate-180"
+                  aria-hidden="true"
+                />
+              </button>
+            </DropdownMenuTrigger>
+          </TooltipTrigger>
+          <TooltipContent side="top" className="max-w-sm">
+            <KycTooltipContent status={status} showDates={!showValidityInLabel} />
+          </TooltipContent>
+        </Tooltip>
+      </TooltipProvider>
+      <DropdownMenuContent align="start" sideOffset={6} className="min-w-[240px]">
+        {isNotApplicable ? (
+          <DropdownMenuItem onSelect={handleToggleApplicability}>
+            <ArrowUturnLeftIcon aria-hidden="true" />
+            <span>Reset to Not started</span>
+          </DropdownMenuItem>
+        ) : (
+          <DropdownMenuItem onSelect={handleToggleApplicability} className="items-start">
+            <NoSymbolIcon aria-hidden="true" className="mt-0.5" />
+            <span className="flex flex-col gap-0.5">
+              <span>Mark as Not applicable</span>
+              <span className="text-xs text-gray-500 dark:text-gray-400">
+                KYC/KYB isn&apos;t required for this application
+              </span>
+            </span>
+          </DropdownMenuItem>
+        )}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
+
+export const KycStatusBadgeWithActions = React.memo(KycStatusBadgeWithActionsComponent);
+KycStatusBadgeWithActions.displayName = "KycStatusBadgeWithActions";

--- a/components/KycStatusIcon.tsx
+++ b/components/KycStatusIcon.tsx
@@ -69,7 +69,7 @@ const statusConfig: Record<
   [KycVerificationStatus.NOT_APPLICABLE]: {
     icon: NoSymbolIcon,
     color: "text-gray-400 dark:text-gray-600",
-    label: "Not applicable",
+    label: "Not Applicable",
     description: "KYC/KYB is not required for this application",
   },
 };

--- a/components/KycStatusIcon.tsx
+++ b/components/KycStatusIcon.tsx
@@ -1,13 +1,12 @@
 "use client";
 
 import {
-  CheckCircleIcon,
-  ClockIcon,
-  ExclamationCircleIcon,
-  MinusCircleIcon,
-  NoSymbolIcon,
-  XCircleIcon,
-} from "@heroicons/react/24/solid";
+  getEffectiveKycStatus,
+  getKycBadgeLabel,
+  KYC_BADGE_BASE,
+  kycBadgeColors,
+  kycStatusConfig,
+} from "@/components/kyc-status-badge.helpers";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { type KycStatusResponse, KycVerificationStatus } from "@/types/kyc";
 import { formatDate } from "@/utilities/formatDate";
@@ -26,63 +25,6 @@ const sizeClasses = {
   lg: "h-6 w-6",
 };
 
-const statusConfig: Record<
-  KycVerificationStatus,
-  { icon: typeof CheckCircleIcon; color: string; label: string; description: string }
-> = {
-  [KycVerificationStatus.NOT_STARTED]: {
-    icon: MinusCircleIcon,
-    color: "text-gray-400",
-    label: "Not Started",
-    description: "KYC verification has not been initiated",
-  },
-  [KycVerificationStatus.PENDING]: {
-    icon: ClockIcon,
-    color: "text-yellow-500",
-    label: "Pending",
-    description: "KYC verification is in progress",
-  },
-  [KycVerificationStatus.OUTREACH]: {
-    icon: ExclamationCircleIcon,
-    color: "text-orange-500",
-    label: "Outreach",
-    description: "Additional information requested",
-  },
-  [KycVerificationStatus.VERIFIED]: {
-    icon: CheckCircleIcon,
-    color: "text-green-500",
-    label: "Verified",
-    description: "KYC verification completed successfully",
-  },
-  [KycVerificationStatus.REJECTED]: {
-    icon: XCircleIcon,
-    color: "text-red-500",
-    label: "Rejected",
-    description: "KYC verification was rejected",
-  },
-  [KycVerificationStatus.EXPIRED]: {
-    icon: ExclamationCircleIcon,
-    color: "text-amber-500",
-    label: "Expired",
-    description: "KYC verification has expired",
-  },
-  [KycVerificationStatus.NOT_APPLICABLE]: {
-    icon: NoSymbolIcon,
-    color: "text-gray-400 dark:text-gray-600",
-    label: "Not Applicable",
-    description: "KYC/KYB is not required for this application",
-  },
-};
-
-/**
- * Shared helper to get the effective status accounting for expiration
- */
-export function getEffectiveKycStatus(status: KycStatusResponse | null): KycVerificationStatus {
-  return status?.isExpired
-    ? KycVerificationStatus.EXPIRED
-    : (status?.status ?? KycVerificationStatus.NOT_STARTED);
-}
-
 /**
  * Shared tooltip content component to reduce duplication
  */
@@ -93,7 +35,7 @@ interface KycTooltipContentProps {
 
 export function KycTooltipContent({ status, showDates = true }: KycTooltipContentProps) {
   const effectiveStatus = getEffectiveKycStatus(status);
-  const config = statusConfig[effectiveStatus];
+  const config = kycStatusConfig[effectiveStatus];
 
   return (
     <div className="space-y-1 text-xs">
@@ -127,7 +69,7 @@ export function KycStatusIcon({
   className,
 }: KycStatusIconProps) {
   const effectiveStatus = getEffectiveKycStatus(status);
-  const config = statusConfig[effectiveStatus];
+  const config = kycStatusConfig[effectiveStatus];
   const Icon = config.icon;
 
   const iconElement = (
@@ -150,64 +92,6 @@ export function KycStatusIcon({
       </Tooltip>
     </TooltipProvider>
   );
-}
-
-/**
- * Base pill classes shared between the read-only badge and the
- * admin-interactive badge (KycStatusBadgeWithActions).
- */
-export const KYC_BADGE_BASE =
-  "inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium";
-
-export const kycBadgeColors: Record<KycVerificationStatus, string> = {
-  [KycVerificationStatus.NOT_STARTED]:
-    "bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400",
-  [KycVerificationStatus.PENDING]:
-    "bg-yellow-100 text-yellow-700 dark:bg-yellow-900/30 dark:text-yellow-400",
-  [KycVerificationStatus.OUTREACH]:
-    "bg-orange-100 text-orange-700 dark:bg-orange-900/30 dark:text-orange-400",
-  [KycVerificationStatus.VERIFIED]:
-    "bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400",
-  [KycVerificationStatus.REJECTED]: "bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400",
-  [KycVerificationStatus.EXPIRED]:
-    "bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-400",
-  // The only outline chip — reads "out of scope" rather than "waiting"
-  [KycVerificationStatus.NOT_APPLICABLE]:
-    "bg-transparent text-gray-500 ring-1 ring-inset ring-gray-300 dark:bg-transparent dark:text-gray-500 dark:ring-zinc-700",
-};
-
-/**
- * Format the badge label - shows only status (the "KYC/KYB:" label is shown separately)
- */
-export function getKycBadgeLabel(
-  status: KycStatusResponse | null,
-  effectiveStatus: KycVerificationStatus,
-  showValidityInLabel: boolean
-): string {
-  const config = statusConfig[effectiveStatus];
-  const verificationType = status?.verificationType ?? "KYC/KYB";
-  const statusLabel = config.label.toLowerCase();
-
-  // For VERIFIED status, include validity date
-  if (
-    effectiveStatus === KycVerificationStatus.VERIFIED &&
-    status?.expiresAt &&
-    showValidityInLabel
-  ) {
-    const expiresDate = formatDate(status.expiresAt);
-    return `${verificationType} ${statusLabel} (valid until ${expiresDate})`;
-  }
-
-  // For NOT_STARTED and NOT_APPLICABLE, show only the label (type-agnostic)
-  if (
-    effectiveStatus === KycVerificationStatus.NOT_STARTED ||
-    effectiveStatus === KycVerificationStatus.NOT_APPLICABLE
-  ) {
-    return config.label;
-  }
-
-  // For all other statuses, include verification type
-  return `${verificationType} ${statusLabel}`;
 }
 
 /**

--- a/components/KycStatusIcon.tsx
+++ b/components/KycStatusIcon.tsx
@@ -5,6 +5,7 @@ import {
   ClockIcon,
   ExclamationCircleIcon,
   MinusCircleIcon,
+  NoSymbolIcon,
   XCircleIcon,
 } from "@heroicons/react/24/solid";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
@@ -65,6 +66,12 @@ const statusConfig: Record<
     label: "Expired",
     description: "KYC verification has expired",
   },
+  [KycVerificationStatus.NOT_APPLICABLE]: {
+    icon: NoSymbolIcon,
+    color: "text-gray-400 dark:text-gray-600",
+    label: "Not applicable",
+    description: "KYC/KYB is not required for this application",
+  },
 };
 
 /**
@@ -92,7 +99,8 @@ export function KycTooltipContent({ status, showDates = true }: KycTooltipConten
     <div className="space-y-1 text-xs">
       <p className="font-medium">{config.label}</p>
       <p className="text-gray-400">{config.description}</p>
-      {status?.verificationType && (
+      {/* NOT_APPLICABLE is type-agnostic — the exemption covers both KYC and KYB */}
+      {status?.verificationType && effectiveStatus !== KycVerificationStatus.NOT_APPLICABLE && (
         <p>
           Type: <span className="font-medium">{status.verificationType}</span>
         </p>
@@ -144,7 +152,14 @@ export function KycStatusIcon({
   );
 }
 
-const badgeColors: Record<KycVerificationStatus, string> = {
+/**
+ * Base pill classes shared between the read-only badge and the
+ * admin-interactive badge (KycStatusBadgeWithActions).
+ */
+export const KYC_BADGE_BASE =
+  "inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium";
+
+export const kycBadgeColors: Record<KycVerificationStatus, string> = {
   [KycVerificationStatus.NOT_STARTED]:
     "bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400",
   [KycVerificationStatus.PENDING]:
@@ -156,12 +171,15 @@ const badgeColors: Record<KycVerificationStatus, string> = {
   [KycVerificationStatus.REJECTED]: "bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400",
   [KycVerificationStatus.EXPIRED]:
     "bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-400",
+  // The only outline chip — reads "out of scope" rather than "waiting"
+  [KycVerificationStatus.NOT_APPLICABLE]:
+    "bg-transparent text-gray-500 ring-1 ring-inset ring-gray-300 dark:bg-transparent dark:text-gray-500 dark:ring-zinc-700",
 };
 
 /**
  * Format the badge label - shows only status (the "KYC/KYB:" label is shown separately)
  */
-function getBadgeLabel(
+export function getKycBadgeLabel(
   status: KycStatusResponse | null,
   effectiveStatus: KycVerificationStatus,
   showValidityInLabel: boolean
@@ -180,8 +198,11 @@ function getBadgeLabel(
     return `${verificationType} ${statusLabel} (valid until ${expiresDate})`;
   }
 
-  // For NOT_STARTED, show only the label (type-agnostic)
-  if (effectiveStatus === KycVerificationStatus.NOT_STARTED) {
+  // For NOT_STARTED and NOT_APPLICABLE, show only the label (type-agnostic)
+  if (
+    effectiveStatus === KycVerificationStatus.NOT_STARTED ||
+    effectiveStatus === KycVerificationStatus.NOT_APPLICABLE
+  ) {
     return config.label;
   }
 
@@ -202,7 +223,7 @@ export function KycStatusBadge({
   showValidityInLabel?: boolean;
 }) {
   const effectiveStatus = getEffectiveKycStatus(status);
-  const badgeLabel = getBadgeLabel(status, effectiveStatus, showValidityInLabel);
+  const badgeLabel = getKycBadgeLabel(status, effectiveStatus, showValidityInLabel);
 
   return (
     <TooltipProvider>
@@ -210,8 +231,9 @@ export function KycStatusBadge({
         <TooltipTrigger asChild>
           <span
             className={cn(
-              "inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium cursor-help",
-              badgeColors[effectiveStatus],
+              KYC_BADGE_BASE,
+              "cursor-help",
+              kycBadgeColors[effectiveStatus],
               className
             )}
           >

--- a/components/Pages/Admin/ControlCenter/FilterToolbar.tsx
+++ b/components/Pages/Admin/ControlCenter/FilterToolbar.tsx
@@ -24,7 +24,7 @@ const FILTER_LABELS: Record<string, Record<string, string>> = {
   status: { NOT_STARTED: "Not Started", IN_PROGRESS: "In Progress", COMPLETED: "Completed" },
   kycStatus: {
     NOT_STARTED: "Not Started",
-    NOT_APPLICABLE: "Not applicable",
+    NOT_APPLICABLE: "Not Applicable",
     PENDING: "Pending",
     VERIFIED: "Verified",
     REJECTED: "Rejected",
@@ -264,7 +264,7 @@ export function FilterToolbar({
               <SelectContent>
                 <SelectItem value="all">All KYB</SelectItem>
                 <SelectItem value="NOT_STARTED">Not Started</SelectItem>
-                <SelectItem value="NOT_APPLICABLE">Not applicable</SelectItem>
+                <SelectItem value="NOT_APPLICABLE">Not Applicable</SelectItem>
                 <SelectItem value="PENDING">Pending</SelectItem>
                 <SelectItem value="VERIFIED">Verified</SelectItem>
                 <SelectItem value="REJECTED">Rejected</SelectItem>

--- a/components/Pages/Admin/ControlCenter/FilterToolbar.tsx
+++ b/components/Pages/Admin/ControlCenter/FilterToolbar.tsx
@@ -24,6 +24,7 @@ const FILTER_LABELS: Record<string, Record<string, string>> = {
   status: { NOT_STARTED: "Not Started", IN_PROGRESS: "In Progress", COMPLETED: "Completed" },
   kycStatus: {
     NOT_STARTED: "Not Started",
+    NOT_APPLICABLE: "Not applicable",
     PENDING: "Pending",
     VERIFIED: "Verified",
     REJECTED: "Rejected",
@@ -263,6 +264,7 @@ export function FilterToolbar({
               <SelectContent>
                 <SelectItem value="all">All KYB</SelectItem>
                 <SelectItem value="NOT_STARTED">Not Started</SelectItem>
+                <SelectItem value="NOT_APPLICABLE">Not applicable</SelectItem>
                 <SelectItem value="PENDING">Pending</SelectItem>
                 <SelectItem value="VERIFIED">Verified</SelectItem>
                 <SelectItem value="REJECTED">Rejected</SelectItem>

--- a/components/__tests__/KycStatusBadgeWithActions.test.tsx
+++ b/components/__tests__/KycStatusBadgeWithActions.test.tsx
@@ -1,0 +1,215 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { ReactNode } from "react";
+import { type KycStatusResponse, KycVerificationStatus, KycVerificationType } from "@/types/kyc";
+import { api } from "@/utilities/api/client";
+import { INDEXER } from "@/utilities/indexer";
+import { KycStatusBadgeWithActions } from "../KycStatusBadgeWithActions";
+
+// Mock the typed api client so the real mutation hook runs against it
+vi.mock("@/utilities/api/client", () => ({
+  api: { get: vi.fn(), post: vi.fn(), put: vi.fn() },
+}));
+
+vi.mock("react-hot-toast", () => ({
+  default: { success: vi.fn(), error: vi.fn() },
+}));
+
+// Role gate — controlled per test. Fail-closed: the real hook returns false
+// while permissions are still resolving, which is the same read-only path.
+const mockUseHasRoleOrHigher = vi.fn();
+vi.mock("@/src/core/rbac/context/permission-context", () => ({
+  useHasRoleOrHigher: (role: string) => mockUseHasRoleOrHigher(role),
+}));
+
+// Radix dropdown is not jsdom-friendly — mock the ui wrappers (established
+// pattern, see ProjectOptionsMenu.test.tsx). Content renders inline so menu
+// items are directly assertable/clickable.
+vi.mock("@/components/ui/dropdown-menu", () => ({
+  DropdownMenu: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  DropdownMenuTrigger: ({ children }: { children: ReactNode }) => <>{children}</>,
+  DropdownMenuContent: ({ children }: { children: ReactNode }) => <div role="menu">{children}</div>,
+  DropdownMenuItem: ({ children, onSelect }: { children: ReactNode; onSelect?: () => void }) => (
+    <button type="button" role="menuitem" onClick={() => onSelect?.()}>
+      {children}
+    </button>
+  ),
+}));
+
+vi.mock("@/components/ui/tooltip", () => ({
+  TooltipProvider: ({ children }: { children: ReactNode }) => <>{children}</>,
+  Tooltip: ({ children }: { children: ReactNode }) => <>{children}</>,
+  TooltipTrigger: ({ children }: { children: ReactNode }) => <>{children}</>,
+  TooltipContent: () => null,
+}));
+
+const mockApi = api as unknown as {
+  get: vi.Mock;
+  post: vi.Mock;
+  put: vi.Mock;
+};
+
+const APP_REF = "APP-123";
+
+const createMockStatus = (overrides: Partial<KycStatusResponse> = {}): KycStatusResponse => ({
+  projectUID: "project-123",
+  communityUID: "community-456",
+  status: KycVerificationStatus.NOT_STARTED,
+  verificationType: KycVerificationType.KYC,
+  isExpired: false,
+  ...overrides,
+});
+
+describe("KycStatusBadgeWithActions", () => {
+  let queryClient: QueryClient;
+
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+
+  const renderBadge = (status: KycStatusResponse | null) =>
+    render(<KycStatusBadgeWithActions status={status} applicationReference={APP_REF} />, {
+      wrapper,
+    });
+
+  beforeEach(() => {
+    queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    vi.clearAllMocks();
+    mockUseHasRoleOrHigher.mockReturnValue(false);
+  });
+
+  afterEach(() => {
+    queryClient.clear();
+  });
+
+  describe("community admin viewer", () => {
+    beforeEach(() => {
+      mockUseHasRoleOrHigher.mockReturnValue(true);
+    });
+
+    it("gates on the COMMUNITY_ADMIN role", () => {
+      renderBadge(createMockStatus());
+
+      expect(mockUseHasRoleOrHigher).toHaveBeenCalledWith("COMMUNITY_ADMIN");
+    });
+
+    it("renders an interactive badge with menu affordances for NOT_STARTED", () => {
+      renderBadge(createMockStatus());
+
+      const trigger = screen.getByRole("button", { name: "Change Not Started status" });
+      expect(trigger).toHaveAttribute("aria-haspopup", "menu");
+      expect(trigger).toHaveAttribute("type", "button");
+      expect(screen.getByRole("menuitem", { name: /Mark as Not applicable/ })).toBeInTheDocument();
+    });
+
+    it("renders the interactive badge when status is null (absent row reads as NOT_STARTED)", () => {
+      renderBadge(null);
+
+      expect(screen.getByRole("button", { name: "Change Not Started status" })).toBeInTheDocument();
+    });
+
+    it("fires the mutation with the correct body when marking Not applicable", async () => {
+      const user = userEvent.setup();
+      mockApi.put.mockResolvedValue(
+        createMockStatus({ status: KycVerificationStatus.NOT_APPLICABLE })
+      );
+
+      renderBadge(createMockStatus());
+
+      await user.click(screen.getByRole("menuitem", { name: /Mark as Not applicable/ }));
+
+      await waitFor(() => {
+        expect(mockApi.put).toHaveBeenCalledWith(INDEXER.KYC.SET_APPLICABILITY, {
+          applicationReference: APP_REF,
+          verificationType: KycVerificationType.KYC,
+          status: KycVerificationStatus.NOT_APPLICABLE,
+        });
+      });
+    });
+
+    it("offers only the reset action for NOT_APPLICABLE and fires the undo mutation", async () => {
+      const user = userEvent.setup();
+      mockApi.put.mockResolvedValue(createMockStatus());
+
+      renderBadge(
+        createMockStatus({
+          status: KycVerificationStatus.NOT_APPLICABLE,
+          verificationType: KycVerificationType.KYB,
+        })
+      );
+
+      expect(
+        screen.getByRole("button", { name: "Change Not applicable status" })
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByRole("menuitem", { name: /Mark as Not applicable/ })
+      ).not.toBeInTheDocument();
+
+      await user.click(screen.getByRole("menuitem", { name: "Reset to Not started" }));
+
+      await waitFor(() => {
+        expect(mockApi.put).toHaveBeenCalledWith(INDEXER.KYC.SET_APPLICABILITY, {
+          applicationReference: APP_REF,
+          // Existing row's type is forwarded (server preserves it regardless)
+          verificationType: KycVerificationType.KYB,
+          status: KycVerificationStatus.NOT_STARTED,
+        });
+      });
+    });
+
+    it.each([
+      KycVerificationStatus.PENDING,
+      KycVerificationStatus.OUTREACH,
+      KycVerificationStatus.VERIFIED,
+      KycVerificationStatus.REJECTED,
+    ])("renders the plain read-only badge for %s (outside the toggle pair)", (status) => {
+      renderBadge(createMockStatus({ status }));
+
+      expect(screen.queryByRole("button")).not.toBeInTheDocument();
+      expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+    });
+
+    it("renders the plain read-only badge for EXPIRED (computed from isExpired)", () => {
+      renderBadge(
+        createMockStatus({
+          status: KycVerificationStatus.VERIFIED,
+          verifiedAt: "2024-01-01T00:00:00Z",
+          expiresAt: "2025-01-01T00:00:00Z",
+          isExpired: true,
+        })
+      );
+
+      expect(screen.queryByRole("button")).not.toBeInTheDocument();
+      expect(screen.getByText("KYC expired")).toBeInTheDocument();
+    });
+  });
+
+  describe("non-admin viewer", () => {
+    it("renders the plain read-only badge with no menu affordances", () => {
+      mockUseHasRoleOrHigher.mockReturnValue(false);
+
+      renderBadge(createMockStatus());
+
+      expect(screen.getByText("Not Started")).toBeInTheDocument();
+      expect(screen.queryByRole("button")).not.toBeInTheDocument();
+      expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+      expect(document.querySelector("[aria-haspopup]")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("permissions resolving (fail-closed)", () => {
+    it("renders the plain read-only badge while the role gate has not resolved to true", () => {
+      // useHasRoleOrHigher returns false while isLoading — same read-only path,
+      // so no clickable control ever flashes for a viewer who turns out denied
+      mockUseHasRoleOrHigher.mockReturnValue(false);
+
+      renderBadge(createMockStatus({ status: KycVerificationStatus.NOT_APPLICABLE }));
+
+      expect(screen.getByText("Not applicable")).toBeInTheDocument();
+      expect(screen.queryByRole("button")).not.toBeInTheDocument();
+    });
+  });
+});

--- a/components/__tests__/KycStatusBadgeWithActions.test.tsx
+++ b/components/__tests__/KycStatusBadgeWithActions.test.tsx
@@ -142,7 +142,7 @@ describe("KycStatusBadgeWithActions", () => {
       );
 
       expect(
-        screen.getByRole("button", { name: "Change Not applicable status" })
+        screen.getByRole("button", { name: "Change Not Applicable status" })
       ).toBeInTheDocument();
       expect(
         screen.queryByRole("menuitem", { name: /Mark as Not applicable/ })
@@ -208,7 +208,7 @@ describe("KycStatusBadgeWithActions", () => {
 
       renderBadge(createMockStatus({ status: KycVerificationStatus.NOT_APPLICABLE }));
 
-      expect(screen.getByText("Not applicable")).toBeInTheDocument();
+      expect(screen.getByText("Not Applicable")).toBeInTheDocument();
       expect(screen.queryByRole("button")).not.toBeInTheDocument();
     });
   });

--- a/components/__tests__/KycStatusIcon.test.tsx
+++ b/components/__tests__/KycStatusIcon.test.tsx
@@ -83,7 +83,7 @@ describe("KycStatusIcon", () => {
         />
       );
 
-      const icon = screen.getByLabelText("Not applicable");
+      const icon = screen.getByLabelText("Not Applicable");
       expect(icon).toBeInTheDocument();
       expect(icon).toHaveClass("text-gray-400");
     });
@@ -245,7 +245,7 @@ describe("KycStatusBadge", () => {
       );
 
       // No "KYB" prefix — the exemption covers both KYC and KYB
-      expect(screen.getByText("Not applicable")).toBeInTheDocument();
+      expect(screen.getByText("Not Applicable")).toBeInTheDocument();
       expect(screen.queryByText(/KYB not applicable/)).not.toBeInTheDocument();
     });
 
@@ -300,7 +300,7 @@ describe("KycStatusBadge", () => {
         />
       );
 
-      const badge = screen.getByText("Not applicable").closest("span");
+      const badge = screen.getByText("Not Applicable").closest("span");
       await user.hover(badge!);
 
       const descriptions = await screen.findAllByText(

--- a/components/__tests__/KycStatusIcon.test.tsx
+++ b/components/__tests__/KycStatusIcon.test.tsx
@@ -75,6 +75,18 @@ describe("KycStatusIcon", () => {
       expect(icon).toBeInTheDocument();
       expect(icon).toHaveClass("text-amber-500");
     });
+
+    it("should render NOT_APPLICABLE icon for not applicable status", () => {
+      render(
+        <KycStatusIcon
+          status={createMockStatus({ status: KycVerificationStatus.NOT_APPLICABLE })}
+        />
+      );
+
+      const icon = screen.getByLabelText("Not applicable");
+      expect(icon).toBeInTheDocument();
+      expect(icon).toHaveClass("text-gray-400");
+    });
   });
 
   describe("size variants", () => {
@@ -221,6 +233,32 @@ describe("KycStatusBadge", () => {
       // Badge shows only status label
       expect(screen.getByText("Not Started")).toBeInTheDocument();
     });
+
+    it("should render type-agnostic label for NOT_APPLICABLE even with a verificationType", () => {
+      render(
+        <KycStatusBadge
+          status={createMockStatus({
+            status: KycVerificationStatus.NOT_APPLICABLE,
+            verificationType: KycVerificationType.KYB,
+          })}
+        />
+      );
+
+      // No "KYB" prefix — the exemption covers both KYC and KYB
+      expect(screen.getByText("Not applicable")).toBeInTheDocument();
+      expect(screen.queryByText(/KYB not applicable/)).not.toBeInTheDocument();
+    });
+
+    it("should render NOT_APPLICABLE as the only outline chip", () => {
+      const { container } = render(
+        <KycStatusBadge
+          status={createMockStatus({ status: KycVerificationStatus.NOT_APPLICABLE })}
+        />
+      );
+
+      const badge = container.querySelector("span.inline-flex");
+      expect(badge).toHaveClass("bg-transparent", "ring-1", "ring-inset", "ring-gray-300");
+    });
   });
 
   describe("tooltip on badge", () => {
@@ -248,6 +286,29 @@ describe("KycStatusBadge", () => {
 
       const expiresRows = await screen.findAllByText(/Expires:/);
       expect(expiresRows.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it("should suppress the Type line in tooltip for NOT_APPLICABLE", async () => {
+      const user = userEvent.setup();
+
+      render(
+        <KycStatusBadge
+          status={createMockStatus({
+            status: KycVerificationStatus.NOT_APPLICABLE,
+            verificationType: KycVerificationType.KYC,
+          })}
+        />
+      );
+
+      const badge = screen.getByText("Not applicable").closest("span");
+      await user.hover(badge!);
+
+      const descriptions = await screen.findAllByText(
+        "KYC/KYB is not required for this application"
+      );
+      expect(descriptions.length).toBeGreaterThanOrEqual(1);
+      // The exemption is type-agnostic — a "Type: KYC" line would imply it covers only one
+      expect(screen.queryByText(/Type:/)).not.toBeInTheDocument();
     });
   });
 

--- a/components/kyc-status-badge.helpers.ts
+++ b/components/kyc-status-badge.helpers.ts
@@ -1,0 +1,125 @@
+import {
+  CheckCircleIcon,
+  ClockIcon,
+  ExclamationCircleIcon,
+  MinusCircleIcon,
+  NoSymbolIcon,
+  XCircleIcon,
+} from "@heroicons/react/24/solid";
+import { type KycStatusResponse, KycVerificationStatus } from "@/types/kyc";
+import { formatDate } from "@/utilities/formatDate";
+
+export const kycStatusConfig: Record<
+  KycVerificationStatus,
+  { icon: typeof CheckCircleIcon; color: string; label: string; description: string }
+> = {
+  [KycVerificationStatus.NOT_STARTED]: {
+    icon: MinusCircleIcon,
+    color: "text-gray-400",
+    label: "Not Started",
+    description: "KYC verification has not been initiated",
+  },
+  [KycVerificationStatus.PENDING]: {
+    icon: ClockIcon,
+    color: "text-yellow-500",
+    label: "Pending",
+    description: "KYC verification is in progress",
+  },
+  [KycVerificationStatus.OUTREACH]: {
+    icon: ExclamationCircleIcon,
+    color: "text-orange-500",
+    label: "Outreach",
+    description: "Additional information requested",
+  },
+  [KycVerificationStatus.VERIFIED]: {
+    icon: CheckCircleIcon,
+    color: "text-green-500",
+    label: "Verified",
+    description: "KYC verification completed successfully",
+  },
+  [KycVerificationStatus.REJECTED]: {
+    icon: XCircleIcon,
+    color: "text-red-500",
+    label: "Rejected",
+    description: "KYC verification was rejected",
+  },
+  [KycVerificationStatus.EXPIRED]: {
+    icon: ExclamationCircleIcon,
+    color: "text-amber-500",
+    label: "Expired",
+    description: "KYC verification has expired",
+  },
+  [KycVerificationStatus.NOT_APPLICABLE]: {
+    icon: NoSymbolIcon,
+    color: "text-gray-400 dark:text-gray-600",
+    label: "Not Applicable",
+    description: "KYC/KYB is not required for this application",
+  },
+};
+
+/**
+ * Shared helper to get the effective status accounting for expiration
+ */
+export function getEffectiveKycStatus(status: KycStatusResponse | null): KycVerificationStatus {
+  return status?.isExpired
+    ? KycVerificationStatus.EXPIRED
+    : (status?.status ?? KycVerificationStatus.NOT_STARTED);
+}
+
+/**
+ * Base pill classes shared between the read-only badge and the
+ * admin-interactive badge (KycStatusBadgeWithActions).
+ */
+export const KYC_BADGE_BASE =
+  "inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium";
+
+export const kycBadgeColors: Record<KycVerificationStatus, string> = {
+  [KycVerificationStatus.NOT_STARTED]:
+    "bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400",
+  [KycVerificationStatus.PENDING]:
+    "bg-yellow-100 text-yellow-700 dark:bg-yellow-900/30 dark:text-yellow-400",
+  [KycVerificationStatus.OUTREACH]:
+    "bg-orange-100 text-orange-700 dark:bg-orange-900/30 dark:text-orange-400",
+  [KycVerificationStatus.VERIFIED]:
+    "bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400",
+  [KycVerificationStatus.REJECTED]: "bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400",
+  [KycVerificationStatus.EXPIRED]:
+    "bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-400",
+  // The only outline chip — reads "out of scope" rather than "waiting"
+  [KycVerificationStatus.NOT_APPLICABLE]:
+    "bg-transparent text-gray-500 ring-1 ring-inset ring-gray-300 dark:bg-transparent dark:text-gray-500 dark:ring-zinc-700",
+};
+
+/**
+ * Format the badge label - shows only status (the "KYC/KYB:" label is shown separately)
+ */
+export function getKycBadgeLabel(
+  status: KycStatusResponse | null,
+  effectiveStatus: KycVerificationStatus,
+  showValidityInLabel: boolean
+): string {
+  const config = kycStatusConfig[effectiveStatus];
+  const verificationType = status?.verificationType ?? "KYC/KYB";
+  const statusLabel = config.label.toLowerCase();
+
+  // For VERIFIED status, include validity date
+  if (
+    effectiveStatus === KycVerificationStatus.VERIFIED &&
+    status?.expiresAt &&
+    showValidityInLabel
+  ) {
+    const expiresDate = formatDate(status.expiresAt);
+    return `${verificationType} ${statusLabel} (valid until ${expiresDate})`;
+  }
+
+  // For NOT_STARTED and NOT_APPLICABLE, show only the label (type-agnostic)
+  if (
+    effectiveStatus === KycVerificationStatus.NOT_STARTED ||
+    effectiveStatus === KycVerificationStatus.NOT_APPLICABLE
+  ) {
+    return config.label;
+  }
+
+  // For all other statuses, include verification type
+  return `${verificationType} ${statusLabel}`;
+}

--- a/hooks/__tests__/useKycStatus.test.tsx
+++ b/hooks/__tests__/useKycStatus.test.tsx
@@ -567,6 +567,77 @@ describe("KYC Hooks", () => {
       expect(mockToast.success).not.toHaveBeenCalled();
     });
 
+    it("should roll back only this application's batch entry, preserving interleaved updates to other entries in the same Map", async () => {
+      seedCaches();
+      let rejectPut!: (error: Error) => void;
+      mockApi.put.mockImplementation(
+        () =>
+          new Promise<KycStatusResponse>((_, reject) => {
+            rejectPut = reject;
+          })
+      );
+
+      const { result } = renderHook(() => useSetKycApplicability(), { wrapper });
+
+      act(() => {
+        result.current.mutate(notApplicableRequest);
+      });
+
+      await waitFor(() => {
+        expect(
+          queryClient.getQueryData<Map<string, KycStatusResponse | null>>(batchKey)?.get(APP_REF)
+            ?.status
+        ).toBe(KycVerificationStatus.NOT_APPLICABLE);
+      });
+
+      // Interleaved update to ANOTHER application sharing the same batch Map
+      // (e.g. a second admin toggle) lands while this mutation is in flight
+      const otherUpdated = createMockKycStatus({
+        status: KycVerificationStatus.NOT_APPLICABLE,
+        verifiedAt: undefined,
+        expiresAt: undefined,
+      });
+      queryClient.setQueryData<Map<string, KycStatusResponse | null>>(batchKey, (old) => {
+        const next = new Map(old);
+        next.set(OTHER_REF, otherUpdated);
+        return next;
+      });
+
+      await act(async () => {
+        rejectPut(httpError(500, "Internal error"));
+      });
+
+      await waitFor(() => {
+        expect(result.current.isError).toBe(true);
+      });
+
+      const rolledBackMap =
+        queryClient.getQueryData<Map<string, KycStatusResponse | null>>(batchKey);
+      // This application's entry snaps back to its pre-mutation value...
+      expect(rolledBackMap?.get(APP_REF)?.status).toBe(KycVerificationStatus.NOT_STARTED);
+      // ...but the interleaved update to the other application survives
+      expect(rolledBackMap?.get(OTHER_REF)).toEqual(otherUpdated);
+    });
+
+    it("should remove the synthetic statusByAppRef entry on error when no cache entry existed before", async () => {
+      // No seedCaches() — the statusByAppRef cache starts empty
+      mockApi.put.mockRejectedValue(httpError(403, "Forbidden"));
+
+      const { result } = renderHook(() => useSetKycApplicability(), { wrapper });
+
+      act(() => {
+        result.current.mutate(notApplicableRequest);
+      });
+
+      await waitFor(() => {
+        expect(result.current.isError).toBe(true);
+      });
+
+      // Rollback must not fabricate a "no KYC row" (null) cache entry for a
+      // query that never ran — the entry created by onMutate is removed
+      expect(queryClient.getQueryState(statusKey)).toBeUndefined();
+    });
+
     it("should invalidate all KYC queries on settle", async () => {
       seedCaches();
       const serverRow = createMockKycStatus({

--- a/hooks/__tests__/useKycStatus.test.tsx
+++ b/hooks/__tests__/useKycStatus.test.tsx
@@ -1,6 +1,7 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { act, renderHook, waitFor } from "@testing-library/react";
 import type { ReactNode } from "react";
+import toast from "react-hot-toast";
 import {
   type KycBatchStatusResponse,
   type KycConfigResponse,
@@ -11,6 +12,7 @@ import {
 } from "@/types/kyc";
 import { api } from "@/utilities/api/client";
 import { HttpError } from "@/utilities/api/errors";
+import { INDEXER } from "@/utilities/indexer";
 import {
   KYC_QUERY_KEYS,
   useKycBatchStatuses,
@@ -18,12 +20,22 @@ import {
   useKycFormUrl,
   useKycStatus,
   useSaveKycConfig,
+  useSetKycApplicability,
 } from "../useKycStatus";
 
 // Mock the typed api client
 vi.mock("@/utilities/api/client", () => ({
   api: { get: vi.fn(), post: vi.fn(), put: vi.fn() },
 }));
+
+vi.mock("react-hot-toast", () => ({
+  default: { success: vi.fn(), error: vi.fn() },
+}));
+
+const mockToast = toast as unknown as {
+  success: vi.Mock;
+  error: vi.Mock;
+};
 
 const mockApi = api as unknown as {
   get: vi.Mock;
@@ -434,6 +446,165 @@ describe("KYC Hooks", () => {
       expect(invalidateQueriesSpy).toHaveBeenCalledWith({
         queryKey: KYC_QUERY_KEYS.config("optimism"),
       });
+    });
+  });
+
+  describe("useSetKycApplicability", () => {
+    const APP_REF = "APP-123";
+    const OTHER_REF = "APP-999";
+    const statusKey = KYC_QUERY_KEYS.statusByAppRef(APP_REF);
+    const batchKey = KYC_QUERY_KEYS.batchStatusesByAppRef("community-456", [APP_REF, OTHER_REF]);
+
+    const notApplicableRequest = {
+      applicationReference: APP_REF,
+      verificationType: KycVerificationType.KYC,
+      status: KycVerificationStatus.NOT_APPLICABLE,
+    } as const;
+
+    const seedCaches = () => {
+      const notStarted = createMockKycStatus({
+        status: KycVerificationStatus.NOT_STARTED,
+        verifiedAt: undefined,
+        expiresAt: undefined,
+      });
+      queryClient.setQueryData(statusKey, notStarted);
+      const batchMap = new Map<string, KycStatusResponse | null>([
+        [APP_REF, notStarted],
+        [OTHER_REF, null],
+      ]);
+      queryClient.setQueryData(batchKey, batchMap);
+      return { notStarted, batchMap };
+    };
+
+    it("should send the request body to the applicability endpoint", async () => {
+      const serverRow = createMockKycStatus({
+        status: KycVerificationStatus.NOT_APPLICABLE,
+        verifiedAt: undefined,
+        expiresAt: undefined,
+      });
+      mockApi.put.mockResolvedValue(serverRow);
+
+      const { result } = renderHook(() => useSetKycApplicability(), { wrapper });
+
+      await act(async () => {
+        await result.current.mutateAsync(notApplicableRequest);
+      });
+
+      expect(mockApi.put).toHaveBeenCalledWith(INDEXER.KYC.SET_APPLICABILITY, notApplicableRequest);
+    });
+
+    it("should optimistically patch statusByAppRef and clone every batch Map, then write the server row", async () => {
+      const { batchMap } = seedCaches();
+      const serverRow = createMockKycStatus({
+        status: KycVerificationStatus.NOT_APPLICABLE,
+        verifiedAt: undefined,
+        expiresAt: undefined,
+        statusSource: "COMMUNITY_ADMIN",
+      });
+      let resolvePut!: (value: KycStatusResponse) => void;
+      mockApi.put.mockImplementation(
+        () =>
+          new Promise<KycStatusResponse>((resolve) => {
+            resolvePut = resolve;
+          })
+      );
+
+      const { result } = renderHook(() => useSetKycApplicability(), { wrapper });
+
+      act(() => {
+        result.current.mutate(notApplicableRequest);
+      });
+
+      // Optimistic flip lands before the response resolves
+      await waitFor(() => {
+        expect(queryClient.getQueryData<KycStatusResponse | null>(statusKey)?.status).toBe(
+          KycVerificationStatus.NOT_APPLICABLE
+        );
+      });
+
+      const optimisticMap =
+        queryClient.getQueryData<Map<string, KycStatusResponse | null>>(batchKey);
+      // Map must be cloned, not mutated in place
+      expect(optimisticMap).not.toBe(batchMap);
+      expect(optimisticMap?.get(APP_REF)?.status).toBe(KycVerificationStatus.NOT_APPLICABLE);
+      // Untouched entries are preserved
+      expect(optimisticMap?.get(OTHER_REF)).toBeNull();
+
+      await act(async () => {
+        resolvePut(serverRow);
+      });
+
+      // Server row becomes the authoritative cache entry
+      await waitFor(() => {
+        expect(queryClient.getQueryData(statusKey)).toEqual(serverRow);
+      });
+      expect(
+        queryClient.getQueryData<Map<string, KycStatusResponse | null>>(batchKey)?.get(APP_REF)
+      ).toEqual(serverRow);
+      expect(mockToast.success).toHaveBeenCalledWith("Marked as Not applicable");
+    });
+
+    it("should roll back statusByAppRef and batch Maps on error", async () => {
+      const { notStarted, batchMap } = seedCaches();
+      mockApi.put.mockRejectedValue(httpError(403, "Forbidden"));
+
+      const { result } = renderHook(() => useSetKycApplicability(), { wrapper });
+
+      act(() => {
+        result.current.mutate(notApplicableRequest);
+      });
+
+      await waitFor(() => {
+        expect(result.current.isError).toBe(true);
+      });
+
+      expect(queryClient.getQueryData(statusKey)).toEqual(notStarted);
+      const rolledBackMap =
+        queryClient.getQueryData<Map<string, KycStatusResponse | null>>(batchKey);
+      expect(rolledBackMap?.get(APP_REF)).toEqual(batchMap.get(APP_REF));
+      expect(rolledBackMap?.get(OTHER_REF)).toBeNull();
+      expect(mockToast.error).toHaveBeenCalledWith("Forbidden");
+      expect(mockToast.success).not.toHaveBeenCalled();
+    });
+
+    it("should invalidate all KYC queries on settle", async () => {
+      seedCaches();
+      const serverRow = createMockKycStatus({
+        status: KycVerificationStatus.NOT_APPLICABLE,
+        verifiedAt: undefined,
+        expiresAt: undefined,
+      });
+      mockApi.put.mockResolvedValue(serverRow);
+      const invalidateQueriesSpy = vi.spyOn(queryClient, "invalidateQueries");
+
+      const { result } = renderHook(() => useSetKycApplicability(), { wrapper });
+
+      await act(async () => {
+        await result.current.mutateAsync(notApplicableRequest);
+      });
+
+      expect(invalidateQueriesSpy).toHaveBeenCalledWith({ queryKey: KYC_QUERY_KEYS.all });
+    });
+
+    it("should toast the reset message when undoing back to Not started", async () => {
+      const serverRow = createMockKycStatus({
+        status: KycVerificationStatus.NOT_STARTED,
+        verifiedAt: undefined,
+        expiresAt: undefined,
+      });
+      mockApi.put.mockResolvedValue(serverRow);
+
+      const { result } = renderHook(() => useSetKycApplicability(), { wrapper });
+
+      await act(async () => {
+        await result.current.mutateAsync({
+          applicationReference: APP_REF,
+          verificationType: KycVerificationType.KYB,
+          status: KycVerificationStatus.NOT_STARTED,
+        });
+      });
+
+      expect(mockToast.success).toHaveBeenCalledWith("Reset to Not started");
     });
   });
 

--- a/hooks/useKycStatus.ts
+++ b/hooks/useKycStatus.ts
@@ -403,7 +403,13 @@ const BATCH_BY_APP_REF_PREFIX = [...KYC_QUERY_KEYS.all, "batch-by-app-ref"] as c
 
 interface SetKycApplicabilityContext {
   previousStatus: KycStatusResponse | null | undefined;
-  previousBatches: [readonly unknown[], Map<string, KycStatusResponse | null> | undefined][];
+  /**
+   * Per-map snapshot of ONLY this application's entry (maps without the
+   * ref are never patched, so they are not snapshotted). Rolling back whole
+   * Maps would clobber interleaved optimistic updates for OTHER applications
+   * sharing the same batch Map.
+   */
+  previousBatchEntries: [readonly unknown[], KycStatusResponse | null][];
 }
 
 /**
@@ -435,9 +441,14 @@ export const useSetKycApplicability = () => {
         await queryClient.cancelQueries({ queryKey: KYC_QUERY_KEYS.all });
 
         const previousStatus = queryClient.getQueryData<KycStatusResponse | null>(statusKey);
-        const previousBatches = queryClient.getQueriesData<Map<string, KycStatusResponse | null>>({
-          queryKey: BATCH_BY_APP_REF_PREFIX,
-        });
+        const previousBatchEntries: SetKycApplicabilityContext["previousBatchEntries"] = [];
+        for (const [queryKey, data] of queryClient.getQueriesData<
+          Map<string, KycStatusResponse | null>
+        >({ queryKey: BATCH_BY_APP_REF_PREFIX })) {
+          if (data?.has(request.applicationReference)) {
+            previousBatchEntries.push([queryKey, data.get(request.applicationReference) ?? null]);
+          }
+        }
 
         const patchStatus = (
           existing: KycStatusResponse | null | undefined
@@ -465,16 +476,28 @@ export const useSetKycApplicability = () => {
           }
         );
 
-        return { previousStatus, previousBatches };
+        return { previousStatus, previousBatchEntries };
       },
       onError: (error, request, context) => {
         if (context) {
-          queryClient.setQueryData(
-            KYC_QUERY_KEYS.statusByAppRef(request.applicationReference),
-            context.previousStatus ?? null
-          );
-          for (const [queryKey, data] of context.previousBatches) {
-            queryClient.setQueryData(queryKey, data);
+          const statusKey = KYC_QUERY_KEYS.statusByAppRef(request.applicationReference);
+          if (context.previousStatus === undefined) {
+            // No cache entry existed before onMutate created one — remove the
+            // synthetic entry instead of fabricating a "no row" (null) result
+            queryClient.removeQueries({ queryKey: statusKey, exact: true });
+          } else {
+            queryClient.setQueryData(statusKey, context.previousStatus);
+          }
+          // Restore ONLY this application's entry in each batch Map, on top of
+          // the map's CURRENT state — other applications' entries (including
+          // interleaved optimistic updates) must survive this rollback
+          for (const [queryKey, previousEntry] of context.previousBatchEntries) {
+            queryClient.setQueryData<Map<string, KycStatusResponse | null>>(queryKey, (current) => {
+              if (!current?.has(request.applicationReference)) return current;
+              const next = new Map(current);
+              next.set(request.applicationReference, previousEntry);
+              return next;
+            });
           }
         }
         toast.error(error instanceof HttpError ? httpErrorMessage(error) : error.message);

--- a/hooks/useKycStatus.ts
+++ b/hooks/useKycStatus.ts
@@ -1,14 +1,17 @@
 "use client";
 
 import { keepPreviousData, useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import type {
-  KycBatchStatusResponse,
-  KycConfigResponse,
-  KycFormUrlRequest,
-  KycFormUrlResponse,
-  KycProviderType,
-  KycStatusResponse,
-  KycVerificationType,
+import toast from "react-hot-toast";
+import {
+  type KycApplicabilityRequest,
+  type KycBatchStatusResponse,
+  type KycConfigResponse,
+  type KycFormUrlRequest,
+  type KycFormUrlResponse,
+  type KycProviderType,
+  type KycStatusResponse,
+  KycVerificationStatus,
+  type KycVerificationType,
 } from "@/types/kyc";
 import { api } from "@/utilities/api/client";
 import { HttpError, isApiError } from "@/utilities/api/errors";
@@ -394,6 +397,113 @@ export const useKycFormUrl = () => {
       });
     },
   });
+};
+
+const BATCH_BY_APP_REF_PREFIX = [...KYC_QUERY_KEYS.all, "batch-by-app-ref"] as const;
+
+interface SetKycApplicabilityContext {
+  previousStatus: KycStatusResponse | null | undefined;
+  previousBatches: [readonly unknown[], Map<string, KycStatusResponse | null> | undefined][];
+}
+
+/**
+ * Hook for community admins to mark an application's KYC/KYB as Not applicable
+ * (or reset it back to Not started).
+ *
+ * Optimistic: flips the cached status immediately (single app-ref query AND
+ * every batch-by-app-ref Map), rolls back on error, and writes the server's
+ * authoritative row on success. Always invalidates on settle so truth wins.
+ */
+export const useSetKycApplicability = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation<KycStatusResponse, Error, KycApplicabilityRequest, SetKycApplicabilityContext>(
+    {
+      mutationFn: async (request) => {
+        // TODO(#1775): add zod schema
+        const data = await api.put<KycStatusResponse>(INDEXER.KYC.SET_APPLICABILITY, request);
+
+        if (!data) {
+          throw new Error("No data returned from KYC applicability request");
+        }
+
+        return data;
+      },
+      onMutate: async (request) => {
+        const statusKey = KYC_QUERY_KEYS.statusByAppRef(request.applicationReference);
+
+        await queryClient.cancelQueries({ queryKey: KYC_QUERY_KEYS.all });
+
+        const previousStatus = queryClient.getQueryData<KycStatusResponse | null>(statusKey);
+        const previousBatches = queryClient.getQueriesData<Map<string, KycStatusResponse | null>>({
+          queryKey: BATCH_BY_APP_REF_PREFIX,
+        });
+
+        const patchStatus = (
+          existing: KycStatusResponse | null | undefined
+        ): KycStatusResponse => ({
+          projectUID: existing?.projectUID ?? "",
+          communityUID: existing?.communityUID ?? "",
+          status: request.status,
+          verificationType: existing?.verificationType ?? request.verificationType,
+          // An exemption never expires; the undo resets to a clean Not started row
+          isExpired: false,
+        });
+
+        queryClient.setQueryData<KycStatusResponse | null>(statusKey, (old) => patchStatus(old));
+
+        queryClient.setQueriesData<Map<string, KycStatusResponse | null>>(
+          { queryKey: BATCH_BY_APP_REF_PREFIX },
+          (old) => {
+            if (!old?.has(request.applicationReference)) return old;
+            const next = new Map(old);
+            next.set(
+              request.applicationReference,
+              patchStatus(old.get(request.applicationReference))
+            );
+            return next;
+          }
+        );
+
+        return { previousStatus, previousBatches };
+      },
+      onError: (error, request, context) => {
+        if (context) {
+          queryClient.setQueryData(
+            KYC_QUERY_KEYS.statusByAppRef(request.applicationReference),
+            context.previousStatus ?? null
+          );
+          for (const [queryKey, data] of context.previousBatches) {
+            queryClient.setQueryData(queryKey, data);
+          }
+        }
+        toast.error(error instanceof HttpError ? httpErrorMessage(error) : error.message);
+      },
+      onSuccess: (data, request) => {
+        queryClient.setQueryData<KycStatusResponse | null>(
+          KYC_QUERY_KEYS.statusByAppRef(request.applicationReference),
+          data
+        );
+        queryClient.setQueriesData<Map<string, KycStatusResponse | null>>(
+          { queryKey: BATCH_BY_APP_REF_PREFIX },
+          (old) => {
+            if (!old?.has(request.applicationReference)) return old;
+            const next = new Map(old);
+            next.set(request.applicationReference, data);
+            return next;
+          }
+        );
+        toast.success(
+          request.status === KycVerificationStatus.NOT_APPLICABLE
+            ? "Marked as Not applicable"
+            : "Reset to Not started"
+        );
+      },
+      onSettled: () => {
+        queryClient.invalidateQueries({ queryKey: KYC_QUERY_KEYS.all });
+      },
+    }
+  );
 };
 
 /**

--- a/src/features/kyc/lib/status-config.ts
+++ b/src/features/kyc/lib/status-config.ts
@@ -1,4 +1,4 @@
-import { AlertCircle, CheckCircle, Clock, MinusCircle, XCircle } from "lucide-react";
+import { AlertCircle, Ban, CheckCircle, Clock, MinusCircle, XCircle } from "lucide-react";
 import { KycVerificationStatus } from "@/types/kyc";
 
 /**
@@ -17,6 +17,8 @@ export const kycStatusStyles: Record<KycVerificationStatus, string> = {
     "inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-medium bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400",
   [KycVerificationStatus.EXPIRED]:
     "inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-medium bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-400",
+  [KycVerificationStatus.NOT_APPLICABLE]:
+    "inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-medium bg-transparent text-gray-500 ring-1 ring-inset ring-gray-300 dark:text-gray-500 dark:ring-zinc-700",
 };
 
 /**
@@ -29,6 +31,7 @@ export const kycIconStyles: Record<KycVerificationStatus, string> = {
   [KycVerificationStatus.VERIFIED]: "h-3.5 w-3.5 text-green-500",
   [KycVerificationStatus.REJECTED]: "h-3.5 w-3.5 text-red-500",
   [KycVerificationStatus.EXPIRED]: "h-3.5 w-3.5 text-amber-500",
+  [KycVerificationStatus.NOT_APPLICABLE]: "h-3.5 w-3.5 text-gray-400 dark:text-gray-600",
 };
 
 /**
@@ -41,6 +44,7 @@ export const kycStatusIcons: Record<KycVerificationStatus, typeof CheckCircle> =
   [KycVerificationStatus.VERIFIED]: CheckCircle,
   [KycVerificationStatus.REJECTED]: XCircle,
   [KycVerificationStatus.EXPIRED]: AlertCircle,
+  [KycVerificationStatus.NOT_APPLICABLE]: Ban,
 };
 
 /**
@@ -53,6 +57,7 @@ export const kycStatusLabels: Record<KycVerificationStatus, string> = {
   [KycVerificationStatus.VERIFIED]: "Verified",
   [KycVerificationStatus.REJECTED]: "Rejected",
   [KycVerificationStatus.EXPIRED]: "Expired",
+  [KycVerificationStatus.NOT_APPLICABLE]: "Not applicable",
 };
 
 /**
@@ -70,6 +75,8 @@ export const kycStatusDescriptions: Record<KycVerificationStatus, string> = {
     "Your verification was not approved. Please contact the program administrator for more information.",
   [KycVerificationStatus.EXPIRED]:
     "Your verification has expired. Please contact the program administrator to receive a new verification link.",
+  [KycVerificationStatus.NOT_APPLICABLE]:
+    "Identity verification is not required for this application.",
 };
 
 /**

--- a/src/features/kyc/lib/status-config.ts
+++ b/src/features/kyc/lib/status-config.ts
@@ -57,7 +57,7 @@ export const kycStatusLabels: Record<KycVerificationStatus, string> = {
   [KycVerificationStatus.VERIFIED]: "Verified",
   [KycVerificationStatus.REJECTED]: "Rejected",
   [KycVerificationStatus.EXPIRED]: "Expired",
-  [KycVerificationStatus.NOT_APPLICABLE]: "Not applicable",
+  [KycVerificationStatus.NOT_APPLICABLE]: "Not Applicable",
 };
 
 /**

--- a/types/kyc.ts
+++ b/types/kyc.ts
@@ -5,6 +5,7 @@ export enum KycVerificationStatus {
   VERIFIED = "VERIFIED",
   REJECTED = "REJECTED",
   EXPIRED = "EXPIRED",
+  NOT_APPLICABLE = "NOT_APPLICABLE",
 }
 
 export enum KycVerificationType {
@@ -16,6 +17,8 @@ export enum KycProviderType {
   TREOVA = "TREOVA",
 }
 
+export type KycStatusSource = "WEBHOOK" | "STAFF_OVERRIDE" | "COMMUNITY_ADMIN";
+
 export interface KycStatusResponse {
   projectUID: string;
   communityUID: string;
@@ -24,6 +27,20 @@ export interface KycStatusResponse {
   verifiedAt?: string;
   expiresAt?: string;
   isExpired: boolean;
+  statusSource?: KycStatusSource;
+  statusUpdatedAt?: string;
+}
+
+/** The only two statuses the applicability toggle can set. */
+export type KycApplicabilityStatus =
+  | KycVerificationStatus.NOT_APPLICABLE
+  | KycVerificationStatus.NOT_STARTED;
+
+export interface KycApplicabilityRequest {
+  applicationReference: string;
+  verificationType: KycVerificationType;
+  status: KycApplicabilityStatus;
+  reason?: string;
 }
 
 export interface KycConfigResponse {

--- a/utilities/indexer.ts
+++ b/utilities/indexer.ts
@@ -752,6 +752,7 @@ export const INDEXER = {
       `/v2/communities/${communityIdOrSlug}/kyc/batch-status/by-application-reference`,
     GET_FORM_URL: (communityIdOrSlug: string) =>
       `/v2/communities/${communityIdOrSlug}/kyc-form-url`,
+    SET_APPLICABILITY: "/v2/admin/kyc/applicability",
   },
   NOTIFICATION_CONFIG: {
     TEST_CONFIG: (communityIdOrSlug: string) =>


### PR DESCRIPTION
## Overview

Community admins (community admin / owner / staff) can now mark a funding application's KYC/KYB as **Not applicable** directly from the status badge — click the badge, one menu item, done. Undo works the same way. Non-admins and all public surfaces keep the exact read-only badge they have today, hover tooltip included.

Paired BE PR: show-karma/gap-indexer — `feat/kyc-not-applicable` (`PUT /v2/admin/kyc/applicability` + `NOT_APPLICABLE` status). **The BE PR must merge and deploy first** — this UI mutates and renders a status the current production API doesn't know.

## Problem

"Not started" conflates "verification pending" with "verification not required". Admins had no way to express an exemption, and no per-application KYC action existed in the UI at all (the staff override endpoint had no frontend).

## Solution

- `NOT_APPLICABLE` added to the `KycVerificationStatus` enum and every exhaustive status map (labels, icons, colors, descriptions).
- Distinct visual identity: the only **outline** chip in the set (`ring-1 ring-inset ring-gray-300`, transparent fill, `NoSymbolIcon`) — reads as "out of scope", not "waiting". Type-agnostic label ("Not applicable", never "KYC Not applicable"); tooltip suppresses the `Type:` line since the exemption covers both.
- New `KycStatusBadgeWithActions` component: for admins on `NOT_STARTED`/`NOT_APPLICABLE` badges, the pill becomes a button with a permanent chevron (rotates on open), hover ring, and a one-item dropdown menu ("Mark as Not applicable" with a one-line explainer / "Reset to Not started"). Radix Tooltip and DropdownMenu share the trigger (tooltip controlled-open, suppressed while the menu is open) so **hover behavior is unchanged**.
- Gated on `useHasRoleOrHigher(Role.COMMUNITY_ADMIN)` — matches the server rule exactly (community admin / registry admin / staff). Fail-closed: while permissions resolve, and for every other status, and for non-admins, the component renders the plain read-only `KycStatusBadge`.
- `useSetKycApplicability` mutation: optimistic flip (badge + every cached batch Map, cloned), rollback + `toast.error` on failure, authoritative server row written on success, `invalidateQueries` on settle. No spinner — trigger is `disabled` + `aria-busy` while pending.
- Clickable surfaces (v1): applications table row (with a `stopPropagation` guard so the row's new-tab navigation doesn't fire) and application detail header. Control Center / Payouts / applicant card / **public financials** keep the read-only badge untouched.
- Control Center KYB filter gains a "Not applicable" option.

## User flows

1. Admin, applications table: click pill → "Mark as Not applicable" → instant flip to outline pill → success toast → refetch confirms.
2. Admin, application detail header: same, and the list shows the new state on back-navigation.
3. Undo: click "Not applicable" pill → "Reset to Not started" → filled gray pill, toast.
4. Reviewer / applicant / logged-out: plain badge, `cursor-help`, no chevron, no menu; public financials read-only even for admins.
5. Permissions still resolving: read-only badge, chevron appears only after resolve (no privileged-UI flash).
6. Mutation fails (403/500): optimistic state rolls back everywhere, error toast, settled invalidation reconciles.
7. Badge on `PENDING`/`VERIFIED`/`REJECTED`/`OUTREACH`/`EXPIRED`: never clickable — the toggle only exists while no verification signal exists (mirrors the server's transition rule, so the UI can't offer an action the server rejects).

## Wire contract

`PUT {INDEXER}/v2/admin/kyc/applicability`, Bearer Privy JWT auto-attached by the API client.
Body: `{ applicationReference, verificationType: 'KYC'|'KYB', status: 'NOT_APPLICABLE'|'NOT_STARTED' }` (`reason` omitted — server writes a canonical audit reason; `verificationType` sent from the current status, server preserves the existing row's value).
Response: flat `KycStatusResponse` + optional `statusSource`/`statusUpdatedAt`, written straight into the query cache.

## Testing

- Full Jest suite green: 1027 files / 14,687 tests.
- New `KycStatusBadgeWithActions.test.tsx` (10 tests): admin menu + chevron + aria, mutation bodies both directions incl. KYB type preservation, read-only for every non-toggle status, non-admin, fail-closed while resolving.
- Extended `KycStatusIcon.test.tsx` (+4: label/colors/tooltip/type-line suppression) and `useKycStatus.test.tsx` (+5: request body, optimistic flip with Map-clone identity, rollback on 403, invalidation, undo toast).
- `pnpm run build` passes; Biome clean on all touched files.

## Smoke results

Cross-service preview E2E (both PRs on the same preview, flows above walked end-to-end incl. 403 and rollback paths) — **pending; required before merge** per the cross-service guardrails. Will be added once this preview points at a deployed preview of the BE branch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a “Not applicable” KYC/KYB status with updated labels, icons, descriptions, and filtering.
  * Community admins can toggle eligible applications between “Not started” and “Not applicable.”
  * Status updates appear immediately with success or error notifications.

* **Bug Fixes**
  * Prevented KYC controls from unintentionally opening application details when clicked or activated by keyboard.

* **Tests**
  * Added coverage for status display, permissions, filtering, updates, optimistic changes, and rollback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->