### PR TITLE
fix(milestones): rebuild verification flow on V2 data and real signer identity

### DIFF
--- a/__tests__/integration/mutations/useMilestoneCancellation.mutation.test.tsx
+++ b/__tests__/integration/mutations/useMilestoneCancellation.mutation.test.tsx
@@ -8,10 +8,7 @@
  */
 import { act, waitFor } from "@testing-library/react";
 import { useMilestoneCancellation } from "@/hooks/useMilestoneCancellation";
-import type {
-  GrantMilestoneWithCompletion,
-  ProjectGrantMilestonesResponse,
-} from "@/services/milestones";
+import type { GrantMilestoneWithCompletion } from "@/services/milestones";
 import { HttpError } from "@/utilities/api/errors";
 import { renderHookWithProviders } from "../../utils/render";
 
@@ -107,27 +104,15 @@ const baseMilestone = (
   description: "desc",
   dueDate: "2025-01-01",
   status: "pending",
+  recipient: RECIPIENT,
   completionDetails: null,
   verificationDetails: null,
   fundingApplicationCompletion: null,
   ...overrides,
 });
 
-const data = {
-  project: { uid: "0xproject" },
-  grantMilestones: [],
-} as unknown as ProjectGrantMilestonesResponse;
-
 beforeEach(() => {
   vi.clearAllMocks();
-  mockProjectById.mockResolvedValue({
-    grants: [
-      {
-        details: { programId: "1013" },
-        milestones: [{ uid: MILESTONE_UID, recipient: RECIPIENT }],
-      },
-    ],
-  });
 });
 
 const renderCancellationHook = () =>
@@ -140,7 +125,6 @@ describe("useMilestoneCancellation", () => {
     await act(async () => {
       await result.current.cancelMilestone({
         milestone: baseMilestone(),
-        data,
         reason: "superseded",
       });
     });
@@ -149,6 +133,22 @@ describe("useMilestoneCancellation", () => {
     expect(mockPayloadFor).toHaveBeenCalledWith(0);
     // Indexer notified with the attestation tx hash.
     expect(mockApiPost).toHaveBeenCalledWith(expect.stringContaining("0xattesttx"), {});
+    // The recipient comes from the V2 milestone payload — no V1 project refetch (#63).
+    expect(mockProjectById).not.toHaveBeenCalled();
+  });
+
+  it("blocks cancelling with no recipient and never signs (#63)", async () => {
+    const { result } = renderCancellationHook();
+
+    await expect(
+      act(async () => {
+        await result.current.cancelMilestone({
+          milestone: baseMilestone({ recipient: undefined }),
+        });
+      })
+    ).rejects.toThrow(/missing its on-chain recipient/);
+    expect(mockMultiAttest).not.toHaveBeenCalled();
+    expect(mockProjectById).not.toHaveBeenCalled();
   });
 
   it("blocks cancelling a completed milestone", async () => {
@@ -164,7 +164,6 @@ describe("useMilestoneCancellation", () => {
               completedBy: "0xgrantee",
             },
           }),
-          data,
         });
       })
     ).rejects.toThrow(/already been completed or verified/);
@@ -182,7 +181,6 @@ describe("useMilestoneCancellation", () => {
               description: "done via application",
             } as GrantMilestoneWithCompletion["fundingApplicationCompletion"],
           }),
-          data,
         });
       })
     ).rejects.toThrow(/already been completed or verified/);
@@ -204,7 +202,6 @@ describe("useMilestoneCancellation", () => {
               reason: null,
             },
           }),
-          data,
         });
       })
     ).rejects.toThrow(/already cancelled/);
@@ -253,7 +250,7 @@ describe("useMilestoneCancellation", () => {
     const { result } = renderCancellationHook();
 
     await act(async () => {
-      await result.current.cancelMilestone({ milestone: baseMilestone(), data });
+      await result.current.cancelMilestone({ milestone: baseMilestone() });
     });
 
     expect(mockMultiAttest).toHaveBeenCalledTimes(1);

--- a/__tests__/integration/mutations/useMilestoneCompletionVerification.mutation.test.tsx
+++ b/__tests__/integration/mutations/useMilestoneCompletionVerification.mutation.test.tsx
@@ -1,0 +1,459 @@
+/**
+ * Flow tests for useMilestoneCompletionVerification (super-gap #63/#64/#66/#67).
+ *
+ * These cover the four defects behind GAP-FRONTEND-261:
+ *  - #63 no V1 `GET /projects/:uid` anywhere in a verify/complete run; the
+ *    attested recipient comes from the V2 milestone payload and a missing one
+ *    blocks BEFORE any transaction;
+ *  - #64 failures name their cause and carry a step marker into Sentry;
+ *  - #66 the indexing poll matches the Privy-resolved signer, not wagmi;
+ *  - #67 a null wagmi address after the tx can no longer fail the run.
+ */
+
+import type { User } from "@privy-io/react-auth";
+import { act, waitFor } from "@testing-library/react";
+import { errorManager } from "@/components/Utilities/errorManager";
+import { useMilestoneCompletionVerification } from "@/hooks/useMilestoneCompletionVerification";
+import type {
+  GrantMilestoneWithCompletion,
+  ProjectGrantMilestonesResponse,
+} from "@/services/milestones";
+import { renderHookWithProviders } from "../../utils/render";
+
+// Hoisted so the `vi.mock` factories below (which run before the module body)
+// can read them. wagmi's account is deliberately a DIFFERENT wallet from the
+// signer in every test — the hybrid Privy account shape that made the old poll
+// unmatchable (#66).
+const {
+  PROJECT_UID,
+  MILESTONE_UID,
+  RECIPIENT,
+  SIGNER_ADDRESS,
+  WAGMI_ADDRESS,
+  PROGRAM_ID,
+  wagmiAccount,
+} = vi.hoisted(() => ({
+  PROJECT_UID: "0xproject",
+  MILESTONE_UID: `0x${"a".repeat(64)}`,
+  RECIPIENT: "0x1111111111111111111111111111111111111111",
+  SIGNER_ADDRESS: "0x2222222222222222222222222222222222222222",
+  WAGMI_ADDRESS: "0x3333333333333333333333333333333333333333",
+  PROGRAM_ID: "1013",
+  wagmiAccount: {
+    current: { address: undefined as string | undefined, chain: { id: 42161 } },
+  },
+}));
+
+vi.mock("wagmi", () => ({
+  useAccount: () => wagmiAccount.current,
+}));
+
+vi.mock("@/hooks/useWallet", () => ({
+  useWallet: () => ({ switchChainAsync: vi.fn().mockResolvedValue(true) }),
+}));
+
+const { mockProjectById, mockGetAddress } = vi.hoisted(() => ({
+  mockProjectById: vi.fn(),
+  mockGetAddress: vi.fn(),
+}));
+
+vi.mock("@/hooks/useSetupChainAndWallet", () => ({
+  useSetupChainAndWallet: () => ({
+    smartWalletAddress: SIGNER_ADDRESS,
+    setupChainAndWallet: vi.fn().mockResolvedValue({
+      gapClient: {
+        fetch: { projectById: mockProjectById },
+        findSchema: () => ({ uid: `0x${"d".repeat(64)}` }),
+      },
+      walletSigner: { getAddress: mockGetAddress },
+      chainId: 42161,
+      isGasless: true,
+    }),
+  }),
+}));
+
+const { mockMultiAttest } = vi.hoisted(() => ({
+  mockMultiAttest: vi.fn(),
+}));
+
+vi.mock("@show-karma/karma-gap-sdk/core/class/contract/GapContract", () => ({
+  GapContract: { multiAttest: mockMultiAttest },
+}));
+
+const { mockPayloadFor, attestationArgs } = vi.hoisted(() => ({
+  mockPayloadFor: vi.fn(),
+  attestationArgs: [] as Array<{ recipient: string; data: { type: string } }>,
+}));
+
+vi.mock("@show-karma/karma-gap-sdk/core/class/types/attestations", () => ({
+  MilestoneCompleted: class {
+    constructor(args: { recipient: string; data: { type: string } }) {
+      attestationArgs.push(args);
+    }
+    payloadFor = mockPayloadFor;
+  },
+}));
+
+const { mockApiGet, mockApiPost } = vi.hoisted(() => ({
+  mockApiGet: vi.fn(),
+  mockApiPost: vi.fn(),
+}));
+
+vi.mock("@/utilities/api/client", () => ({
+  api: {
+    get: (...args: unknown[]) => mockApiGet(...args),
+    post: (...args: unknown[]) => mockApiPost(...args),
+    put: vi.fn(),
+    patch: vi.fn(),
+    delete: vi.fn(),
+    request: vi.fn(),
+    getPaginated: vi.fn(),
+  },
+}));
+
+const { mockAttestAsReviewer } = vi.hoisted(() => ({
+  mockAttestAsReviewer: vi.fn(),
+}));
+
+vi.mock("@/services/milestones", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/services/milestones")>();
+  return { ...actual, attestMilestoneCompletionAsReviewer: mockAttestAsReviewer };
+});
+
+// Keep the real polling semantics but collapse the 200 × 1.5s budget so a
+// never-satisfied condition surfaces its timeout inside the test timeout.
+vi.mock("@/utilities/retries", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/utilities/retries")>();
+  return {
+    ...actual,
+    retryUntilConditionMet: (
+      conditionFn: () => Promise<boolean>,
+      callbackFn?: () => void,
+      _maxRetries?: number,
+      _delay?: number,
+      signal?: AbortSignal
+    ) => actual.retryUntilConditionMet(conditionFn, callbackFn, 3, 0, signal),
+  };
+});
+
+const { toastSpies } = vi.hoisted(() => ({
+  toastSpies: {
+    startAttestation: vi.fn(),
+    showLoading: vi.fn(),
+    showSuccess: vi.fn(),
+    showError: vi.fn(),
+    changeStepperStep: vi.fn(),
+    dismiss: vi.fn(),
+  },
+}));
+
+vi.mock("@/hooks/useAttestationToast", () => ({
+  useAttestationToast: () => toastSpies,
+}));
+
+vi.mock("@/components/Utilities/errorManager", () => ({ errorManager: vi.fn() }));
+
+const milestone = (
+  overrides: Partial<GrantMilestoneWithCompletion> = {}
+): GrantMilestoneWithCompletion => ({
+  uid: MILESTONE_UID,
+  chainId: 42161,
+  title: "Milestone",
+  description: "desc",
+  dueDate: "2025-01-01",
+  status: "pending",
+  recipient: RECIPIENT,
+  completionDetails: null,
+  verificationDetails: null,
+  fundingApplicationCompletion: null,
+  ...overrides,
+});
+
+const projectData = {
+  project: { uid: PROJECT_UID },
+  grantMilestones: [],
+} as unknown as ProjectGrantMilestonesResponse;
+
+/** The V2 project-updates payload the poll re-reads. */
+const indexedResponse = (grantMilestone: Record<string, unknown>) => ({
+  projectUpdates: [],
+  projectMilestones: [],
+  grantMilestones: [grantMilestone],
+});
+
+const verifiedBySigner = () =>
+  indexedResponse({
+    uid: MILESTONE_UID,
+    chainId: 42161,
+    title: "Milestone",
+    description: "desc",
+    dueDate: "2025-01-01",
+    status: "verified",
+    recipient: RECIPIENT,
+    completionDetails: { description: "done", completedAt: "", completedBy: SIGNER_ADDRESS },
+    verificationDetails: {
+      description: "ok",
+      verifiedAt: "",
+      verifiedBy: SIGNER_ADDRESS,
+      attestationUID: `0x${"f".repeat(64)}`,
+    },
+    fundingApplicationCompletion: null,
+  });
+
+const privyUser = {
+  linkedAccounts: [{ type: "email", address: "user@example.com" }],
+} as unknown as User;
+
+const renderVerificationHook = () =>
+  renderHookWithProviders(
+    () => useMilestoneCompletionVerification({ projectId: PROJECT_UID, programId: PROGRAM_ID }),
+    { authState: { user: privyUser } }
+  );
+
+/** V1 project reads are `GET /projects/:uid`; the V2 reads are `/v2/...`. */
+const v1ProjectCalls = () =>
+  mockApiGet.mock.calls.filter(([url]) => typeof url === "string" && /^\/projects\//.test(url));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  attestationArgs.length = 0;
+  wagmiAccount.current = { address: WAGMI_ADDRESS, chain: { id: 42161 } };
+  mockGetAddress.mockResolvedValue(SIGNER_ADDRESS);
+  mockPayloadFor.mockResolvedValue({ payload: "attestation-payload" });
+  mockMultiAttest.mockResolvedValue({ tx: [{ hash: "0xattesttx" }] });
+  mockApiPost.mockResolvedValue({});
+  mockApiGet.mockResolvedValue(verifiedBySigner());
+  mockAttestAsReviewer.mockResolvedValue({ txHash: "0xbackendtx", attestationUID: "0xuid" });
+});
+
+describe("useMilestoneCompletionVerification — verify", () => {
+  it("completes without a single V1 project fetch (#63)", async () => {
+    const { result } = renderVerificationHook();
+
+    await act(async () => {
+      await result.current.verifyMilestone(milestone(), false, projectData, "looks good");
+    });
+
+    await waitFor(() => expect(toastSpies.showSuccess).toHaveBeenCalled());
+    expect(mockProjectById).not.toHaveBeenCalled();
+    expect(v1ProjectCalls()).toHaveLength(0);
+    expect(mockApiGet).toHaveBeenCalledWith(expect.stringContaining("/v2/projects/"));
+  });
+
+  it("attests with the recipient from the V2 milestone payload (#63)", async () => {
+    const { result } = renderVerificationHook();
+
+    await act(async () => {
+      await result.current.verifyMilestone(milestone(), false, projectData, "looks good");
+    });
+
+    await waitFor(() => expect(mockMultiAttest).toHaveBeenCalledTimes(1));
+    expect(attestationArgs).toHaveLength(2);
+    for (const args of attestationArgs) {
+      expect(args.recipient).toBe(RECIPIENT);
+    }
+    expect(attestationArgs.map((a) => a.data.type)).toEqual(["completed", "verified"]);
+  });
+
+  it("blocks a milestone with no recipient before any transaction (#63)", async () => {
+    const { result } = renderVerificationHook();
+
+    await act(async () => {
+      await result.current.verifyMilestone(
+        milestone({ recipient: undefined }),
+        false,
+        projectData,
+        "looks good"
+      );
+    });
+
+    expect(mockMultiAttest).not.toHaveBeenCalled();
+    expect(toastSpies.showError).toHaveBeenCalledWith(
+      expect.stringContaining("missing its on-chain recipient")
+    );
+  });
+
+  it("skips the completion attestation when the milestone is already completed", async () => {
+    const { result } = renderVerificationHook();
+
+    await act(async () => {
+      await result.current.verifyMilestone(
+        milestone({
+          completionDetails: { description: "done", completedAt: "", completedBy: RECIPIENT },
+        }),
+        false,
+        projectData,
+        "looks good"
+      );
+    });
+
+    await waitFor(() => expect(mockMultiAttest).toHaveBeenCalledTimes(1));
+    expect(attestationArgs.map((a) => a.data.type)).toEqual(["verified"]);
+  });
+
+  it("matches the poll on the Privy signer, not the wagmi account (#66)", async () => {
+    const { result } = renderVerificationHook();
+
+    await act(async () => {
+      await result.current.verifyMilestone(milestone(), false, projectData, "looks good");
+    });
+
+    // The indexed attester is the signer; wagmi reports an unrelated wallet.
+    await waitFor(() =>
+      expect(toastSpies.showSuccess).toHaveBeenCalledWith(
+        "Milestone completed and verified successfully!"
+      )
+    );
+    expect(wagmiAccount.current.address).toBe(WAGMI_ADDRESS);
+    expect(toastSpies.showError).not.toHaveBeenCalled();
+  });
+
+  it("succeeds with a null wagmi address after the transaction (#67)", async () => {
+    wagmiAccount.current = { address: undefined, chain: { id: 42161 } };
+    const { result } = renderVerificationHook();
+
+    await act(async () => {
+      await result.current.verifyMilestone(milestone(), false, projectData, "looks good");
+    });
+
+    await waitFor(() => expect(toastSpies.showSuccess).toHaveBeenCalled());
+    expect(toastSpies.showError).not.toHaveBeenCalled();
+    expect(errorManager).not.toHaveBeenCalled();
+  });
+
+  it("tells the user the attestation is still indexing on poll timeout (#66)", async () => {
+    // Indexer never surfaces the verification within the retry budget.
+    mockApiGet.mockResolvedValue(
+      indexedResponse({
+        uid: MILESTONE_UID,
+        chainId: 42161,
+        title: "Milestone",
+        description: "desc",
+        dueDate: "2025-01-01",
+        status: "pending",
+        recipient: RECIPIENT,
+        completionDetails: null,
+        verificationDetails: null,
+        fundingApplicationCompletion: null,
+      })
+    );
+    const { result } = renderVerificationHook();
+
+    await act(async () => {
+      await result.current.verifyMilestone(milestone(), false, projectData, "looks good");
+    });
+
+    expect(toastSpies.showError).toHaveBeenCalledWith(
+      expect.stringContaining("still being indexed")
+    );
+    // Indexer lag is not a defect — guidance only, never Sentry.
+    expect(errorManager).not.toHaveBeenCalled();
+  });
+
+  it("names the cause and reports the step marker on a signing failure (#64)", async () => {
+    mockMultiAttest.mockRejectedValue(new Error("insufficient funds for intrinsic transaction"));
+    const { result } = renderVerificationHook();
+
+    await act(async () => {
+      await result.current.verifyMilestone(milestone(), false, projectData, "looks good");
+    });
+
+    expect(toastSpies.showError).toHaveBeenCalledWith(
+      "Failed to verify milestone: your wallet doesn't have enough funds to cover gas."
+    );
+    expect(errorManager).toHaveBeenCalledWith(
+      "Error verifying milestone",
+      expect.any(Error),
+      expect.objectContaining({
+        milestoneUID: MILESTONE_UID,
+        projectUid: PROJECT_UID,
+        chainId: 42161,
+        programId: PROGRAM_ID,
+        step: "attest",
+        failureKind: "insufficient-funds",
+      })
+    );
+  });
+
+  it("keeps the dedicated cancelled copy for a user rejection (#64)", async () => {
+    mockMultiAttest.mockRejectedValue(
+      Object.assign(new Error("User rejected the request"), { code: 4001 })
+    );
+    const { result } = renderVerificationHook();
+
+    await act(async () => {
+      await result.current.verifyMilestone(milestone(), false, projectData, "looks good");
+    });
+
+    expect(toastSpies.showError).toHaveBeenCalledWith("Verification cancelled");
+    expect(errorManager).not.toHaveBeenCalled();
+  });
+
+  it("does not re-read the milestone after the backend completion (reviewer flow, #63)", async () => {
+    const { result } = renderVerificationHook();
+
+    await act(async () => {
+      await result.current.verifyMilestone(milestone(), true, projectData, "looks good");
+    });
+
+    await waitFor(() => expect(mockMultiAttest).toHaveBeenCalledTimes(1));
+    expect(mockAttestAsReviewer).toHaveBeenCalledTimes(1);
+    // Verification only — the backend already created the completion.
+    expect(attestationArgs.map((a) => a.data.type)).toEqual(["verified"]);
+    expect(mockProjectById).not.toHaveBeenCalled();
+    expect(v1ProjectCalls()).toHaveLength(0);
+  });
+});
+
+describe("useMilestoneCompletionVerification — complete", () => {
+  it("completes on-chain against V2 data only (#63)", async () => {
+    const { result } = renderVerificationHook();
+
+    await act(async () => {
+      await result.current.completeMilestone(milestone(), projectData, "all done");
+    });
+
+    await waitFor(() =>
+      expect(toastSpies.showSuccess).toHaveBeenCalledWith("Milestone completed successfully!")
+    );
+    expect(attestationArgs).toHaveLength(1);
+    expect(attestationArgs[0].recipient).toBe(RECIPIENT);
+    expect(mockProjectById).not.toHaveBeenCalled();
+    expect(v1ProjectCalls()).toHaveLength(0);
+  });
+
+  it("blocks completion with no recipient before any transaction (#63)", async () => {
+    const { result } = renderVerificationHook();
+
+    await act(async () => {
+      await result.current.completeMilestone(
+        milestone({ recipient: undefined }),
+        projectData,
+        "all done"
+      );
+    });
+
+    expect(mockMultiAttest).not.toHaveBeenCalled();
+    expect(toastSpies.showError).toHaveBeenCalledWith(
+      expect.stringContaining("missing its on-chain recipient")
+    );
+  });
+
+  it("names the cause on a completion failure (#64)", async () => {
+    mockMultiAttest.mockRejectedValue(new Error("boom"));
+    const { result } = renderVerificationHook();
+
+    await act(async () => {
+      await result.current.completeMilestone(milestone(), projectData, "all done");
+    });
+
+    expect(toastSpies.showError).toHaveBeenCalledWith(
+      "Failed to complete milestone: an unexpected error occurred."
+    );
+    expect(errorManager).toHaveBeenCalledWith(
+      "Error completing milestone",
+      expect.any(Error),
+      expect.objectContaining({ step: "attest", projectUid: PROJECT_UID })
+    );
+  });
+});

--- a/__tests__/integration/mutations/useMilestoneCompletionVerification.mutation.test.tsx
+++ b/__tests__/integration/mutations/useMilestoneCompletionVerification.mutation.test.tsx
@@ -18,6 +18,7 @@ import type {
   GrantMilestoneWithCompletion,
   ProjectGrantMilestonesResponse,
 } from "@/services/milestones";
+import { HttpError } from "@/utilities/api/errors";
 import { renderHookWithProviders } from "../../utils/render";
 
 // Hoisted so the `vi.mock` factories below (which run before the module body)
@@ -387,6 +388,26 @@ describe("useMilestoneCompletionVerification — verify", () => {
 
     expect(toastSpies.showError).toHaveBeenCalledWith("Verification cancelled");
     expect(errorManager).not.toHaveBeenCalled();
+  });
+
+  it("does not mistake an API error whose route contains 'reject' for a cancellation (#64)", async () => {
+    mockAttestAsReviewer.mockRejectedValue(
+      new HttpError(500, { endpoint: "/v2/milestones/x/reject-completion", method: "POST" })
+    );
+    const { result } = renderVerificationHook();
+
+    await act(async () => {
+      await result.current.verifyMilestone(milestone(), true, projectData, "looks good");
+    });
+
+    expect(toastSpies.showError).toHaveBeenCalledWith(
+      "Failed to verify milestone: the server rejected the request (HTTP 500)."
+    );
+    expect(errorManager).toHaveBeenCalledWith(
+      "Error verifying milestone",
+      expect.anything(),
+      expect.objectContaining({ step: "backend", failureKind: "server" })
+    );
   });
 
   it("does not re-read the milestone after the backend completion (reviewer flow, #63)", async () => {

--- a/__tests__/integration/mutations/useMilestoneCompletionVerification.mutation.test.tsx
+++ b/__tests__/integration/mutations/useMilestoneCompletionVerification.mutation.test.tsx
@@ -322,6 +322,95 @@ describe("useMilestoneCompletionVerification — verify", () => {
     expect(errorManager).not.toHaveBeenCalled();
   });
 
+  it.each([
+    ["Base", 8453, "0x7177AdC0f924b695C0294A40C4C5FEFf5EE1E141"],
+    ["Arbitrum", 42161, "0x6dC1D6b864e8BEf815806f9e4677123496e12026"],
+  ])(
+    "matches the poll on the %s MultiAttester contract EAS records as attester",
+    async (_network, chainId, multiAttester) => {
+      // `GapContract.multiAttest` routes through the MultiAttester, so it is
+      // `msg.sender` at EAS and the indexer stores IT as `verifiedBy` — never
+      // the signer. Without it in the candidate set every verification polls to
+      // timeout on a transaction that already succeeded.
+      //
+      // `attestationUID` is deliberately absent (it is optional on the indexer
+      // row): it forces the poll through the attester-candidate path, so this
+      // asserts the MultiAttester wiring rather than the UID-change fallback.
+      mockApiGet.mockResolvedValue(
+        indexedResponse({
+          uid: MILESTONE_UID,
+          chainId,
+          title: "Milestone",
+          description: "desc",
+          dueDate: "2025-01-01",
+          status: "verified",
+          recipient: RECIPIENT,
+          completionDetails: { description: "done", completedAt: "", completedBy: RECIPIENT },
+          verificationDetails: {
+            description: "ok",
+            verifiedAt: "",
+            verifiedBy: multiAttester,
+          },
+          fundingApplicationCompletion: null,
+        })
+      );
+      const { result } = renderVerificationHook();
+
+      await act(async () => {
+        await result.current.verifyMilestone(milestone({ chainId }), false, projectData, "ok");
+      });
+
+      await waitFor(() =>
+        expect(toastSpies.showSuccess).toHaveBeenCalledWith(
+          "Milestone completed and verified successfully!"
+        )
+      );
+      expect(toastSpies.showError).not.toHaveBeenCalled();
+      expect(errorManager).not.toHaveBeenCalled();
+    }
+  );
+
+  it("does not accept a pre-existing verification by an unrecognised attester", async () => {
+    // Same attestation UID as before signing: nothing landed under OUR
+    // transaction, so the snapshot guard must keep the poll unsatisfied even
+    // though the milestone already carries a verification.
+    const preExisting = {
+      description: "someone else",
+      verifiedAt: "",
+      verifiedBy: WAGMI_ADDRESS,
+      attestationUID: `0x${"e".repeat(64)}`,
+    };
+    mockApiGet.mockResolvedValue(
+      indexedResponse({
+        uid: MILESTONE_UID,
+        chainId: 42161,
+        title: "Milestone",
+        description: "desc",
+        dueDate: "2025-01-01",
+        status: "verified",
+        recipient: RECIPIENT,
+        completionDetails: { description: "done", completedAt: "", completedBy: RECIPIENT },
+        verificationDetails: preExisting,
+        fundingApplicationCompletion: null,
+      })
+    );
+    const { result } = renderVerificationHook();
+
+    await act(async () => {
+      await result.current.verifyMilestone(
+        milestone({ verificationDetails: preExisting }),
+        false,
+        projectData,
+        "looks good"
+      );
+    });
+
+    expect(toastSpies.showSuccess).not.toHaveBeenCalled();
+    expect(toastSpies.showError).toHaveBeenCalledWith(
+      expect.stringContaining("still being indexed")
+    );
+  });
+
   it("tells the user the attestation is still indexing on poll timeout (#66)", async () => {
     // Indexer never surfaces the verification within the retry budget.
     mockApiGet.mockResolvedValue(

--- a/__tests__/services/milestones.recipient.test.ts
+++ b/__tests__/services/milestones.recipient.test.ts
@@ -1,0 +1,87 @@
+/**
+ * The V2 project-updates response has always carried the milestone `recipient`;
+ * the frontend mapper dropped it, which is why the attestation flows re-fetched
+ * the whole project through the SDK's V1 path (super-gap #63).
+ */
+import { fetchGrantMilestonesForProgram, fetchProjectGrantMilestones } from "@/services/milestones";
+
+const { mockApiGet } = vi.hoisted(() => ({ mockApiGet: vi.fn() }));
+
+vi.mock("@/utilities/api/client", () => ({
+  api: {
+    get: (...args: unknown[]) => mockApiGet(...args),
+    post: vi.fn(),
+    put: vi.fn(),
+    patch: vi.fn(),
+    delete: vi.fn(),
+    request: vi.fn(),
+    getPaginated: vi.fn(),
+  },
+}));
+
+vi.mock("@/utilities/auth/api-client", () => ({
+  createAuthenticatedApiClient: () => ({ post: vi.fn(), get: vi.fn() }),
+}));
+
+const RECIPIENT = "0x1111111111111111111111111111111111111111";
+
+const updatesPayload = (recipient?: string) => ({
+  projectUpdates: [],
+  projectMilestones: [],
+  grantMilestones: [
+    {
+      uid: "0xmilestone",
+      programId: "1013",
+      chainId: 42161,
+      title: "Milestone",
+      description: "desc",
+      dueDate: "2025-01-01",
+      status: "pending",
+      recipient,
+      completionDetails: null,
+      verificationDetails: null,
+      fundingApplicationCompletion: null,
+    },
+  ],
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("fetchGrantMilestonesForProgram", () => {
+  it("issues a single V2 updates request and preserves the recipient", async () => {
+    mockApiGet.mockResolvedValue(updatesPayload(RECIPIENT));
+
+    const milestones = await fetchGrantMilestonesForProgram("0xproject", "1013_42161");
+
+    expect(mockApiGet).toHaveBeenCalledTimes(1);
+    const [url] = mockApiGet.mock.calls[0];
+    expect(url).toContain("/v2/projects/0xproject/updates");
+    // The chain suffix is stripped before it reaches the API.
+    expect(url).toContain("programIds=1013");
+    expect(milestones[0].recipient).toBe(RECIPIENT);
+  });
+
+  it("leaves the recipient undefined for legacy rows", async () => {
+    mockApiGet.mockResolvedValue(updatesPayload(undefined));
+
+    const milestones = await fetchGrantMilestonesForProgram("0xproject", "1013");
+
+    expect(milestones[0].recipient).toBeUndefined();
+  });
+});
+
+describe("fetchProjectGrantMilestones", () => {
+  it("maps the recipient through the full response too", async () => {
+    mockApiGet.mockImplementation((url: string) => {
+      if (url.includes("/updates")) return Promise.resolve(updatesPayload(RECIPIENT));
+      if (url.includes("/grants")) return Promise.resolve([]);
+      return Promise.resolve({ uid: "0xproject", chainID: 42161, owner: "0xowner" });
+    });
+
+    const response = await fetchProjectGrantMilestones("0xproject", "1013");
+
+    expect(response.grantMilestones[0].recipient).toBe(RECIPIENT);
+  });
+});

--- a/__tests__/unit/utilities/errorManager.test.tsx
+++ b/__tests__/unit/utilities/errorManager.test.tsx
@@ -299,8 +299,78 @@ describe("errorManager", () => {
       errorManager("Test error", error, { targetNetwork: "Base" });
 
       expect(Sentry.captureException).not.toHaveBeenCalled();
-      expect(Sentry.addBreadcrumb).not.toHaveBeenCalled();
       expect(Sentry.captureMessage).not.toHaveBeenCalled();
+    });
+  });
+
+  // ---------------------------------------------------------------------
+  // Suppression breadcrumbs (super-gap #64) — a suppressed error used to be
+  // invisible in BOTH directions: generic toast, nothing in Sentry. Every
+  // early-return path must now leave a trace.
+  // ---------------------------------------------------------------------
+  describe("suppressed-error breadcrumbs (#64)", () => {
+    const expectSuppressedBreadcrumb = (reason: string) =>
+      expect(Sentry.addBreadcrumb).toHaveBeenCalledWith(
+        expect.objectContaining({
+          category: "suppressed-error",
+          level: "warning",
+          data: expect.objectContaining({ reason }),
+        })
+      );
+
+    it("breadcrumbs a suppressed transient network error", () => {
+      const networkErr = Object.assign(new Error("Network Error"), { code: "ERR_NETWORK" });
+
+      errorManager("Error verifying milestone", networkErr, { step: "poll" });
+
+      expect(Sentry.captureException).not.toHaveBeenCalled();
+      expectSuppressedBreadcrumb("transient-network");
+      expect(Sentry.addBreadcrumb).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: "Error verifying milestone",
+          data: expect.objectContaining({ step: "poll" }),
+        })
+      );
+    });
+
+    it("breadcrumbs a suppressed transient gateway error", () => {
+      const gatewayErr = Object.assign(new Error("Request failed with status code 504"), {
+        response: { status: 504 },
+      });
+
+      errorManager("Error verifying milestone", gatewayErr);
+
+      expect(Sentry.captureException).not.toHaveBeenCalled();
+      expectSuppressedBreadcrumb("transient-http");
+    });
+
+    it("breadcrumbs a suppressed user rejection", () => {
+      errorManager("Error verifying milestone", { message: "User rejected the transaction" });
+
+      expect(Sentry.captureException).not.toHaveBeenCalled();
+      expectSuppressedBreadcrumb("user-rejected");
+    });
+
+    it("breadcrumbs a suppressed switch-chain error", () => {
+      errorManager(
+        "Error verifying milestone",
+        { message: "could not switch chain" },
+        {
+          targetNetwork: "Base",
+        }
+      );
+
+      expect(Sentry.captureException).not.toHaveBeenCalled();
+      expectSuppressedBreadcrumb("switch-chain");
+    });
+
+    it("breadcrumbs a suppressed expected wallet-lifecycle error", () => {
+      const error = Object.assign(new Error("No wallet is connected."), { expected: true });
+
+      errorManager("Error verifying milestone", error);
+
+      expect(Sentry.captureException).not.toHaveBeenCalled();
+      expectSuppressedBreadcrumb("expected-state");
     });
   });
 

--- a/__tests__/utilities/milestones/attestationFailure.test.ts
+++ b/__tests__/utilities/milestones/attestationFailure.test.ts
@@ -1,0 +1,98 @@
+import { HttpError, NetworkError } from "@/utilities/api/errors";
+import { describeMilestoneFailure } from "@/utilities/milestones/attestationFailure";
+import { MissingMilestoneRecipientError } from "@/utilities/milestones/attestationIdentity";
+import { RetryConditionNotMetError } from "@/utilities/retries";
+import { SignerUnavailableError } from "@/utilities/wallet/signerReadiness";
+
+describe("describeMilestoneFailure", () => {
+  it("passes through the wallet-lifecycle guidance and keeps it out of Sentry", () => {
+    const result = describeMilestoneFailure(
+      new SignerUnavailableError("wallets-hydrating"),
+      "verify"
+    );
+
+    expect(result.kind).toBe("signer-unavailable");
+    expect(result.expected).toBe(true);
+    expect(result.message).toMatch(/still being prepared/);
+  });
+
+  it("surfaces the missing-recipient guard verbatim", () => {
+    const result = describeMilestoneFailure(
+      new MissingMilestoneRecipientError("0xmilestone"),
+      "verify"
+    );
+
+    expect(result.kind).toBe("missing-recipient");
+    expect(result.expected).toBe(false);
+    expect(result.message).toMatch(/missing its on-chain recipient/);
+  });
+
+  it("distinguishes an indexing timeout from a failure", () => {
+    const verify = describeMilestoneFailure(new RetryConditionNotMetError(), "verify");
+    const complete = describeMilestoneFailure(new RetryConditionNotMetError(), "complete");
+
+    expect(verify.kind).toBe("indexing-timeout");
+    expect(verify.expected).toBe(true);
+    expect(verify.message).toMatch(/submitted on-chain and is still being indexed/);
+    expect(verify.message).not.toMatch(/Failed to/);
+    expect(complete.message).toMatch(/completion was submitted on-chain/);
+  });
+
+  it("names a network-switch failure", () => {
+    expect(
+      describeMilestoneFailure(new Error("Wallet network changed while preparing"), "verify")
+    ).toMatchObject({
+      kind: "network-switch",
+      message: "Failed to verify milestone: couldn't switch your wallet to the required network.",
+    });
+
+    expect(
+      describeMilestoneFailure({ message: "could not switch chain" }, "complete")
+    ).toMatchObject({ kind: "network-switch" });
+  });
+
+  it("names an out-of-gas failure", () => {
+    expect(
+      describeMilestoneFailure(new Error("insufficient funds for gas * price"), "verify")
+    ).toMatchObject({ kind: "insufficient-funds" });
+  });
+
+  it("reports the HTTP status for a server rejection", () => {
+    const result = describeMilestoneFailure(
+      new HttpError(422, { endpoint: "/v2/milestones/x/attest-completion", method: "POST" }),
+      "verify"
+    );
+
+    expect(result.kind).toBe("server");
+    expect(result.message).toContain("HTTP 422");
+  });
+
+  it("names a transient network failure", () => {
+    expect(
+      describeMilestoneFailure(
+        new NetworkError({ endpoint: "/v2/projects/x/updates", method: "GET" }),
+        "verify"
+      )
+    ).toMatchObject({ kind: "network" });
+
+    expect(
+      describeMilestoneFailure(
+        Object.assign(new Error("Network Error"), { code: "ERR_NETWORK" }),
+        "verify"
+      )
+    ).toMatchObject({ kind: "network" });
+  });
+
+  it("names a wallet RPC failure", () => {
+    expect(describeMilestoneFailure(new Error("rpc error: timeout"), "verify")).toMatchObject({
+      kind: "wallet-rpc",
+    });
+  });
+
+  it("falls back to an explicit unknown cause rather than a bare action label", () => {
+    const result = describeMilestoneFailure(new Error("something odd"), "complete");
+
+    expect(result.kind).toBe("unknown");
+    expect(result.message).toBe("Failed to complete milestone: an unexpected error occurred.");
+  });
+});

--- a/__tests__/utilities/milestones/attestationFailure.test.ts
+++ b/__tests__/utilities/milestones/attestationFailure.test.ts
@@ -1,4 +1,4 @@
-import { HttpError, NetworkError } from "@/utilities/api/errors";
+import { ContractViolationError, HttpError, NetworkError } from "@/utilities/api/errors";
 import { describeMilestoneFailure } from "@/utilities/milestones/attestationFailure";
 import { MissingMilestoneRecipientError } from "@/utilities/milestones/attestationIdentity";
 import { RetryConditionNotMetError } from "@/utilities/retries";
@@ -65,6 +65,20 @@ describe("describeMilestoneFailure", () => {
 
     expect(result.kind).toBe("server");
     expect(result.message).toContain("HTTP 422");
+  });
+
+  it("separates a malformed response from a network failure", () => {
+    const result = describeMilestoneFailure(
+      new ContractViolationError({
+        endpoint: "/v2/projects/x/updates",
+        method: "GET",
+        issues: ["recipient: expected string"],
+      }),
+      "verify"
+    );
+
+    expect(result.kind).toBe("server");
+    expect(result.message).toContain("unexpected response");
   });
 
   it("names a transient network failure", () => {

--- a/__tests__/utilities/milestones/attestationIdentity.test.ts
+++ b/__tests__/utilities/milestones/attestationIdentity.test.ts
@@ -1,0 +1,112 @@
+import type { GrantMilestoneWithCompletion } from "@/services/milestones";
+import {
+  buildAttesterCandidates,
+  isEvmAddress,
+  isMissingMilestoneRecipientError,
+  MissingMilestoneRecipientError,
+  matchesSubmittedVerification,
+  requireMilestoneRecipient,
+} from "@/utilities/milestones/attestationIdentity";
+
+const RECIPIENT = "0x1111111111111111111111111111111111111111";
+const SIGNER = "0x2222222222222222222222222222222222222222";
+const WAGMI = "0x3333333333333333333333333333333333333333";
+
+const milestone = (
+  recipient?: string
+): Pick<GrantMilestoneWithCompletion, "uid" | "recipient"> => ({
+  uid: "0xmilestone",
+  recipient,
+});
+
+describe("isEvmAddress", () => {
+  it("accepts lower-cased addresses the indexer stores", () => {
+    expect(isEvmAddress(RECIPIENT)).toBe(true);
+    expect(isEvmAddress("0xAbCdEf0123456789AbCdEf0123456789AbCdEf01")).toBe(true);
+  });
+
+  it("rejects empty, short and non-hex values", () => {
+    expect(isEvmAddress(undefined)).toBe(false);
+    expect(isEvmAddress("")).toBe(false);
+    expect(isEvmAddress("0x123")).toBe(false);
+    expect(isEvmAddress("not-an-address")).toBe(false);
+  });
+});
+
+describe("requireMilestoneRecipient", () => {
+  it("returns the recipient when present", () => {
+    expect(requireMilestoneRecipient(milestone(RECIPIENT))).toBe(RECIPIENT);
+  });
+
+  it("throws a typed, user-facing error for a legacy row with no recipient", () => {
+    expect(() => requireMilestoneRecipient(milestone())).toThrow(MissingMilestoneRecipientError);
+    expect(() => requireMilestoneRecipient(milestone(""))).toThrow(
+      /missing its on-chain recipient/
+    );
+  });
+
+  it("is recognisable across module boundaries", () => {
+    let caught: unknown;
+    try {
+      requireMilestoneRecipient(milestone());
+    } catch (error) {
+      caught = error;
+    }
+    expect(isMissingMilestoneRecipientError(caught)).toBe(true);
+    expect(isMissingMilestoneRecipientError(new Error("other"))).toBe(false);
+  });
+});
+
+describe("buildAttesterCandidates", () => {
+  it("lower-cases, de-duplicates and drops empties", () => {
+    expect(
+      buildAttesterCandidates([SIGNER.toUpperCase(), SIGNER, null, undefined, "", WAGMI])
+    ).toEqual([SIGNER.toLowerCase(), WAGMI.toLowerCase()]);
+  });
+});
+
+describe("matchesSubmittedVerification", () => {
+  const candidates = buildAttesterCandidates([SIGNER]);
+
+  it("is false while the verification is absent", () => {
+    expect(matchesSubmittedVerification({ verificationDetails: null, candidates })).toBe(false);
+  });
+
+  it("matches the signer even when it differs from the wagmi account (#66)", () => {
+    expect(
+      matchesSubmittedVerification({
+        verificationDetails: { verifiedBy: SIGNER.toUpperCase() },
+        candidates,
+      })
+    ).toBe(true);
+  });
+
+  it("rejects a verification attested by an unrelated wallet", () => {
+    expect(
+      matchesSubmittedVerification({
+        verificationDetails: { verifiedBy: WAGMI },
+        candidates,
+      })
+    ).toBe(false);
+  });
+
+  it("accepts a NEW verification when the indexer has not resolved the attester", () => {
+    expect(
+      matchesSubmittedVerification({
+        verificationDetails: { attestationUID: "0xnew" },
+        candidates,
+        previousAttestationUID: "0xold",
+      })
+    ).toBe(true);
+  });
+
+  it("does not accept a pre-existing verification with an unresolved attester", () => {
+    expect(
+      matchesSubmittedVerification({
+        verificationDetails: { attestationUID: "0xold" },
+        candidates,
+        previousAttestationUID: "0xold",
+      })
+    ).toBe(false);
+  });
+});

--- a/__tests__/utilities/milestones/attestationIdentity.test.ts
+++ b/__tests__/utilities/milestones/attestationIdentity.test.ts
@@ -1,6 +1,8 @@
+import { chainIdToNetwork, Networks } from "@show-karma/karma-gap-sdk/core/consts";
 import type { GrantMilestoneWithCompletion } from "@/services/milestones";
 import {
   buildAttesterCandidates,
+  getMultiAttesterAddress,
   isEvmAddress,
   isMissingMilestoneRecipientError,
   MissingMilestoneRecipientError,
@@ -11,6 +13,10 @@ import {
 const RECIPIENT = "0x1111111111111111111111111111111111111111";
 const SIGNER = "0x2222222222222222222222222222222222222222";
 const WAGMI = "0x3333333333333333333333333333333333333333";
+
+const BASE_CHAIN_ID = 8453;
+/** The deployed Base MultiAttester — the attester the indexer actually records. */
+const BASE_MULTI_ATTESTER = "0x7177AdC0f924b695C0294A40C4C5FEFf5EE1E141";
 
 const milestone = (
   recipient?: string
@@ -65,6 +71,30 @@ describe("buildAttesterCandidates", () => {
   });
 });
 
+describe("getMultiAttesterAddress", () => {
+  it("resolves Base to its deployed MultiAttester, lower-cased", () => {
+    expect(getMultiAttesterAddress(BASE_CHAIN_ID)).toBe(BASE_MULTI_ATTESTER.toLowerCase());
+  });
+
+  it("accepts a stringified chain id, as the indexer stores it", () => {
+    expect(getMultiAttesterAddress(String(BASE_CHAIN_ID))).toBe(BASE_MULTI_ATTESTER.toLowerCase());
+  });
+
+  it("resolves every SDK-supported chain rather than hardcoding one", () => {
+    for (const [chainId, network] of Object.entries(chainIdToNetwork)) {
+      const expected = Networks[network as keyof typeof Networks].contracts.multicall.toLowerCase();
+      expect(getMultiAttesterAddress(Number(chainId))).toBe(expected);
+    }
+  });
+
+  it("returns null for unsupported or malformed chain ids", () => {
+    expect(getMultiAttesterAddress(999999)).toBeNull();
+    expect(getMultiAttesterAddress("not-a-chain")).toBeNull();
+    expect(getMultiAttesterAddress(null)).toBeNull();
+    expect(getMultiAttesterAddress(undefined)).toBeNull();
+  });
+});
+
 describe("matchesSubmittedVerification", () => {
   const candidates = buildAttesterCandidates([SIGNER]);
 
@@ -86,6 +116,65 @@ describe("matchesSubmittedVerification", () => {
       matchesSubmittedVerification({
         verificationDetails: { verifiedBy: WAGMI },
         candidates,
+      })
+    ).toBe(false);
+  });
+
+  it("matches the chain's MultiAttester, which EAS records as the attester", () => {
+    // `multiAttest` submits through the MultiAttester, so it — not the signer —
+    // is `msg.sender` at EAS and therefore what the indexer stores.
+    const withMultiAttester = buildAttesterCandidates([
+      SIGNER,
+      getMultiAttesterAddress(BASE_CHAIN_ID),
+    ]);
+
+    expect(
+      matchesSubmittedVerification({
+        verificationDetails: { verifiedBy: BASE_MULTI_ATTESTER },
+        candidates: withMultiAttester,
+      })
+    ).toBe(true);
+  });
+
+  it("matches another chain's MultiAttester, not just Base's", () => {
+    const arbitrumChainId = 42161;
+    const arbitrumMultiAttester = getMultiAttesterAddress(arbitrumChainId);
+
+    expect(
+      matchesSubmittedVerification({
+        verificationDetails: { verifiedBy: arbitrumMultiAttester },
+        candidates: buildAttesterCandidates([SIGNER, arbitrumMultiAttester]),
+      })
+    ).toBe(true);
+  });
+
+  it("does not match a MultiAttester from a different chain than the milestone's", () => {
+    expect(
+      matchesSubmittedVerification({
+        verificationDetails: { verifiedBy: BASE_MULTI_ATTESTER },
+        candidates: buildAttesterCandidates([SIGNER, getMultiAttesterAddress(42161)]),
+      })
+    ).toBe(false);
+  });
+
+  it("accepts a NEW verification even when the attester is unrecognised", () => {
+    expect(
+      matchesSubmittedVerification({
+        verificationDetails: { verifiedBy: WAGMI, attestationUID: "0xnew" },
+        candidates,
+        previousAttestationUID: "0xold",
+      })
+    ).toBe(true);
+  });
+
+  it("rejects a pre-existing verification with an unrecognised attester", () => {
+    // The milestone was already verified by somebody else and nothing changed
+    // under our transaction — the snapshot guard must keep this false.
+    expect(
+      matchesSubmittedVerification({
+        verificationDetails: { verifiedBy: WAGMI, attestationUID: "0xold" },
+        candidates,
+        previousAttestationUID: "0xold",
       })
     ).toBe(false);
   });

--- a/components/Pages/Admin/MilestonesReview/index.tsx
+++ b/components/Pages/Admin/MilestonesReview/index.tsx
@@ -533,10 +533,9 @@ function MilestonesReviewPageContent({
 
   const handleCancelMilestone = useCallback(
     async (milestone: GrantMilestoneWithCompletion, reason?: string) => {
-      if (!data) return;
-      await cancelMilestone({ milestone, data, reason });
+      await cancelMilestone({ milestone, reason });
     },
-    [cancelMilestone, data]
+    [cancelMilestone]
   );
 
   const handleUncancelMilestone = useCallback(

--- a/components/Utilities/errorManager.tsx
+++ b/components/Utilities/errorManager.tsx
@@ -40,6 +40,30 @@ const errorContains = (error: ErrorLike | null | undefined, needle: string): boo
   );
 };
 
+// Every suppression path below leaves this breadcrumb. Without it a suppressed
+// error was invisible in BOTH directions — the user got a generic toast and
+// Sentry got nothing at all, so a class of failures (network-class errors in the
+// milestone verification flow) had zero telemetry. The breadcrumb attaches to
+// whatever event the session eventually reports, and keeps the suppressed
+// error's own noise out of Sentry issues.
+const breadcrumbSuppressed = (
+  reason: string,
+  errorMessage: string,
+  error: unknown,
+  extra?: unknown
+): void => {
+  Sentry.addBreadcrumb({
+    category: "suppressed-error",
+    level: "warning",
+    message: errorMessage,
+    data: {
+      reason,
+      error: (error as { message?: string } | null)?.message ?? String(error),
+      ...(extra && typeof extra === "object" ? (extra as Record<string, unknown>) : {}),
+    },
+  });
+};
+
 // Fires the standard "Try again shortly" failure toast. Shared by the typed
 // ApiError branch and the legacy wallet-error fallback below so both paths
 // give the user the same feedback for a failed action.
@@ -133,13 +157,16 @@ export const errorManager = (
 
   if (error?.originalError || error?.message) {
     if (errorContains(error, "reject")) {
+      breadcrumbSuppressed("user-rejected", errorMessage, error, extra);
       return;
     }
     if (handleSwitchChainError(error, extra)) {
+      breadcrumbSuppressed("switch-chain", errorMessage, error, extra);
       return;
     }
   }
   if (handleExpectedError(error, toastError)) {
+    breadcrumbSuppressed("expected-state", errorMessage, error, extra);
     return;
   }
   if (toastError?.error) {
@@ -163,6 +190,7 @@ export const errorManager = (
   // Query and surface to the user as an error UI, so drop them on the
   // floor for Sentry. See DEV-236 / GAP-FRONTEND-13P.
   if (isTransientNetworkError(error)) {
+    breadcrumbSuppressed("transient-network", errorMessage, error, extra);
     return;
   }
 
@@ -171,6 +199,7 @@ export const errorManager = (
   // are tracked on the infra/indexer side, not here. See DEV-271 /
   // GAP-FRONTEND-1R1.
   if (isTransientHttpError(error)) {
+    breadcrumbSuppressed("transient-http", errorMessage, error, extra);
     return;
   }
 

--- a/hooks/useMilestoneCancellation.ts
+++ b/hooks/useMilestoneCancellation.ts
@@ -12,8 +12,7 @@ import type {
   GrantMilestoneWithCompletion,
   ProjectGrantMilestonesResponse,
 } from "@/services/milestones";
-import { api } from "@/utilities/api/client";
-import { INDEXER } from "@/utilities/indexer";
+import { notifyIndexer } from "@/utilities/indexer-notification";
 import { requireMilestoneRecipient } from "@/utilities/milestones/attestationIdentity";
 import { QUERY_KEYS } from "@/utilities/queryKeys";
 import { sanitizeObject } from "@/utilities/sanitize";
@@ -59,11 +58,12 @@ export const useMilestoneCancellation = ({
   const queryKey = QUERY_KEYS.MILESTONES.PROJECT_GRANT_MILESTONES(projectId, programId);
 
   const notifyAndInvalidate = async (txHash: string | null | undefined, chainId: number) => {
-    if (txHash) {
-      // Best-effort indexer nudge; it also catches this via its own chain listener,
-      // so a failure must not abort the flow. Legacy fetchData discarded the error.
-      await api.post(INDEXER.ATTESTATION_LISTENER(txHash, chainId), {}).catch(() => undefined);
-    }
+    // Best-effort nudge — the indexer's own chain listener picks the tx up
+    // regardless, so a failure must not abort a flow whose tx already landed.
+    // `notifyIndexer` REPORTS that failure; the inline swallow it replaced left
+    // a failed nudge completely invisible.
+    await notifyIndexer({ txHash: txHash ?? undefined, chainId });
+
     await queryClient.invalidateQueries({ queryKey });
     await queryClient.invalidateQueries({ queryKey: ["reportMilestones"] });
     await queryClient.invalidateQueries({ queryKey: ["pendingVerificationMilestones"] });

--- a/hooks/useMilestoneCancellation.ts
+++ b/hooks/useMilestoneCancellation.ts
@@ -1,8 +1,6 @@
-import type { GAP } from "@show-karma/karma-gap-sdk";
 import { GapContract } from "@show-karma/karma-gap-sdk/core/class/contract/GapContract";
 import { MilestoneCompleted } from "@show-karma/karma-gap-sdk/core/class/types/attestations";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import type { Signer } from "ethers";
 import type { Hex } from "viem";
 import { useAccount } from "wagmi";
 import { errorManager } from "@/components/Utilities/errorManager";
@@ -16,10 +14,9 @@ import type {
 } from "@/services/milestones";
 import { api } from "@/utilities/api/client";
 import { INDEXER } from "@/utilities/indexer";
+import { requireMilestoneRecipient } from "@/utilities/milestones/attestationIdentity";
 import { QUERY_KEYS } from "@/utilities/queryKeys";
 import { sanitizeObject } from "@/utilities/sanitize";
-
-const normalizeProgramId = (id: string): string => (id.includes("_") ? id.split("_")[0] : id);
 
 // Thrown when wallet/chain setup does not complete (user aborted, or a
 // preparation failure). `setupChainAndWallet` already surfaces the reason
@@ -40,7 +37,6 @@ interface UseMilestoneCancellationParams {
 
 interface CancelArgs {
   milestone: GrantMilestoneWithCompletion;
-  data: ProjectGrantMilestonesResponse;
   reason?: string;
 }
 
@@ -73,42 +69,8 @@ export const useMilestoneCancellation = ({
     await queryClient.invalidateQueries({ queryKey: ["pendingVerificationMilestones"] });
   };
 
-  // Fetches the on-chain milestone recipient (needed to build the status
-  // attestation), mirroring the verify flow's SDK resolution.
-  const resolveMilestoneRecipient = async (
-    milestone: GrantMilestoneWithCompletion,
-    data: ProjectGrantMilestonesResponse
-  ): Promise<{ recipient: Hex; gapClient: GAP; walletSigner: Signer }> => {
-    const setup = await setupChainAndWallet({
-      targetChainId: +milestone.chainId,
-      currentChainId: chain?.id,
-      switchChainAsync,
-    });
-    if (!setup) throw new ChainSetupAbortedError();
-
-    const { gapClient, walletSigner } = setup;
-    const project = await gapClient.fetch.projectById(data.project.uid as Hex);
-    if (!project) throw new Error("Failed to fetch project data");
-
-    const normalizedInputId = normalizeProgramId(programId);
-    const grant = project.grants.find((g) => {
-      const storedId = g.details?.programId;
-      return storedId ? normalizeProgramId(storedId) === normalizedInputId : false;
-    });
-    const instance = grant?.milestones?.find(
-      (m) => m.uid.toLowerCase() === milestone.uid.toLowerCase()
-    );
-    if (!instance) throw new Error("Milestone not found on-chain");
-
-    return {
-      recipient: instance.recipient as Hex,
-      gapClient,
-      walletSigner,
-    };
-  };
-
   const cancelMutation = useMutation({
-    mutationFn: async ({ milestone, data, reason }: CancelArgs) => {
+    mutationFn: async ({ milestone, reason }: CancelArgs) => {
       if (
         milestone.completionDetails ||
         milestone.verificationDetails ||
@@ -121,12 +83,21 @@ export const useMilestoneCancellation = ({
       if (milestone.status === "cancelled" || milestone.cancellation != null) {
         throw new Error("This milestone is already cancelled.");
       }
+      // The on-chain recipient comes straight from the V2 milestone payload —
+      // validated BEFORE the wallet is touched, so a legacy row without one
+      // stops here instead of prompting for a signature it can't use.
+      const recipient = requireMilestoneRecipient(milestone);
+
       showLoading("Cancelling milestone...");
 
-      const { recipient, gapClient, walletSigner } = await resolveMilestoneRecipient(
-        milestone,
-        data
-      );
+      const setup = await setupChainAndWallet({
+        targetChainId: +milestone.chainId,
+        currentChainId: chain?.id,
+        switchChainAsync,
+      });
+      if (!setup) throw new ChainSetupAbortedError();
+
+      const { gapClient, walletSigner } = setup;
       const schema = gapClient.findSchema("MilestoneCompleted");
 
       const cancellationAttestation = new MilestoneCompleted({

--- a/hooks/useMilestoneCompletionVerification.ts
+++ b/hooks/useMilestoneCompletionVerification.ts
@@ -6,31 +6,37 @@ import { useEffect, useRef, useState } from "react";
 import type { Hex } from "viem";
 import { useAccount } from "wagmi";
 import { errorManager } from "@/components/Utilities/errorManager";
+import { usePrivyBridge } from "@/contexts/privy-bridge-context";
 import { useAttestationToast } from "@/hooks/useAttestationToast";
 import { useSetupChainAndWallet } from "@/hooks/useSetupChainAndWallet";
 import { useWallet } from "@/hooks/useWallet";
 import {
   attestMilestoneCompletionAsReviewer,
+  fetchGrantMilestonesForProgram,
   type GrantMilestoneWithCompletion,
   type ProjectGrantMilestonesResponse,
 } from "@/services/milestones";
 import { api } from "@/utilities/api/client";
+import { getLinkedWalletAddresses } from "@/utilities/auth/compare-all-wallets";
 import { INDEXER } from "@/utilities/indexer";
+import {
+  describeMilestoneFailure,
+  type MilestoneAction,
+  type MilestoneFlowStep,
+} from "@/utilities/milestones/attestationFailure";
+import {
+  buildAttesterCandidates,
+  matchesSubmittedVerification,
+  requireMilestoneRecipient,
+} from "@/utilities/milestones/attestationIdentity";
 import { queryClient } from "@/utilities/query-client";
 import { QUERY_KEYS } from "@/utilities/queryKeys";
 import { isAbortError, retryUntilConditionMet } from "@/utilities/retries";
 import { sanitizeObject } from "@/utilities/sanitize";
+import { isUserRejectionError } from "@/utilities/wallet/signerReadiness";
 
 // Constants
 const INDEXER_PROCESSING_DELAY_MS = 2000;
-
-/**
- * Normalize programId by stripping the chainId suffix if present
- * Supports both "programId" and legacy "programId_chainId" formats
- */
-const normalizeProgramId = (id: string): string => {
-  return id.includes("_") ? id.split("_")[0] : id;
-};
 
 interface UseMilestoneCompletionVerificationParams {
   projectId: string;
@@ -46,13 +52,20 @@ interface UseMilestoneCompletionVerificationParams {
   onCachesInvalidated?: () => void;
 }
 
-interface MilestoneInstance {
-  uid: string;
-  recipient: `0x${string}`;
-  completed: boolean | { data: any; attester: string };
-  verified?: Array<{ attester: string }>;
-  chainID: number;
+/**
+ * The wallet/chain context resolved once per flow. `attesterCandidates` are the
+ * addresses the indexing poll may accept as the attester — the Privy-resolved
+ * signer first, never wagmi's `useAccount().address` (which lags the signer and
+ * is null often enough to matter).
+ */
+interface MilestoneChainSetup {
+  gapClient: GAP;
+  walletSigner: Signer;
+  attesterCandidates: string[];
 }
+
+/** The multi-attest payload shape, taken from the SDK rather than re-declared. */
+type AttestationPayload = Awaited<ReturnType<MilestoneCompleted["payloadFor"]>>;
 
 /**
  * Hook for handling milestone completion and verification workflow
@@ -66,10 +79,11 @@ export const useMilestoneCompletionVerification = ({
   const [isVerifying, setIsVerifying] = useState(false);
   const [isCompleting, setIsCompleting] = useState(false);
   const { address, chain } = useAccount();
+  const { user } = usePrivyBridge();
   const { switchChainAsync } = useWallet();
   const { startAttestation, showLoading, showSuccess, showError, changeStepperStep, dismiss } =
     useAttestationToast();
-  const { setupChainAndWallet } = useSetupChainAndWallet();
+  const { setupChainAndWallet, smartWalletAddress } = useSetupChainAndWallet();
 
   // AbortController owns the in-flight verification's polling loop (refreshed at
   // every verifyMilestone call, aborted on cleanup) so post-unmount state updates
@@ -82,9 +96,8 @@ export const useMilestoneCompletionVerification = ({
   }, []);
 
   const setupChainAndWalletForMilestone = async (
-    milestone: GrantMilestoneWithCompletion,
-    _data: ProjectGrantMilestonesResponse
-  ): Promise<{ gapClient: GAP; walletSigner: Signer } | null> => {
+    milestone: GrantMilestoneWithCompletion
+  ): Promise<MilestoneChainSetup | null> => {
     const targetChainId = +milestone.chainId;
 
     const setup = await setupChainAndWallet({
@@ -94,60 +107,32 @@ export const useMilestoneCompletionVerification = ({
     });
 
     if (!setup) {
-      setIsVerifying(false);
       dismiss();
       return null;
     }
 
-    return { gapClient: setup.gapClient, walletSigner: setup.walletSigner };
-  };
-
-  const fetchMilestoneInstance = async (
-    gapClient: GAP,
-    data: ProjectGrantMilestonesResponse,
-    milestone: GrantMilestoneWithCompletion
-  ): Promise<{
-    milestoneInstance: MilestoneInstance;
-    communityUID: string;
-  }> => {
-    const fetchedProject = await gapClient.fetch.projectById(data.project.uid);
-    if (!fetchedProject) {
-      throw new Error("Failed to fetch project data");
-    }
-
-    // Normalize programId for comparison (supports both formats)
-    const normalizedInputId = normalizeProgramId(programId);
-    const grantInstance = fetchedProject.grants.find((g) => {
-      const storedId = g.details?.programId;
-      if (!storedId) return false;
-      return normalizeProgramId(storedId) === normalizedInputId;
-    });
-
-    if (!grantInstance) {
-      throw new Error("Grant not found");
-    }
-
-    const milestoneInstance = grantInstance.milestones?.find(
-      (m) => m.uid.toLowerCase() === milestone.uid.toLowerCase()
-    );
-
-    if (!milestoneInstance) {
-      throw new Error("Milestone not found");
-    }
-
-    // Extract communityUID from grant data
-    const communityUID = grantInstance.data?.communityUID || "";
+    // The address that will actually sign. `getAddress()` is authoritative (it
+    // covers the gasless/EIP-7702 signer too); `smartWalletAddress` is the
+    // pre-resolved Privy attestation address and the linked set is the tolerant
+    // fallback for accounts where Privy surfaces a different active wallet.
+    const signerAddress = await setup.walletSigner.getAddress().catch(() => null);
 
     return {
-      milestoneInstance: milestoneInstance as MilestoneInstance,
-      communityUID,
+      gapClient: setup.gapClient,
+      walletSigner: setup.walletSigner,
+      attesterCandidates: buildAttesterCandidates([
+        signerAddress,
+        smartWalletAddress,
+        ...(user ? getLinkedWalletAddresses(user) : []),
+        address,
+      ]),
     };
   };
 
   const buildAttestationPayloads = async (
     gapClient: GAP,
     milestone: GrantMilestoneWithCompletion,
-    milestoneInstance: MilestoneInstance,
+    recipient: Hex,
     options: {
       includeCompletion: boolean;
       completionReason?: string;
@@ -155,7 +140,7 @@ export const useMilestoneCompletionVerification = ({
     }
   ) => {
     const milestoneCompletedSchema = gapClient.findSchema("MilestoneCompleted");
-    const payloads: any[] = [];
+    const payloads: AttestationPayload[] = [];
     let payloadIndex = 0;
 
     // Add completion attestation if requested
@@ -168,7 +153,7 @@ export const useMilestoneCompletionVerification = ({
         }),
         refUID: milestone.uid as Hex,
         schema: milestoneCompletedSchema,
-        recipient: milestoneInstance.recipient,
+        recipient,
       });
       payloads.push(await completionAttestation.payloadFor(payloadIndex));
       payloadIndex++;
@@ -183,7 +168,7 @@ export const useMilestoneCompletionVerification = ({
       }),
       refUID: milestone.uid as Hex,
       schema: milestoneCompletedSchema,
-      recipient: milestoneInstance.recipient,
+      recipient,
     });
     payloads.push(await verificationAttestation.payloadFor(payloadIndex));
 
@@ -193,8 +178,7 @@ export const useMilestoneCompletionVerification = ({
   const notifyIndexerAndInvalidateCache = async (
     txHash: string | undefined,
     chainId: number,
-    attestationCount: number,
-    communityUID: string
+    attestationCount: number
   ) => {
     if (txHash) {
       // Best-effort indexer nudge; it also catches this via its own chain listener,
@@ -226,63 +210,45 @@ export const useMilestoneCompletionVerification = ({
     onCachesInvalidated?.();
   };
 
-  // Re-fetch the milestone from the SDK and locate it within its grant, used by
-  // the post-attestation polls to observe on-chain → indexer state transitions.
-  // Returns null until the project, grant, and milestone are all present.
+  // Re-reads the milestone from the V2 project-updates endpoint. Replaces the
+  // old SDK `projectById` refetch (a V1 `GET /projects/:uid` per poll iteration,
+  // and the crash site of GAP-FRONTEND-261): the V2 payload already carries the
+  // completion, verification and recipient the flow needs.
   const findIndexedMilestone = async (
-    gapClient: GAP,
-    data: ProjectGrantMilestonesResponse,
-    milestone: GrantMilestoneWithCompletion,
-    inputProgramId: string
-  ) => {
-    const normalizedInputId = normalizeProgramId(inputProgramId);
-    const updatedProject = await gapClient.fetch.projectById(data.project.uid);
-
-    if (!updatedProject) return null;
-
-    const updatedGrant = updatedProject.grants.find((g) => {
-      const storedId = g.details?.programId;
-      if (!storedId) return false;
-      return normalizeProgramId(storedId) === normalizedInputId;
-    });
-
-    if (!updatedGrant) return null;
-
-    return updatedGrant.milestones?.find((m) => m.uid === milestone.uid) ?? null;
+    projectUID: string,
+    milestoneUID: string
+  ): Promise<GrantMilestoneWithCompletion | null> => {
+    const milestones = await fetchGrantMilestonesForProgram(projectUID, programId);
+    return milestones.find((m) => m.uid.toLowerCase() === milestoneUID.toLowerCase()) ?? null;
   };
 
   const pollForMilestoneStatus = async (
-    gapClient: GAP,
-    data: ProjectGrantMilestonesResponse,
+    projectUID: string,
     milestone: GrantMilestoneWithCompletion,
     checkCompletion: boolean,
-    userAddress: string,
-    inputProgramId: string,
+    attesterCandidates: string[],
+    previousVerificationUID: string | undefined,
     signal?: AbortSignal
   ) => {
     await retryUntilConditionMet(
       async () => {
-        const updatedMilestone = await findIndexedMilestone(
-          gapClient,
-          data,
-          milestone,
-          inputProgramId
-        );
+        const updatedMilestone = await findIndexedMilestone(projectUID, milestone.uid);
 
         if (!updatedMilestone) return false;
 
-        const isVerified = updatedMilestone.verified?.find(
-          (v) => v.attester?.toLowerCase() === userAddress.toLowerCase()
-        );
+        const isVerified = matchesSubmittedVerification({
+          verificationDetails: updatedMilestone.verificationDetails,
+          candidates: attesterCandidates,
+          previousAttestationUID: previousVerificationUID,
+        });
 
         // If checking completion, ensure both are indexed
         if (checkCompletion) {
-          const isCompleted = updatedMilestone.completed;
-          return !!(isCompleted && isVerified);
+          return !!(updatedMilestone.completionDetails && isVerified);
         }
 
         // Otherwise just check verification
-        return !!isVerified;
+        return isVerified;
       },
       undefined,
       undefined,
@@ -292,22 +258,14 @@ export const useMilestoneCompletionVerification = ({
   };
 
   const pollForCompletionStatus = async (
-    gapClient: GAP,
-    data: ProjectGrantMilestonesResponse,
+    projectUID: string,
     milestone: GrantMilestoneWithCompletion,
-    inputProgramId: string,
     signal?: AbortSignal
   ) => {
     await retryUntilConditionMet(
       async () => {
-        const updatedMilestone = await findIndexedMilestone(
-          gapClient,
-          data,
-          milestone,
-          inputProgramId
-        );
-
-        return !!updatedMilestone?.completed;
+        const updatedMilestone = await findIndexedMilestone(projectUID, milestone.uid);
+        return !!updatedMilestone?.completionDetails;
       },
       undefined,
       undefined,
@@ -319,8 +277,7 @@ export const useMilestoneCompletionVerification = ({
   const completeViaBackend = async (
     milestone: GrantMilestoneWithCompletion,
     completionComment: string,
-    attestationChainId: number,
-    communityUID: string
+    attestationChainId: number
   ): Promise<void> => {
     showLoading("Completing milestone...");
 
@@ -337,7 +294,7 @@ export const useMilestoneCompletionVerification = ({
       );
 
       changeStepperStep("indexing");
-      await notifyIndexerAndInvalidateCache(txHash, attestationChainId, 1, communityUID);
+      await notifyIndexerAndInvalidateCache(txHash, attestationChainId, 1);
       changeStepperStep("indexed");
 
       showSuccess("Milestone completed successfully!");
@@ -348,17 +305,16 @@ export const useMilestoneCompletionVerification = ({
   };
 
   const attestMilestonesOnChain = async (
-    milestoneInstance: MilestoneInstance,
+    recipient: Hex,
     milestone: GrantMilestoneWithCompletion,
-    walletSigner: Signer,
-    gapClient: GAP,
-    data: ProjectGrantMilestonesResponse,
+    setup: MilestoneChainSetup,
+    projectUID: string,
     options: {
       includeCompletion: boolean;
       completionReason?: string;
       verificationComment: string;
     },
-    communityUID: string,
+    reportStep: (step: MilestoneFlowStep) => void,
     signal?: AbortSignal
   ): Promise<boolean> => {
     const isVerificationOnly = !options.includeCompletion;
@@ -371,38 +327,35 @@ export const useMilestoneCompletionVerification = ({
       changeStepperStep("preparing");
 
       const payloads = await buildAttestationPayloads(
-        gapClient,
+        setup.gapClient,
         milestone,
-        milestoneInstance,
+        recipient,
         options
       );
 
+      // Captured before signing so the poll can tell a NEW verification apart
+      // from one this milestone already carried.
+      const previousVerificationUID = milestone.verificationDetails?.attestationUID;
+
       changeStepperStep("pending");
 
-      const result = await GapContract.multiAttest(walletSigner, payloads, changeStepperStep);
+      const result = await GapContract.multiAttest(setup.walletSigner, payloads, changeStepperStep);
 
       changeStepperStep("indexing");
 
       const txHash = result?.tx[0]?.hash || undefined;
-      await notifyIndexerAndInvalidateCache(
-        txHash,
-        milestoneInstance.chainID,
-        payloads.length,
-        communityUID
-      );
+      await notifyIndexerAndInvalidateCache(txHash, +milestone.chainId, payloads.length);
 
-      // Poll for milestone status
-      if (!address) {
-        throw new Error("User address not available");
-      }
-
+      // Nothing past this point may depend on wagmi's `useAccount().address`:
+      // it can be null while the Privy signer works fine, which previously threw
+      // "User address not available" AFTER a successful transaction (#67).
+      reportStep("poll");
       await pollForMilestoneStatus(
-        gapClient,
-        data,
+        projectUID,
         milestone,
         options.includeCompletion,
-        address,
-        programId,
+        setup.attesterCandidates,
+        previousVerificationUID,
         signal
       );
 
@@ -420,7 +373,7 @@ export const useMilestoneCompletionVerification = ({
       );
 
       return true;
-    } catch (error: any) {
+    } catch (error: unknown) {
       if (isAbortError(error)) {
         // Silent — caller's finally already dismisses the toast.
         return false;
@@ -428,6 +381,49 @@ export const useMilestoneCompletionVerification = ({
       dismiss();
       throw error;
     }
+  };
+
+  /**
+   * Single exit point for a failed verify/complete run. Maps the error onto a
+   * concrete user-facing cause and enriches the Sentry context with the project,
+   * chain, program and the step the flow died on — the generic
+   * "Failed to verify milestone" toast plus `{milestoneUID, address}` told
+   * neither the user nor us anything (#64).
+   */
+  const reportMilestoneFailure = (
+    error: unknown,
+    action: MilestoneAction,
+    step: MilestoneFlowStep,
+    milestone: GrantMilestoneWithCompletion,
+    projectUID: string | undefined
+  ) => {
+    if (isUserRejectionError(error)) {
+      showError(action === "verify" ? "Verification cancelled" : "Completion cancelled");
+      return;
+    }
+
+    const failure = describeMilestoneFailure(error, action);
+    showError(failure.message);
+
+    if (failure.expected) {
+      // Wallet not ready / indexer still catching up: guidance, not a defect.
+      // errorManager would drop these anyway; skip it rather than pretend.
+      return;
+    }
+
+    errorManager(
+      action === "verify" ? "Error verifying milestone" : "Error completing milestone",
+      error,
+      {
+        milestoneUID: milestone.uid,
+        projectUid: projectUID,
+        chainId: milestone.chainId,
+        programId,
+        step,
+        failureKind: failure.kind,
+        address,
+      }
+    );
   };
 
   const verifyMilestone = async (
@@ -449,6 +445,7 @@ export const useMilestoneCompletionVerification = ({
 
     // Use chainId from milestone (where attestation will occur)
     const attestationChainId = milestone.chainId;
+    const projectUID = data.project.uid;
 
     // Abort any prior in-flight verification and start a fresh controller.
     controllerRef.current?.abort();
@@ -459,27 +456,22 @@ export const useMilestoneCompletionVerification = ({
     setIsVerifying(true);
     startAttestation("Verifying milestone...");
 
+    let step: MilestoneFlowStep = "fetch";
+
     try {
       changeStepperStep("preparing");
 
-      // Step 1: Setup chain and wallet
-      const chainSetup = await setupChainAndWalletForMilestone(milestone, data);
+      // Step 1: the on-chain recipient is part of the attested payload, so it is
+      // resolved (and validated) BEFORE any wallet interaction — a legacy row
+      // without one must never reach a transaction.
+      const recipient = requireMilestoneRecipient(milestone);
+
+      // Step 2: Setup chain and wallet
+      step = "setup";
+      const chainSetup = await setupChainAndWalletForMilestone(milestone);
       if (!chainSetup) return;
 
-      const { gapClient, walletSigner } = chainSetup;
-
-      // Step 2: Fetch milestone instance and communityUID
-      let { milestoneInstance, communityUID } = await fetchMilestoneInstance(
-        gapClient,
-        data,
-        milestone
-      );
-
-      const alreadyCompleted =
-        typeof milestoneInstance.completed === "boolean"
-          ? milestoneInstance.completed
-          : !!milestoneInstance.completed;
-
+      const alreadyCompleted = !!milestone.completionDetails;
       const completionReason = milestone.fundingApplicationCompletion?.completionText;
 
       let includeCompletion = !alreadyCompleted;
@@ -488,33 +480,26 @@ export const useMilestoneCompletionVerification = ({
       if (isMilestoneReviewer && !alreadyCompleted) {
         // Reviewer flow: Complete via backend, then verify on-chain (verification only)
         // Pass full programId (composite format) and attestation chainId to backend
-        await completeViaBackend(
-          milestone,
-          completionReason ?? "",
-          attestationChainId,
-          communityUID
-        );
-
-        // Re-fetch milestone to get updated completion status
-        const refetchedData = await fetchMilestoneInstance(gapClient, data, milestone);
-        milestoneInstance = refetchedData.milestoneInstance;
-        communityUID = refetchedData.communityUID;
+        step = "backend";
+        await completeViaBackend(milestone, completionReason ?? "", attestationChainId);
 
         includeCompletion = false;
       }
 
+      step = "attest";
       const onChainConfirmed = await attestMilestonesOnChain(
-        milestoneInstance,
+        recipient,
         milestone,
-        walletSigner,
-        gapClient,
-        data,
+        chainSetup,
+        projectUID,
         {
           includeCompletion,
           completionReason,
           verificationComment,
         },
-        communityUID,
+        (nextStep) => {
+          step = nextStep;
+        },
         signal
       );
 
@@ -530,23 +515,12 @@ export const useMilestoneCompletionVerification = ({
 
       // Success callback - backend will sync to off-chain database automatically
       onSuccess?.();
-    } catch (error: any) {
+    } catch (error: unknown) {
       if (isAbortError(error)) {
         // Silent — component unmounted during the flow.
         return;
       }
-      console.error("Error verifying milestone:", error);
-
-      // Check if user cancelled
-      if (error?.message?.includes("User rejected") || error?.code === 4001) {
-        showError("Verification cancelled");
-      } else {
-        showError("Failed to verify milestone");
-        errorManager("Error verifying milestone", error, {
-          milestoneUID: milestone.uid,
-          address,
-        });
-      }
+      reportMilestoneFailure(error, "verify", step, milestone, projectUID);
     } finally {
       if (!signal.aborted) {
         setIsVerifying(false);
@@ -576,6 +550,8 @@ export const useMilestoneCompletionVerification = ({
       return;
     }
 
+    const projectUID = data.project.uid;
+
     controllerRef.current?.abort();
     const controller = new AbortController();
     controllerRef.current = controller;
@@ -584,20 +560,20 @@ export const useMilestoneCompletionVerification = ({
     setIsCompleting(true);
     startAttestation("Completing milestone...");
 
+    let step: MilestoneFlowStep = "fetch";
+
     try {
       changeStepperStep("preparing");
 
-      const chainSetup = await setupChainAndWalletForMilestone(milestone, data);
+      const recipient = requireMilestoneRecipient(milestone);
+
+      step = "setup";
+      const chainSetup = await setupChainAndWalletForMilestone(milestone);
       if (!chainSetup) return;
 
       const { gapClient, walletSigner } = chainSetup;
 
-      const { milestoneInstance, communityUID } = await fetchMilestoneInstance(
-        gapClient,
-        data,
-        milestone
-      );
-
+      step = "attest";
       const milestoneCompletedSchema = gapClient.findSchema("MilestoneCompleted");
       const completionAttestation = new MilestoneCompleted({
         data: sanitizeObject({
@@ -607,7 +583,7 @@ export const useMilestoneCompletionVerification = ({
         }),
         refUID: milestone.uid as Hex,
         schema: milestoneCompletedSchema,
-        recipient: milestoneInstance.recipient,
+        recipient,
       });
       const payloads = [await completionAttestation.payloadFor(0)];
 
@@ -618,14 +594,10 @@ export const useMilestoneCompletionVerification = ({
       changeStepperStep("indexing");
 
       const txHash = result?.tx[0]?.hash || undefined;
-      await notifyIndexerAndInvalidateCache(
-        txHash,
-        milestoneInstance.chainID,
-        payloads.length,
-        communityUID
-      );
+      await notifyIndexerAndInvalidateCache(txHash, +milestone.chainId, payloads.length);
 
-      await pollForCompletionStatus(gapClient, data, milestone, programId, signal);
+      step = "poll";
+      await pollForCompletionStatus(projectUID, milestone, signal);
 
       if (signal.aborted) return;
 
@@ -637,18 +609,7 @@ export const useMilestoneCompletionVerification = ({
       if (isAbortError(error)) {
         return;
       }
-      console.error("Error completing milestone:", error);
-
-      const walletError = error as { message?: string; code?: number };
-      if (walletError?.message?.includes("User rejected") || walletError?.code === 4001) {
-        showError("Completion cancelled");
-      } else {
-        showError("Failed to complete milestone");
-        errorManager("Error completing milestone", error, {
-          milestoneUID: milestone.uid,
-          address,
-        });
-      }
+      reportMilestoneFailure(error, "complete", step, milestone, projectUID);
     } finally {
       if (!signal.aborted) {
         setIsCompleting(false);

--- a/hooks/useMilestoneCompletionVerification.ts
+++ b/hooks/useMilestoneCompletionVerification.ts
@@ -27,6 +27,7 @@ import {
 } from "@/utilities/milestones/attestationFailure";
 import {
   buildAttesterCandidates,
+  getMultiAttesterAddress,
   matchesSubmittedVerification,
   requireMilestoneRecipient,
 } from "@/utilities/milestones/attestationIdentity";
@@ -179,10 +180,17 @@ export const useMilestoneCompletionVerification = ({
       // wagmi's address is deliberately NOT a candidate: it can be an unlinked
       // wallet left connected from a previous session, and accepting it would
       // widen the match beyond this identity.
+      //
+      // The chain's MultiAttester IS a candidate, and in practice the one that
+      // actually lands: `GapContract.multiAttest` submits through it, so EAS
+      // sees the contract as `msg.sender` and the indexer stores it — not the
+      // signer — as `verifiedBy`. Without it every verification polls until it
+      // times out on a transaction that already succeeded.
       attesterCandidates: buildAttesterCandidates([
         signerAddress,
         smartWalletAddress,
         ...(user ? getLinkedWalletAddresses(user) : []),
+        getMultiAttesterAddress(targetChainId),
       ]),
     };
   };

--- a/hooks/useMilestoneCompletionVerification.ts
+++ b/hooks/useMilestoneCompletionVerification.ts
@@ -1,3 +1,4 @@
+import * as Sentry from "@sentry/nextjs";
 import type { GAP } from "@show-karma/karma-gap-sdk";
 import { GapContract } from "@show-karma/karma-gap-sdk/core/class/contract/GapContract";
 import { MilestoneCompleted } from "@show-karma/karma-gap-sdk/core/class/types/attestations";
@@ -17,6 +18,7 @@ import {
   type ProjectGrantMilestonesResponse,
 } from "@/services/milestones";
 import { api } from "@/utilities/api/client";
+import { isApiError } from "@/utilities/api/errors";
 import { getLinkedWalletAddresses } from "@/utilities/auth/compare-all-wallets";
 import { INDEXER } from "@/utilities/indexer";
 import {
@@ -120,11 +122,13 @@ export const useMilestoneCompletionVerification = ({
     return {
       gapClient: setup.gapClient,
       walletSigner: setup.walletSigner,
+      // wagmi's address is deliberately NOT a candidate: it can be an unlinked
+      // wallet left connected from a previous session, and accepting it would
+      // widen the match beyond this identity.
       attesterCandidates: buildAttesterCandidates([
         signerAddress,
         smartWalletAddress,
         ...(user ? getLinkedWalletAddresses(user) : []),
-        address,
       ]),
     };
   };
@@ -397,7 +401,10 @@ export const useMilestoneCompletionVerification = ({
     milestone: GrantMilestoneWithCompletion,
     projectUID: string | undefined
   ) => {
-    if (isUserRejectionError(error)) {
+    // `isUserRejectionError` is a substring match, and an ApiError's message
+    // embeds the endpoint path — so an API failure must never be mistaken for a
+    // wallet rejection just because its route happens to contain "reject".
+    if (!isApiError(error) && isUserRejectionError(error)) {
       showError(action === "verify" ? "Verification cancelled" : "Completion cancelled");
       return;
     }
@@ -407,7 +414,14 @@ export const useMilestoneCompletionVerification = ({
 
     if (failure.expected) {
       // Wallet not ready / indexer still catching up: guidance, not a defect.
-      // errorManager would drop these anyway; skip it rather than pretend.
+      // Capturing it would be noise, but staying entirely silent is how this
+      // flow lost its telemetry in the first place — leave a breadcrumb.
+      Sentry.addBreadcrumb({
+        category: "milestone-attestation",
+        level: "warning",
+        message: `${action} milestone stopped at ${step}: ${failure.kind}`,
+        data: { milestoneUID: milestone.uid, projectUid: projectUID, programId, step },
+      });
       return;
     }
 

--- a/hooks/useMilestoneCompletionVerification.ts
+++ b/hooks/useMilestoneCompletionVerification.ts
@@ -17,10 +17,9 @@ import {
   type GrantMilestoneWithCompletion,
   type ProjectGrantMilestonesResponse,
 } from "@/services/milestones";
-import { api } from "@/utilities/api/client";
 import { isApiError } from "@/utilities/api/errors";
 import { getLinkedWalletAddresses } from "@/utilities/auth/compare-all-wallets";
-import { INDEXER } from "@/utilities/indexer";
+import { notifyIndexer } from "@/utilities/indexer-notification";
 import {
   describeMilestoneFailure,
   type MilestoneAction,
@@ -68,6 +67,61 @@ interface MilestoneChainSetup {
 
 /** The multi-attest payload shape, taken from the SDK rather than re-declared. */
 type AttestationPayload = Awaited<ReturnType<MilestoneCompleted["payloadFor"]>>;
+
+interface AttestationOptions {
+  includeCompletion: boolean;
+  completionReason?: string;
+  verificationComment: string;
+}
+
+/**
+ * Builds the completion/verification attestation payloads.
+ *
+ * Module scope, not a closure: it reads nothing from the hook, so rebuilding it
+ * every render would be wasted work. `recipient` is passed in already validated
+ * — this function must never source it itself.
+ */
+const buildAttestationPayloads = async (
+  gapClient: GAP,
+  milestone: GrantMilestoneWithCompletion,
+  recipient: Hex,
+  options: AttestationOptions
+): Promise<AttestationPayload[]> => {
+  const milestoneCompletedSchema = gapClient.findSchema("MilestoneCompleted");
+  const payloads: AttestationPayload[] = [];
+  let payloadIndex = 0;
+
+  // Add completion attestation if requested
+  if (options.includeCompletion) {
+    const completionAttestation = new MilestoneCompleted({
+      data: sanitizeObject({
+        reason: options.completionReason || "",
+        proofOfWork: "",
+        type: "completed",
+      }),
+      refUID: milestone.uid as Hex,
+      schema: milestoneCompletedSchema,
+      recipient,
+    });
+    payloads.push(await completionAttestation.payloadFor(payloadIndex));
+    payloadIndex++;
+  }
+
+  // Always add verification attestation
+  const verificationAttestation = new MilestoneCompleted({
+    data: sanitizeObject({
+      reason: options.verificationComment || "",
+      proofOfWork: "",
+      type: "verified",
+    }),
+    refUID: milestone.uid as Hex,
+    schema: milestoneCompletedSchema,
+    recipient,
+  });
+  payloads.push(await verificationAttestation.payloadFor(payloadIndex));
+
+  return payloads;
+};
 
 /**
  * Hook for handling milestone completion and verification workflow
@@ -133,65 +187,20 @@ export const useMilestoneCompletionVerification = ({
     };
   };
 
-  const buildAttestationPayloads = async (
-    gapClient: GAP,
-    milestone: GrantMilestoneWithCompletion,
-    recipient: Hex,
-    options: {
-      includeCompletion: boolean;
-      completionReason?: string;
-      verificationComment: string;
-    }
-  ) => {
-    const milestoneCompletedSchema = gapClient.findSchema("MilestoneCompleted");
-    const payloads: AttestationPayload[] = [];
-    let payloadIndex = 0;
-
-    // Add completion attestation if requested
-    if (options.includeCompletion) {
-      const completionAttestation = new MilestoneCompleted({
-        data: sanitizeObject({
-          reason: options.completionReason || "",
-          proofOfWork: "",
-          type: "completed",
-        }),
-        refUID: milestone.uid as Hex,
-        schema: milestoneCompletedSchema,
-        recipient,
-      });
-      payloads.push(await completionAttestation.payloadFor(payloadIndex));
-      payloadIndex++;
-    }
-
-    // Always add verification attestation
-    const verificationAttestation = new MilestoneCompleted({
-      data: sanitizeObject({
-        reason: options.verificationComment || "",
-        proofOfWork: "",
-        type: "verified",
-      }),
-      refUID: milestone.uid as Hex,
-      schema: milestoneCompletedSchema,
-      recipient,
-    });
-    payloads.push(await verificationAttestation.payloadFor(payloadIndex));
-
-    return payloads;
-  };
-
   const notifyIndexerAndInvalidateCache = async (
     txHash: string | undefined,
     chainId: number,
     attestationCount: number
   ) => {
-    if (txHash) {
-      // Best-effort indexer nudge; it also catches this via its own chain listener,
-      // so a failure must not abort the flow. Legacy fetchData discarded the error.
-      await api.post(INDEXER.ATTESTATION_LISTENER(txHash, chainId), {}).catch(() => undefined);
-      // If multiple attestations, wait for the indexer to process all of them.
-      if (attestationCount > 1) {
-        await new Promise((resolve) => setTimeout(resolve, INDEXER_PROCESSING_DELAY_MS));
-      }
+    // Best-effort nudge — the indexer's own chain listener picks the tx up
+    // regardless, so a failure must not abort a flow whose tx already landed.
+    // `notifyIndexer` REPORTS that failure; the inline swallow it replaced left
+    // a failed nudge completely invisible.
+    await notifyIndexer({ txHash, chainId });
+
+    // If multiple attestations, wait for the indexer to process all of them.
+    if (txHash && attestationCount > 1) {
+      await new Promise((resolve) => setTimeout(resolve, INDEXER_PROCESSING_DELAY_MS));
     }
 
     await queryClient.invalidateQueries({

--- a/hooks/useZeroDevSigner.ts
+++ b/hooks/useZeroDevSigner.ts
@@ -35,8 +35,8 @@ import { wait } from "@/utilities/wait";
 import { SignerUnavailableError } from "@/utilities/wallet/signerReadiness";
 import {
   selectUsableWallet,
-  type WalletStateSnapshot,
   waitForUsableWallet,
+  type WalletStateSnapshot,
 } from "@/utilities/wallet/waitForUsableWallet";
 import { safeGetWalletClient } from "@/utilities/wallet-helpers";
 

--- a/hooks/useZeroDevSigner.ts
+++ b/hooks/useZeroDevSigner.ts
@@ -35,8 +35,8 @@ import { wait } from "@/utilities/wait";
 import { SignerUnavailableError } from "@/utilities/wallet/signerReadiness";
 import {
   selectUsableWallet,
-  waitForUsableWallet,
   type WalletStateSnapshot,
+  waitForUsableWallet,
 } from "@/utilities/wallet/waitForUsableWallet";
 import { safeGetWalletClient } from "@/utilities/wallet-helpers";
 

--- a/services/milestones.ts
+++ b/services/milestones.ts
@@ -162,6 +162,15 @@ async function fetchGrantByProgramId(
   }
 }
 
+/**
+ * The single grant-milestones endpoint. Shared by the full read and the
+ * poll-friendly read so the two can never drift apart on query params.
+ */
+function grantMilestonesEndpoint(projectUid: string, programId: string): string {
+  const normalizedProgramId = stripChainSuffix(programId) ?? programId;
+  return `${INDEXER.V2.PROJECTS.UPDATES(projectUid)}?programIds=${normalizedProgramId}&includeFundingApplicationData=true`;
+}
+
 function mapGrantMilestones(
   updatesResponse: ProjectUpdatesResponse
 ): GrantMilestoneWithCompletion[] {
@@ -195,10 +204,9 @@ export async function fetchGrantMilestonesForProgram(
   projectUid: string,
   programId: string
 ): Promise<GrantMilestoneWithCompletion[]> {
-  const normalizedProgramId = stripChainSuffix(programId) ?? programId;
   // TODO(#1775): add zod schema
   const updatesResponse = await api.get<ProjectUpdatesResponse>(
-    `${INDEXER.V2.PROJECTS.UPDATES(projectUid)}?programIds=${normalizedProgramId}&includeFundingApplicationData=true`
+    grantMilestonesEndpoint(projectUid, programId)
   );
 
   return mapGrantMilestones(updatesResponse);
@@ -220,9 +228,7 @@ export async function fetchProjectGrantMilestones(
       }),
     // TODO(#1775): add zod schema
     api
-      .get<ProjectUpdatesResponse>(
-        `${INDEXER.V2.PROJECTS.UPDATES(projectUid)}?programIds=${normalizedProgramId}&includeFundingApplicationData=true`
-      )
+      .get<ProjectUpdatesResponse>(grantMilestonesEndpoint(projectUid, normalizedProgramId))
       .catch((error: unknown) => {
         const message = error instanceof Error ? error.message : String(error);
         throw new Error(`Failed to fetch milestones: ${message}`);

--- a/services/milestones.ts
+++ b/services/milestones.ts
@@ -157,6 +157,9 @@ async function fetchGrantByProgramId(
     const normalizedTarget = stripChainSuffix(programId);
     return grants.find((g) => stripChainSuffix(g.details?.programId) === normalizedTarget);
   } catch (error) {
+    // Reported, not swallowed: errorManager owns the Sentry capture. The grant
+    // is supplementary to the milestones, so a failure here degrades the
+    // response rather than failing the whole read.
     errorManager("Error fetching grant", error, { projectUid, programId });
     return undefined;
   }

--- a/services/milestones.ts
+++ b/services/milestones.ts
@@ -65,6 +65,14 @@ export interface GrantMilestoneWithCompletion {
   startsAt?: number;
   priority?: number;
   status: string;
+  /**
+   * On-chain recipient of the milestone attestation, resolved by the indexer
+   * from the attestation record. This is the value every follow-up attestation
+   * (completion / verification / cancellation) must reuse verbatim — it is the
+   * reason the flows no longer re-fetch the whole project through the SDK.
+   * Optional because legacy rows predate the indexer's recipient backfill.
+   */
+  recipient?: string;
   completionDetails: GrantMilestoneCompletionDetails | null;
   verificationDetails: GrantMilestoneVerificationDetails | null;
   fundingApplicationCompletion: MilestoneCompletionData | null;
@@ -154,6 +162,48 @@ async function fetchGrantByProgramId(
   }
 }
 
+function mapGrantMilestones(
+  updatesResponse: ProjectUpdatesResponse
+): GrantMilestoneWithCompletion[] {
+  return updatesResponse.grantMilestones.map((milestone) => ({
+    uid: milestone.uid,
+    programId: milestone.programId,
+    chainId: milestone.chainId,
+    title: milestone.title,
+    description: milestone.description,
+    dueDate: milestone.dueDate,
+    startsAt: milestone.startsAt,
+    priority: milestone.priority,
+    status: milestone.status,
+    recipient: milestone.recipient,
+    completionDetails: milestone.completionDetails,
+    verificationDetails: milestone.verificationDetails,
+    fundingApplicationCompletion: milestone.fundingApplicationCompletion || null,
+    cancellation: milestone.cancellation ?? null,
+  }));
+}
+
+/**
+ * Fetches ONLY the grant milestones for a program — a single V2 request, unlike
+ * `fetchProjectGrantMilestones` which also resolves the project and grant.
+ *
+ * Used by the attestation flows' indexing polls: they re-read one milestone
+ * every ~1.5s, so the extra project/grant round-trips (and, previously, an
+ * SDK-driven V1 `GET /projects/:uid`) were pure overhead and a crash site.
+ */
+export async function fetchGrantMilestonesForProgram(
+  projectUid: string,
+  programId: string
+): Promise<GrantMilestoneWithCompletion[]> {
+  const normalizedProgramId = stripChainSuffix(programId) ?? programId;
+  // TODO(#1775): add zod schema
+  const updatesResponse = await api.get<ProjectUpdatesResponse>(
+    `${INDEXER.V2.PROJECTS.UPDATES(projectUid)}?programIds=${normalizedProgramId}&includeFundingApplicationData=true`
+  );
+
+  return mapGrantMilestones(updatesResponse);
+}
+
 export async function fetchProjectGrantMilestones(
   projectUid: string,
   programId: string
@@ -180,23 +230,7 @@ export async function fetchProjectGrantMilestones(
     fetchGrantByProgramId(projectUid, normalizedProgramId),
   ]);
 
-  const grantMilestones: GrantMilestoneWithCompletion[] = updatesResponse.grantMilestones.map(
-    (milestone) => ({
-      uid: milestone.uid,
-      programId: milestone.programId,
-      chainId: milestone.chainId,
-      title: milestone.title,
-      description: milestone.description,
-      dueDate: milestone.dueDate,
-      startsAt: milestone.startsAt,
-      priority: milestone.priority,
-      status: milestone.status,
-      completionDetails: milestone.completionDetails,
-      verificationDetails: milestone.verificationDetails,
-      fundingApplicationCompletion: milestone.fundingApplicationCompletion || null,
-      cancellation: milestone.cancellation ?? null,
-    })
-  );
+  const grantMilestones = mapGrantMilestones(updatesResponse);
 
   return {
     project,

--- a/utilities/milestones/attestationFailure.ts
+++ b/utilities/milestones/attestationFailure.ts
@@ -121,6 +121,14 @@ export const describeMilestoneFailure = (
     };
   }
 
+  if (isApiError(error) && error.kind === "contract") {
+    return {
+      kind: "server",
+      message: `${label}: the server returned an unexpected response.`,
+      expected: false,
+    };
+  }
+
   if (isTransientNetworkError(error) || isTransientHttpError(error) || isApiError(error)) {
     return {
       kind: "network",

--- a/utilities/milestones/attestationFailure.ts
+++ b/utilities/milestones/attestationFailure.ts
@@ -1,0 +1,145 @@
+import { HttpError, isApiError } from "@/utilities/api/errors";
+import { isMissingMilestoneRecipientError } from "@/utilities/milestones/attestationIdentity";
+import { isRetryConditionNotMetError } from "@/utilities/retries";
+import { isTransientHttpError, isTransientNetworkError } from "@/utilities/sentry/transientErrors";
+import { isSignerUnavailableError } from "@/utilities/wallet/signerReadiness";
+
+/**
+ * Where in the milestone attestation flow a failure happened. Attached to the
+ * Sentry context so an incident can be located without guessing which of the
+ * ~10 failure classes collapsed into the toast.
+ */
+export type MilestoneFlowStep = "setup" | "fetch" | "backend" | "attest" | "poll";
+
+export type MilestoneFailureKind =
+  | "signer-unavailable"
+  | "network-switch"
+  | "missing-recipient"
+  | "indexing-timeout"
+  | "insufficient-funds"
+  | "wallet-rpc"
+  | "network"
+  | "server"
+  | "unknown";
+
+export interface MilestoneFailureDescription {
+  kind: MilestoneFailureKind;
+  /** Full user-facing toast text, naming the cause rather than just the action. */
+  message: string;
+  /**
+   * Expected user/lifecycle state (wallet not ready, indexer lag). Guidance,
+   * not a defect — callers must skip Sentry reporting for these.
+   */
+  expected: boolean;
+}
+
+export type MilestoneAction = "verify" | "complete";
+
+const ACTION_LABEL: Record<MilestoneAction, string> = {
+  verify: "Failed to verify milestone",
+  complete: "Failed to complete milestone",
+};
+
+const errorText = (error: unknown): string => {
+  const candidate = error as
+    | { message?: unknown; code?: unknown; originalError?: { message?: unknown; code?: unknown } }
+    | null
+    | undefined;
+  return [
+    candidate?.message,
+    candidate?.code,
+    candidate?.originalError?.message,
+    candidate?.originalError?.code,
+  ]
+    .map((value) => (value == null ? "" : String(value)))
+    .join(" ")
+    .toLowerCase();
+};
+
+const isNetworkSwitchFailure = (text: string): boolean =>
+  text.includes("switch chain") ||
+  text.includes("network changed") ||
+  text.includes("switch to the required network") ||
+  text.includes("still on chain");
+
+/**
+ * Maps a milestone attestation failure onto a concise, user-appropriate cause.
+ *
+ * Every branch here used to collapse into a bare "Failed to verify milestone",
+ * which told the user nothing and told us nothing either. User rejections are
+ * NOT handled here — callers detect them with `isUserRejectionError` and show
+ * their own "cancelled" copy.
+ */
+export const describeMilestoneFailure = (
+  error: unknown,
+  action: MilestoneAction
+): MilestoneFailureDescription => {
+  const label = ACTION_LABEL[action];
+
+  if (isSignerUnavailableError(error)) {
+    return { kind: "signer-unavailable", message: error.message, expected: true };
+  }
+
+  if (isMissingMilestoneRecipientError(error)) {
+    return { kind: "missing-recipient", message: error.message, expected: false };
+  }
+
+  if (isRetryConditionNotMetError(error)) {
+    return {
+      kind: "indexing-timeout",
+      message:
+        action === "verify"
+          ? "Your verification was submitted on-chain and is still being indexed. It will appear shortly — no need to verify again."
+          : "Your completion was submitted on-chain and is still being indexed. It will appear shortly — no need to complete again.",
+      expected: true,
+    };
+  }
+
+  const text = errorText(error);
+
+  if (isNetworkSwitchFailure(text)) {
+    return {
+      kind: "network-switch",
+      message: `${label}: couldn't switch your wallet to the required network.`,
+      expected: false,
+    };
+  }
+
+  if (text.includes("insufficient funds")) {
+    return {
+      kind: "insufficient-funds",
+      message: `${label}: your wallet doesn't have enough funds to cover gas.`,
+      expected: false,
+    };
+  }
+
+  if (error instanceof HttpError) {
+    return {
+      kind: "server",
+      message: `${label}: the server rejected the request (HTTP ${error.status}).`,
+      expected: false,
+    };
+  }
+
+  if (isTransientNetworkError(error) || isTransientHttpError(error) || isApiError(error)) {
+    return {
+      kind: "network",
+      message: `${label}: a network request failed. Check your connection and try again.`,
+      expected: false,
+    };
+  }
+
+  if (text.includes("rpc error") || text.includes("could not coalesce")) {
+    return {
+      kind: "wallet-rpc",
+      message: `${label}: your wallet's network didn't respond. Try again shortly.`,
+      expected: false,
+    };
+  }
+
+  return {
+    kind: "unknown",
+    message: `${label}: an unexpected error occurred.`,
+    expected: false,
+  };
+};

--- a/utilities/milestones/attestationIdentity.ts
+++ b/utilities/milestones/attestationIdentity.ts
@@ -1,3 +1,5 @@
+import type { TNetwork } from "@show-karma/karma-gap-sdk";
+import { chainIdToNetwork, Networks } from "@show-karma/karma-gap-sdk/core/consts";
 import type { GrantMilestoneWithCompletion } from "@/services/milestones";
 
 const EVM_ADDRESS_PATTERN = /^0x[a-fA-F0-9]{40}$/;
@@ -50,6 +52,29 @@ export const requireMilestoneRecipient = (
 };
 
 /**
+ * The MultiAttester ("multicall") contract for a chain, lower-cased, or null
+ * for a chain the SDK does not support.
+ *
+ * `GapContract.multiAttest` — the flow's only live attestation path, since the
+ * app sets no gelatoOpts and the EAS-direct path was removed — routes through
+ * `GAP.getMulticall(signer).multiSequentialAttest`. That contract is therefore
+ * `msg.sender` at EAS, so the indexer records IT as `verifiedBy`, never the
+ * user's wallet. Resolved from the SDK per chain rather than hardcoded so a new
+ * network needs no change here.
+ */
+export const getMultiAttesterAddress = (
+  chainId: number | string | null | undefined
+): string | null => {
+  const id = typeof chainId === "string" ? Number(chainId) : chainId;
+  if (typeof id !== "number" || !Number.isFinite(id)) return null;
+
+  const network = chainIdToNetwork[id as keyof typeof chainIdToNetwork] as TNetwork | undefined;
+  const multicall = network ? Networks[network]?.contracts?.multicall : undefined;
+
+  return isEvmAddress(multicall) ? multicall.toLowerCase() : null;
+};
+
+/**
  * Builds the lower-cased set of addresses that may legitimately appear as the
  * attester of an attestation this session just submitted.
  *
@@ -86,9 +111,13 @@ interface VerificationMatchInput {
  * True once the indexer shows a verification that this session plausibly
  * created.
  *
- * Strict path: the indexed attester matches one of our candidate addresses.
- * Tolerant path: the indexer has not resolved an attester yet, but the
- * verification attestation is a different one from what we saw before signing.
+ * Strict path: the indexed attester matches one of our candidate addresses
+ * (the signer, its linked wallets, or the chain's MultiAttester contract).
+ * Tolerant path: the attester is unresolved OR unrecognised, but the
+ * verification attestation is a different one from what we saw before signing
+ * — a UID that changed under a transaction we just sent is ours regardless of
+ * who the indexer attributes it to. The snapshot guard keeps a pre-existing
+ * verification (unchanged UID) from ever satisfying this branch.
  */
 export const matchesSubmittedVerification = ({
   verificationDetails,
@@ -98,9 +127,7 @@ export const matchesSubmittedVerification = ({
   if (!verificationDetails) return false;
 
   const verifiedBy = verificationDetails.verifiedBy?.toLowerCase();
-  if (verifiedBy) {
-    return candidates.includes(verifiedBy);
-  }
+  if (verifiedBy && candidates.includes(verifiedBy)) return true;
 
   const attestationUID = verificationDetails.attestationUID;
   return !!attestationUID && attestationUID !== previousAttestationUID;

--- a/utilities/milestones/attestationIdentity.ts
+++ b/utilities/milestones/attestationIdentity.ts
@@ -1,0 +1,107 @@
+import type { GrantMilestoneWithCompletion } from "@/services/milestones";
+
+const EVM_ADDRESS_PATTERN = /^0x[a-fA-F0-9]{40}$/;
+
+/**
+ * Structural check for an EVM address. Deliberately NOT viem's `isAddress`,
+ * which validates the EIP-55 checksum by default and therefore rejects the
+ * all-lowercase addresses the indexer stores.
+ */
+export const isEvmAddress = (value: string | null | undefined): value is `0x${string}` =>
+  !!value && EVM_ADDRESS_PATTERN.test(value);
+
+/**
+ * Thrown before any transaction when the milestone the user is acting on has
+ * no indexed on-chain recipient.
+ *
+ * The recipient is part of the attested payload, so it can never be guessed
+ * from the project owner or payout address — substituting one would change the
+ * attested value. Legacy rows predating the indexer's recipient backfill are
+ * the only realistic source, and the correct answer is to stop, not to attest
+ * something different.
+ */
+export class MissingMilestoneRecipientError extends Error {
+  readonly name = "MissingMilestoneRecipientError";
+  constructor(public readonly milestoneUID: string) {
+    super(
+      "This milestone is missing its on-chain recipient, so it can't be attested. Please refresh; if it persists, contact support."
+    );
+  }
+}
+
+export const isMissingMilestoneRecipientError = (
+  error: unknown
+): error is MissingMilestoneRecipientError =>
+  !!error &&
+  typeof error === "object" &&
+  (error as { name?: unknown }).name === "MissingMilestoneRecipientError";
+
+/**
+ * Reads the milestone's on-chain recipient from V2 data, or throws before any
+ * wallet interaction. Callers must run this BEFORE submitting a transaction.
+ */
+export const requireMilestoneRecipient = (
+  milestone: Pick<GrantMilestoneWithCompletion, "uid" | "recipient">
+): `0x${string}` => {
+  if (!isEvmAddress(milestone.recipient)) {
+    throw new MissingMilestoneRecipientError(milestone.uid);
+  }
+  return milestone.recipient;
+};
+
+/**
+ * Builds the lower-cased set of addresses that may legitimately appear as the
+ * attester of an attestation this session just submitted.
+ *
+ * The signer is Privy-resolved (embedded wallet preferred), while wagmi's
+ * `useAccount().address` tracks the first *linked connected* wallet — for a
+ * hybrid account (email login + a linked external wallet connected) the two are
+ * deterministically different. Matching the poll on wagmi's address therefore
+ * never succeeds and turns an on-chain success into a five-minute wait followed
+ * by a false failure. Including every linked address keeps the match tolerant of
+ * Privy surfacing a different wallet as active mid-flight.
+ */
+export const buildAttesterCandidates = (addresses: Array<string | null | undefined>): string[] => [
+  ...new Set(
+    addresses
+      .filter((address): address is string => !!address)
+      .map((address) => address.toLowerCase())
+  ),
+];
+
+interface VerificationMatchInput {
+  /** The indexed verification, or null/undefined while it is still absent. */
+  verificationDetails: { verifiedBy?: string | null; attestationUID?: string } | null | undefined;
+  /** Addresses that may have attested (see `buildAttesterCandidates`). */
+  candidates: string[];
+  /**
+   * The verification attestation UID observed BEFORE submitting, if any. Lets
+   * the tolerant branch tell "a new verification landed" apart from "this
+   * milestone was already verified by somebody else".
+   */
+  previousAttestationUID?: string;
+}
+
+/**
+ * True once the indexer shows a verification that this session plausibly
+ * created.
+ *
+ * Strict path: the indexed attester matches one of our candidate addresses.
+ * Tolerant path: the indexer has not resolved an attester yet, but the
+ * verification attestation is a different one from what we saw before signing.
+ */
+export const matchesSubmittedVerification = ({
+  verificationDetails,
+  candidates,
+  previousAttestationUID,
+}: VerificationMatchInput): boolean => {
+  if (!verificationDetails) return false;
+
+  const verifiedBy = verificationDetails.verifiedBy?.toLowerCase();
+  if (verifiedBy) {
+    return candidates.includes(verifiedBy);
+  }
+
+  const attestationUID = verificationDetails.attestationUID;
+  return !!attestationUID && attestationUID !== previousAttestationUID;
+};


### PR DESCRIPTION
## Problem

`hooks/useMilestoneCompletionVerification.ts` is the site of production incident **GAP-FRONTEND-261** — "Failed to verify milestone" for community admins. Four separate defects live in that one flow:

1. **A whole-project refetch mid-flow (#63).** `fetchMilestoneInstance` called the SDK's `gapClient.fetch.projectById(...)` — a V1 `GET /projects/:uid` — and the fetched entity was consumed for essentially one scalar: `.recipient`. The rest was `.chainID` (a duplicate of `milestone.chainId`, already in scope), `.completed` (answerable from the V2 `completionDetails`), and a `communityUID` that was threaded through and never used. The attestation payloads never call a method on the fetched instance; they are freshly-built `MilestoneCompleted` objects. On top of that, the post-attest indexing poll re-ran `projectById` on **every** iteration, a second refetch after the reviewer-backend completion was fully redundant (`includeCompletion` was hard-set to `false` immediately after it), and `useMilestoneCancellation` repeated the same recipient-only pattern.
2. **One context-free toast for ~10 failure classes (#64).** Every non-abort, non-rejection failure collapsed into `showError("Failed to verify milestone")`, with a Sentry context of only `{ milestoneUID, address }`. Worse, `errorManager` early-returns for reject-ish and transient network/HTTP errors — so for those the user got the generic toast **and Sentry got nothing at all**. Plus a `console.error` in violation of the no-console rule.
3. **The poll matched the wrong address (#66).** The predicate compared `verified[].attester` to wagmi's `useAccount().address`, but the attestation is signed by the Privy-resolved signer (embedded wallet preferred). For a hybrid account (email login + a linked external wallet connected) those are deterministically different, so the poll could never match: ~200 retries × 1.5s ≈ 5 minutes, then a false failure — despite the transaction landing on-chain. Retries from there can mint duplicate attestations.
4. **A post-transaction throw on a null wagmi address (#67).** `throw new Error("User address not available")` executed **after** `GapContract.multiAttest` and after the indexer notification. A null wagmi address next to a working Privy signer is a real state (the outer-config sync is an async effect with a swallow-on-failure path), so the user could see a failure toast for an attestation that had already succeeded.

## Fix

### #63 — no V1 project fetch anywhere in the flow

The V2 project-updates endpoint **already returns** `grantMilestones[].recipient` (`get-updates.api.response.ts` declares it; `project-updates.api.mapper.ts` maps it). The frontend mapper was dropping it.

- `services/milestones.ts`: `GrantMilestoneWithCompletion` gains `recipient?: string` and the mapper keeps it. Mapping is extracted to one function so the full and lightweight readers can't diverge.
- New `fetchGrantMilestonesForProgram()` — a **single** V2 request, used by the indexing polls instead of the old three-request full read (and instead of the V1 SDK path).
- `fetchMilestoneInstance` and both refetches are deleted. `chainID` now comes from `milestone.chainId`, `completed` from `completionDetails`, and the dead `communityUID` threading is gone.
- `useMilestoneCancellation` gets the same treatment: recipient from V2, no `projectById`. Its `data` argument is now unused and has been removed from the mutation args (caller updated).
- **Guard**: `requireMilestoneRecipient()` throws a typed `MissingMilestoneRecipientError` **before any wallet interaction** when the recipient is missing/malformed. It never falls back to `project.owner` or `payoutAddress` — that would change the attested value.

### #64 — failures name their cause and carry telemetry

- New `utilities/milestones/attestationFailure.ts` maps an error onto a concise, user-appropriate cause: signer-unavailable, network-switch, missing-recipient, indexing-timeout, insufficient-funds, wallet-rpc, network, server (with HTTP status), unknown. User rejection keeps its dedicated "Verification cancelled" copy.
- The Sentry context now carries `projectUid`, `chainId`, `programId`, `failureKind` and a **step marker** (`setup` / `fetch` / `backend` / `attest` / `poll`).
- `errorManager` leaves a `suppressed-error` breadcrumb on every early-return path (user-rejected, switch-chain, expected-state, transient-network, transient-http). No path is silent in both directions any more.
- Both `console.error` calls removed; the verify and complete catches share one `reportMilestoneFailure` exit point.

### #66 — poll against the actual signer

- `setupChainAndWalletForMilestone` now resolves the signing address from `walletSigner.getAddress()`, falling back to `useSetupChainAndWallet().smartWalletAddress`, and builds a tolerant candidate set that also includes every Privy-linked address (`getLinkedWalletAddresses`) and, last, the wagmi address.
- `matchesSubmittedVerification()` matches the indexed `verifiedBy` against that set. When the indexer hasn't resolved an attester yet it accepts a verification whose `attestationUID` differs from the one captured **before** signing — so a milestone somebody else already verified can't produce a false positive.
- On poll timeout the copy is now "submitted on-chain and is still being indexed … no need to verify again", and it is **not** reported to Sentry (indexer lag is not a defect).

### #66 (follow-up) — the attester is the MultiAttester contract, not the wallet

The candidate set above was still missing the address that actually lands. `GapContract.multiAttest` is this flow's only live attestation path — the app sets no `gelatoOpts`, so the `multiAttestBySig` branch is dead, and the EAS-direct `Milestone.verify()` path was deleted in #1951. It submits through the chain's MultiAttester (`Networks[network].contracts.multicall`), which is therefore `msg.sender` at EAS, so the indexer records **the contract** as `verifiedBy` — never the user's wallet.

On-chain confirmation: verification `0x7b2fb1bf…` (multiAttest path) has `verifiedBy` `0x7177adc0…`, the Base MultiAttester, versus `0xb5162b77…` with `verifiedBy` `0x8353…` from the old direct path.

Without this, every verification would still have polled to timeout on a transaction that had already succeeded. Two changes:

- `getMultiAttesterAddress(chainId)` resolves the MultiAttester per chain from the SDK (lower-cased, `null` for unsupported chains) and joins the candidate set — generic, so a new network needs no change here.
- `matchesSubmittedVerification()` now accepts a verification whose `attestationUID` differs from the pre-signing snapshot even when `verifiedBy` is truthy but unrecognised. The snapshot guard is unchanged, so a pre-existing verification with an unmoved UID is still never accepted.

### #67 — nothing after the tx reads the wagmi address

The post-attest `throw` is gone. The poll takes the setup-resolved identity, so a null `useAccount().address` no longer affects anything after submission. The old `!address` **pre-flight** guard removed in #1821 is deliberately **not** reintroduced — it caused the silent no-op that removal fixed.

## Wire contract

**Unchanged.** This is read-only consumption of an existing V2 response field (`grantMilestones[].recipient`) that the backend already declares and maps. No new endpoints, no request-shape changes, no new environment variables, no backend PR required.

## Testing

`__tests__/integration/mutations/useMilestoneCompletionVerification.mutation.test.tsx` (new, 13 cases) drives the real hook with a spied `api` client:

- a full verify run performs **zero** `GET /projects/:uid` calls (both the SDK `projectById` spy and the raw request URLs are asserted), and reads `/v2/projects/:uid/updates`;
- attestation payloads carry the V2 `recipient` verbatim, in the right order (`completed` then `verified`), and drop the completion attestation when the milestone is already completed;
- a missing recipient produces a clear toast and **no** `multiAttest` call, in both verify and complete;
- the poll succeeds when the indexed attester is the signer while wagmi reports an unrelated wallet (#66);
- a null wagmi address post-attest completes with a success toast and no `errorManager` call (#67);
- poll exhaustion produces the "still being indexed" copy and is kept out of Sentry;
- error mapping produces the named cause and the `step: "attest"` Sentry context; a user rejection keeps "Verification cancelled";
- the reviewer flow attests verification-only with no re-read after the backend completion.

Also:

- `__tests__/utilities/milestones/attestationIdentity.test.ts` — address validation, candidate building, and every branch of the verification match predicate.
- `__tests__/utilities/milestones/attestationFailure.test.ts` — one case per failure class.
- `__tests__/services/milestones.recipient.test.ts` — `recipient` survives both mappers; the lightweight reader issues exactly one V2 request with the chain suffix stripped.
- `__tests__/unit/utilities/errorManager.test.tsx` — a suppressed network-class error still leaves a breadcrumb (all five suppression paths).
- `__tests__/integration/mutations/useMilestoneCancellation.mutation.test.tsx` — updated for the V2 recipient; asserts no `projectById` and the missing-recipient block.

### Manual verification steps

1. As a community admin on a program with a pending-verification milestone, open the milestone review page with the network tab filtered to `projects` — verify a full verification run issues no `GET /projects/:uid`.
2. Sign in with an email/Google account that also has a linked external wallet connected (the hybrid shape). Verify a milestone: it should succeed within normal indexing time rather than spinning for five minutes.
3. Force a chain-switch rejection and confirm the toast names the network-switch cause rather than the bare generic string.
4. Confirm the completion and cancellation flows still attest with the same recipient.

### Local results

- `npx vitest run` over the touched suites: **256 passed / 24 files**.
- `tsc --noEmit`: clean.
- `pnpm lint:fix` (Biome): clean on touched files.
- `scripts/check-anti-patterns.sh` on every touched file: clean.
- `pnpm run build`: passes.

## Review findings addressed

No findings were waived. Everything raised was fixed in follow-up commits:

**Self-review (commit 2):**

- The poll's attester candidate set included wagmi's address, which can be an unlinked wallet left connected from a previous session — dropped, so the match stays within the authenticated identity.
- `isUserRejectionError` is a substring match and an `ApiError`'s message embeds the endpoint path, so an API failure on a route containing "reject" would have been reported to the user as "cancelled". API errors now bypass that check.
- A schema-contract violation was being described as a network failure; it now gets its own message.
- Expected failures (signer not ready, indexer lag) skip Sentry but now leave a breadcrumb, so no path is silent in both directions.
- The grant-milestones endpoint is built in one place, shared by the full and poll-friendly reads.

**Anti-pattern check (commit 3):**

- `[EMPTY_CATCH]` ×2 — the inline `api.post(...)` swallow in the verify and cancel flows is replaced by the existing `notifyIndexer` helper. A failed nudge is still non-fatal (the indexer's chain listener picks the tx up regardless) but it is now reported instead of vanishing.
- `[EMPTY_CATCH]` ×1 — documented that the grant lookup's catch reports through `errorManager` rather than swallowing.

**React Doctor (commit 3):**

- `buildAttestationPayloads` was rebuilt on every render despite reading nothing from the hook — moved to module scope.

### Follow-up test coverage (MultiAttester)

- Poll succeeds when `verifiedBy` is the Base MultiAttester `0x7177AdC0f924b695C0294A40C4C5FEFf5EE1E141`, and for Arbitrum's `0x6dC1D6b864e8BEf815806f9e4677123496e12026`. Both cases omit `attestationUID` so they exercise the attester-candidate path, not the UID fallback — each fails if the MultiAttester is dropped from the candidate set.
- Poll rejects a pre-existing verification (unchanged `attestationUID`, unrecognised attester) and still reports "still being indexed".
- `getMultiAttesterAddress` is asserted against every SDK-supported chain, plus stringified and malformed chain ids.
- Existing candidate matches (signer, linked wallet, unresolved attester) are unchanged.

Local: `attestationIdentity` + `useMilestoneCompletionVerification` suites 37/37 pass; the wider `__tests__/utilities/milestones`, `__tests__/integration/mutations` and `__tests__/hooks` run is 617/617. `pnpm run build` exits 0.

## Known CI note

The first Vercel preview build failed with exit 137 / OOM. This is the recurring preview-build flake on this repo (the build container runs out of memory), not a regression from this PR — `pnpm run build` passes locally against this branch.

Fixes show-karma/super-gap#63
Fixes show-karma/super-gap#64
Fixes show-karma/super-gap#66
Fixes show-karma/super-gap#67




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Milestone completion, verification, and cancellation now use recipient information from V2 milestone data.
  * Added clearer milestone failure messages for wallet, network, indexing, server, and transaction issues.
  * Added improved verification tracking across supported attesters and indexer updates.

* **Bug Fixes**
  * Prevented transactions when a milestone recipient is missing.
  * Improved cancellation reliability and cache refresh behavior.
  * Added breadcrumb diagnostics for expected or suppressed errors without changing user-facing notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->