### PR TITLE
fix(seo): truthful article date model for knowledge pages

### DIFF
--- a/__tests__/components/Seo/ArticleJsonLd.test.tsx
+++ b/__tests__/components/Seo/ArticleJsonLd.test.tsx
@@ -1,0 +1,64 @@
+import { render } from "@testing-library/react";
+import { ArticleJsonLd } from "@/components/Seo/ArticleJsonLd";
+import { SITE_URL } from "@/utilities/meta";
+import "@testing-library/jest-dom";
+
+describe("ArticleJsonLd", () => {
+  function getSchema(container: HTMLElement) {
+    const scripts = Array.from(container.querySelectorAll('script[type="application/ld+json"]'));
+    expect(scripts).toHaveLength(1);
+    return JSON.parse(scripts[0].innerHTML);
+  }
+
+  const baseProps = {
+    title: "The Grant Lifecycle",
+    description: "Follow the complete grant process.",
+    url: "/knowledge/grant-lifecycle",
+  };
+
+  it("emits an Article schema with the site URL and Karma as publisher", () => {
+    const { container } = render(<ArticleJsonLd {...baseProps} />);
+    const schema = getSchema(container);
+
+    expect(schema["@context"]).toBe("https://schema.org");
+    expect(schema["@type"]).toBe("Article");
+    expect(schema.headline).toBe(baseProps.title);
+    expect(schema.url).toBe(`${SITE_URL}/knowledge/grant-lifecycle`);
+    expect(schema.publisher.name).toBe("Karma");
+  });
+
+  it("includes datePublished when it is supplied", () => {
+    const { container } = render(<ArticleJsonLd {...baseProps} datePublished="2026-01-06" />);
+    const schema = getSchema(container);
+
+    expect(schema.datePublished).toBe("2026-01-06");
+  });
+
+  it("includes dateModified when it is supplied", () => {
+    const { container } = render(
+      <ArticleJsonLd {...baseProps} datePublished="2026-01-06" dateModified="2026-02-10" />
+    );
+    const schema = getSchema(container);
+
+    expect(schema.dateModified).toBe("2026-02-10");
+  });
+
+  // Knowledge pages rely on this contract: they pass no dateModified because no
+  // truthful modified date exists, and the key must then be absent rather than
+  // emitted as null/undefined.
+  it("omits both date keys entirely when neither prop is supplied", () => {
+    const { container } = render(<ArticleJsonLd {...baseProps} />);
+    const schema = getSchema(container);
+
+    expect("datePublished" in schema).toBe(false);
+    expect("dateModified" in schema).toBe(false);
+  });
+
+  it("omits dateModified while keeping datePublished", () => {
+    const { container } = render(<ArticleJsonLd {...baseProps} datePublished="2026-01-06" />);
+    const schema = getSchema(container);
+
+    expect("datePublished" in schema).toBe(true);
+    expect("dateModified" in schema).toBe(false);
+  });
+});

--- a/__tests__/integration/pages/knowledge-article-dates.test.tsx
+++ b/__tests__/integration/pages/knowledge-article-dates.test.tsx
@@ -1,0 +1,127 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import type { ComponentType } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { getKnowledgeArticleDate, KNOWLEDGE_ARTICLE_DATES } from "@/app/knowledge/articleDates";
+import GrantKycPage from "@/app/knowledge/grant-kyc/page";
+import GrantLifecyclePage from "@/app/knowledge/grant-lifecycle/page";
+import ProjectProfilesPage from "@/app/knowledge/project-profiles/page";
+import "@testing-library/jest-dom";
+
+/**
+ * Knowledge articles must never publish a fabricated freshness signal:
+ * every date they emit has to come from the checked-in provenance map and be
+ * visible on the page itself.
+ */
+
+const KNOWLEDGE_DIR = path.resolve(__dirname, "../../../app/knowledge");
+
+// The literals that were hardcoded on all 25 pages before the provenance map.
+const FABRICATED_DATES = ["2025-01-15", "2026-03-24"];
+
+function knowledgeSlugs(): string[] {
+  return fs
+    .readdirSync(KNOWLEDGE_DIR, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => entry.name)
+    .filter((name) => fs.existsSync(path.join(KNOWLEDGE_DIR, name, "page.tsx")));
+}
+
+/**
+ * Renders a page through `renderToStaticMarkup` (no client runtime, no
+ * hydration) so the assertions describe what a crawler receives from the
+ * server, not what React produces after mounting.
+ */
+function renderStatic(Page: ComponentType): Document {
+  const html = renderToStaticMarkup(<Page />);
+  return new DOMParser().parseFromString(
+    `<!doctype html><html><body>${html}</body></html>`,
+    "text/html"
+  );
+}
+
+function articleSchema(doc: Document): Record<string, unknown> {
+  const schemas = Array.from(doc.querySelectorAll('script[type="application/ld+json"]')).map(
+    (script) => JSON.parse(script.textContent ?? "{}") as Record<string, unknown>
+  );
+  const article = schemas.find((schema) => schema["@type"] === "Article");
+  expect(article).toBeDefined();
+  return article as Record<string, unknown>;
+}
+
+describe("knowledge article publication dates", () => {
+  describe("provenance map", () => {
+    it("covers every knowledge article directory", () => {
+      const slugs = knowledgeSlugs();
+      expect(slugs.length).toBeGreaterThan(0);
+
+      for (const slug of slugs) {
+        expect(KNOWLEDGE_ARTICLE_DATES).toHaveProperty(slug);
+      }
+    });
+
+    it("has no orphan entries without a matching page", () => {
+      const slugs = new Set(knowledgeSlugs());
+
+      for (const slug of Object.keys(KNOWLEDGE_ARTICLE_DATES)) {
+        expect(slugs.has(slug)).toBe(true);
+      }
+    });
+
+    it("records only plausible past dates, never the previously fabricated ones", () => {
+      const today = new Date().toISOString().slice(0, 10);
+
+      for (const [slug, date] of Object.entries(KNOWLEDGE_ARTICLE_DATES)) {
+        expect(date, slug).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+        expect(date.localeCompare(today), slug).toBeLessThanOrEqual(0);
+        expect(FABRICATED_DATES, slug).not.toContain(date);
+      }
+    });
+
+    it("throws for a slug with no recorded date", () => {
+      expect(() => getKnowledgeArticleDate("not-a-knowledge-article")).toThrow(
+        /No publication date recorded/
+      );
+    });
+  });
+
+  describe("page sources", () => {
+    it("never hardcode a date literal and never claim a modified date", () => {
+      for (const slug of knowledgeSlugs()) {
+        const source = fs.readFileSync(path.join(KNOWLEDGE_DIR, slug, "page.tsx"), "utf8");
+
+        expect(source, slug).not.toMatch(/dateModified/);
+        expect(source, slug).not.toMatch(/datePublished\s*=\s*"/);
+      }
+    });
+  });
+
+  describe.each([
+    ["grant-lifecycle", GrantLifecyclePage, "Jan 6, 2026"],
+    ["grant-kyc", GrantKycPage, "Jan 7, 2026"],
+    ["project-profiles", ProjectProfilesPage, "Jan 14, 2026"],
+  ])("%s (server-rendered)", (slug, Page, formatted) => {
+    const expectedDate = KNOWLEDGE_ARTICLE_DATES[slug];
+
+    it("emits the recorded datePublished in the Article JSON-LD", () => {
+      const schema = articleSchema(renderStatic(Page));
+
+      expect(schema.datePublished).toBe(expectedDate);
+    });
+
+    it("emits no dateModified", () => {
+      const schema = articleSchema(renderStatic(Page));
+
+      expect("dateModified" in schema).toBe(false);
+    });
+
+    it("shows the same date to readers in the server-rendered markup", () => {
+      const doc = renderStatic(Page);
+      const time = doc.querySelector(`time[datetime="${expectedDate}"]`);
+
+      expect(time).not.toBeNull();
+      expect(time?.textContent).toBe(formatted);
+      expect(doc.body.textContent).toContain(`Published ${formatted}`);
+    });
+  });
+});

--- a/app/knowledge/ai-grant-evaluation/page.tsx
+++ b/app/knowledge/ai-grant-evaluation/page.tsx
@@ -1,6 +1,8 @@
 import type { Metadata } from "next";
 import Link from "next/link";
+import { getKnowledgeArticleDate } from "@/app/knowledge/articleDates";
 import { Breadcrumbs } from "@/components/Breadcrumbs";
+import { ArticlePublishedDate } from "@/components/Knowledge/ArticlePublishedDate";
 import { ArticleJsonLd } from "@/components/Seo/ArticleJsonLd";
 import { BreadcrumbJsonLd } from "@/components/Seo/BreadcrumbJsonLd";
 import { customMetadata } from "@/utilities/meta";
@@ -12,6 +14,8 @@ export const metadata: Metadata = customMetadata({
   path: "/knowledge/ai-grant-evaluation",
   ogType: "article",
 });
+
+const PUBLISHED_AT = getKnowledgeArticleDate("ai-grant-evaluation");
 
 export default function AiGrantEvaluationPage() {
   return (
@@ -27,8 +31,7 @@ export default function AiGrantEvaluationPage() {
         title="AI-Assisted Grant Evaluation at Scale"
         description="Learn how AI-assisted evaluation helps grant programs process hundreds of applications without sacrificing review quality. Explore practical approaches to scaling."
         url="/knowledge/ai-grant-evaluation"
-        datePublished="2025-01-15"
-        dateModified="2026-03-24"
+        datePublished={PUBLISHED_AT}
       />
       <BreadcrumbJsonLd
         items={[
@@ -38,7 +41,10 @@ export default function AiGrantEvaluationPage() {
         ]}
       />
       <article className="space-y-8">
-        <h1 className="text-3xl font-bold">AI-Assisted Grant Evaluation at Scale</h1>
+        <header className="space-y-2">
+          <h1 className="text-3xl font-bold">AI-Assisted Grant Evaluation at Scale</h1>
+          <ArticlePublishedDate date={PUBLISHED_AT} />
+        </header>
 
         <section className="space-y-4">
           <h2 className="text-xl font-semibold">In one sentence</h2>

--- a/app/knowledge/articleDates.ts
+++ b/app/knowledge/articleDates.ts
@@ -1,0 +1,73 @@
+/**
+ * Publication dates for the static knowledge-base articles under `app/knowledge/`.
+ *
+ * These articles are not CMS-backed (unlike `/blog/[slug]`, which carries Sanity's
+ * `publishedAt`), so the only truthful per-article record is the commit that first
+ * added the page to the repository. Each value below is the UTC calendar date of
+ * that commit, recovered with:
+ *
+ *   gh api "repos/show-karma/gap-app-v2/commits?path=app/knowledge/<slug>/page.tsx&per_page=100" \
+ *     --jq '.[] | .sha[0:9] + " " + .commit.author.date' | tail -1
+ *
+ * (The GitHub API is authoritative here: local clones of this repo are often
+ * shallow, and grafted commits report every file as newly added.)
+ *
+ * Source commits:
+ *   a83858e12 "Add knowledge pages"    2026-01-06T22:57:57Z -> 2026-01-06
+ *   363e897ea "checkin missing files"  2026-01-07T22:57:37Z -> 2026-01-07
+ *   840b81144 "more knowledge pages"   2026-01-14T07:12:20Z -> 2026-01-14
+ *
+ * Rules for maintaining this map:
+ *   - Every date must be copied from a real commit. Never approximate, backfill,
+ *     or stamp "today" onto an existing article.
+ *   - Adding a knowledge page without adding it here fails the build, because the
+ *     page calls `getKnowledgeArticleDate` at module scope.
+ *   - There is deliberately no modified-date map. Git last-touch dates on these
+ *     files are merge/mechanical artifacts, so any `dateModified` derived from
+ *     them would fabricate freshness — the same reasoning that keeps
+ *     `lastModified` off these pages in `app/sitemaps/static/sitemap.ts`.
+ */
+export const KNOWLEDGE_ARTICLE_DATES: Readonly<Record<string, string>> = {
+  "ai-grant-evaluation": "2026-01-07",
+  "dao-grant-milestones": "2026-01-06",
+  "funding-distribution-mechanisms": "2026-01-07",
+  "grant-accountability": "2026-01-06",
+  "grant-document-signing": "2026-01-07",
+  "grant-fund-disbursement": "2026-01-07",
+  "grant-kyc": "2026-01-07",
+  "grant-lifecycle": "2026-01-06",
+  "how-funders-use-project-profiles": "2026-01-14",
+  "impact-measurement": "2026-01-07",
+  "impact-verification": "2026-01-06",
+  "manual-vs-platform-grant-tracking": "2026-01-06",
+  "milestones-vs-impact": "2026-01-06",
+  "onchain-project-profiles": "2026-01-14",
+  "onchain-reputation": "2026-01-06",
+  "project-profiles": "2026-01-14",
+  "project-profiles-as-resumes": "2026-01-14",
+  "project-profiles-software-vs-nonsoftware": "2026-01-14",
+  "project-registry": "2026-01-07",
+  "project-reputation": "2026-01-06",
+  "project-updates-and-reputation": "2026-01-14",
+  "reputation-compounding": "2026-01-06",
+  "whitelabel-funding-platforms": "2026-01-07",
+  "why-grant-programs-fail": "2026-01-06",
+  "why-grantees-need-project-profiles": "2026-01-14",
+};
+
+/**
+ * Returns the recorded publication date (`YYYY-MM-DD`, UTC) for a knowledge article.
+ * Throws for an unrecorded slug so a new page can never ship with a missing or
+ * invented date.
+ */
+export function getKnowledgeArticleDate(slug: string): string {
+  const publishedAt = KNOWLEDGE_ARTICLE_DATES[slug];
+
+  if (!publishedAt) {
+    throw new Error(
+      `No publication date recorded for knowledge article "${slug}". Add its first-commit date to KNOWLEDGE_ARTICLE_DATES in app/knowledge/articleDates.ts.`
+    );
+  }
+
+  return publishedAt;
+}

--- a/app/knowledge/dao-grant-milestones/page.tsx
+++ b/app/knowledge/dao-grant-milestones/page.tsx
@@ -1,6 +1,8 @@
 import type { Metadata } from "next";
 import Link from "next/link";
+import { getKnowledgeArticleDate } from "@/app/knowledge/articleDates";
 import { Breadcrumbs } from "@/components/Breadcrumbs";
+import { ArticlePublishedDate } from "@/components/Knowledge/ArticlePublishedDate";
 import { ArticleJsonLd } from "@/components/Seo/ArticleJsonLd";
 import { BreadcrumbJsonLd } from "@/components/Seo/BreadcrumbJsonLd";
 import { customMetadata } from "@/utilities/meta";
@@ -12,6 +14,8 @@ export const metadata: Metadata = customMetadata({
   path: "/knowledge/dao-grant-milestones",
   ogType: "article",
 });
+
+const PUBLISHED_AT = getKnowledgeArticleDate("dao-grant-milestones");
 
 export default function DaoGrantMilestonesPage() {
   return (
@@ -27,8 +31,7 @@ export default function DaoGrantMilestonesPage() {
         title="How DAOs Track Grant Milestones"
         description="Explore how DAOs define, track, and evaluate grant milestones. Compare approaches from spreadsheets to modular platforms and learn the tradeoffs of each method."
         url="/knowledge/dao-grant-milestones"
-        datePublished="2025-01-15"
-        dateModified="2026-03-24"
+        datePublished={PUBLISHED_AT}
       />
       <BreadcrumbJsonLd
         items={[
@@ -38,7 +41,10 @@ export default function DaoGrantMilestonesPage() {
         ]}
       />
       <article className="space-y-8">
-        <h1 className="text-3xl font-bold">How DAOs Track Grant Milestones</h1>
+        <header className="space-y-2">
+          <h1 className="text-3xl font-bold">How DAOs Track Grant Milestones</h1>
+          <ArticlePublishedDate date={PUBLISHED_AT} />
+        </header>
 
         <section className="space-y-4">
           <h2 className="text-xl font-semibold">In one sentence</h2>

--- a/app/knowledge/funding-distribution-mechanisms/page.tsx
+++ b/app/knowledge/funding-distribution-mechanisms/page.tsx
@@ -1,6 +1,8 @@
 import type { Metadata } from "next";
 import Link from "next/link";
+import { getKnowledgeArticleDate } from "@/app/knowledge/articleDates";
 import { Breadcrumbs } from "@/components/Breadcrumbs";
+import { ArticlePublishedDate } from "@/components/Knowledge/ArticlePublishedDate";
 import { ArticleJsonLd } from "@/components/Seo/ArticleJsonLd";
 import { BreadcrumbJsonLd } from "@/components/Seo/BreadcrumbJsonLd";
 import { customMetadata } from "@/utilities/meta";
@@ -15,6 +17,8 @@ export const metadata: Metadata = customMetadata({
   path: "/knowledge/funding-distribution-mechanisms",
   ogType: "article",
 });
+
+const PUBLISHED_AT = getKnowledgeArticleDate("funding-distribution-mechanisms");
 
 export default function FundingDistributionMechanismsPage() {
   return (
@@ -33,8 +37,7 @@ export default function FundingDistributionMechanismsPage() {
         title={title}
         description={description}
         url="/knowledge/funding-distribution-mechanisms"
-        datePublished="2025-01-15"
-        dateModified="2026-03-24"
+        datePublished={PUBLISHED_AT}
       />
       <BreadcrumbJsonLd
         items={[
@@ -47,7 +50,10 @@ export default function FundingDistributionMechanismsPage() {
         ]}
       />
       <article className="space-y-8">
-        <h1 className="text-3xl font-bold">Grant Funding Distribution Mechanisms Explained</h1>
+        <header className="space-y-2">
+          <h1 className="text-3xl font-bold">Grant Funding Distribution Mechanisms Explained</h1>
+          <ArticlePublishedDate date={PUBLISHED_AT} />
+        </header>
 
         <section className="space-y-4">
           <h2 className="text-xl font-semibold">In one sentence</h2>

--- a/app/knowledge/grant-accountability/page.tsx
+++ b/app/knowledge/grant-accountability/page.tsx
@@ -1,6 +1,8 @@
 import type { Metadata } from "next";
 import Link from "next/link";
+import { getKnowledgeArticleDate } from "@/app/knowledge/articleDates";
 import { Breadcrumbs } from "@/components/Breadcrumbs";
+import { ArticlePublishedDate } from "@/components/Knowledge/ArticlePublishedDate";
 import { ArticleJsonLd } from "@/components/Seo/ArticleJsonLd";
 import { BreadcrumbJsonLd } from "@/components/Seo/BreadcrumbJsonLd";
 import { customMetadata } from "@/utilities/meta";
@@ -12,6 +14,8 @@ export const metadata: Metadata = customMetadata({
   path: "/knowledge/grant-accountability",
   ogType: "article",
 });
+
+const PUBLISHED_AT = getKnowledgeArticleDate("grant-accountability");
 
 export default function GrantAccountabilityPage() {
   return (
@@ -27,8 +31,7 @@ export default function GrantAccountabilityPage() {
         title="What Is Grant Accountability in Open Funding?"
         description="Grant accountability turns funding promises into persistent execution history. Discover how to track funded projects and improve capital allocation over time."
         url="/knowledge/grant-accountability"
-        datePublished="2025-01-15"
-        dateModified="2026-03-24"
+        datePublished={PUBLISHED_AT}
       />
       <BreadcrumbJsonLd
         items={[
@@ -38,7 +41,10 @@ export default function GrantAccountabilityPage() {
         ]}
       />
       <article className="space-y-8">
-        <h1 className="text-3xl font-bold">What Is Grant Accountability in Open Funding?</h1>
+        <header className="space-y-2">
+          <h1 className="text-3xl font-bold">What Is Grant Accountability in Open Funding?</h1>
+          <ArticlePublishedDate date={PUBLISHED_AT} />
+        </header>
 
         <section className="space-y-4">
           <h2 className="text-xl font-semibold">In one sentence</h2>

--- a/app/knowledge/grant-document-signing/page.tsx
+++ b/app/knowledge/grant-document-signing/page.tsx
@@ -1,6 +1,8 @@
 import type { Metadata } from "next";
 import Link from "next/link";
+import { getKnowledgeArticleDate } from "@/app/knowledge/articleDates";
 import { Breadcrumbs } from "@/components/Breadcrumbs";
+import { ArticlePublishedDate } from "@/components/Knowledge/ArticlePublishedDate";
 import { ArticleJsonLd } from "@/components/Seo/ArticleJsonLd";
 import { BreadcrumbJsonLd } from "@/components/Seo/BreadcrumbJsonLd";
 import { customMetadata } from "@/utilities/meta";
@@ -12,6 +14,8 @@ export const metadata: Metadata = customMetadata({
   path: "/knowledge/grant-document-signing",
   ogType: "article",
 });
+
+const PUBLISHED_AT = getKnowledgeArticleDate("grant-document-signing");
 
 export default function GrantDocumentSigningPage() {
   return (
@@ -27,8 +31,7 @@ export default function GrantDocumentSigningPage() {
         title="Document Signing in Grant Programs"
         description="Understand why grant agreements must be tracked as part of the funding workflow. Learn how integrated document signing prevents operational chaos and payment delays."
         url="/knowledge/grant-document-signing"
-        datePublished="2025-01-15"
-        dateModified="2026-03-24"
+        datePublished={PUBLISHED_AT}
       />
       <BreadcrumbJsonLd
         items={[
@@ -38,7 +41,10 @@ export default function GrantDocumentSigningPage() {
         ]}
       />
       <article className="space-y-8">
-        <h1 className="text-3xl font-bold">Document Signing in Grant Programs</h1>
+        <header className="space-y-2">
+          <h1 className="text-3xl font-bold">Document Signing in Grant Programs</h1>
+          <ArticlePublishedDate date={PUBLISHED_AT} />
+        </header>
 
         <section className="space-y-4">
           <h2 className="text-xl font-semibold">In one sentence</h2>

--- a/app/knowledge/grant-fund-disbursement/page.tsx
+++ b/app/knowledge/grant-fund-disbursement/page.tsx
@@ -1,6 +1,8 @@
 import type { Metadata } from "next";
 import Link from "next/link";
+import { getKnowledgeArticleDate } from "@/app/knowledge/articleDates";
 import { Breadcrumbs } from "@/components/Breadcrumbs";
+import { ArticlePublishedDate } from "@/components/Knowledge/ArticlePublishedDate";
 import { ArticleJsonLd } from "@/components/Seo/ArticleJsonLd";
 import { BreadcrumbJsonLd } from "@/components/Seo/BreadcrumbJsonLd";
 import { customMetadata } from "@/utilities/meta";
@@ -12,6 +14,8 @@ export const metadata: Metadata = customMetadata({
   path: "/knowledge/grant-fund-disbursement",
   ogType: "article",
 });
+
+const PUBLISHED_AT = getKnowledgeArticleDate("grant-fund-disbursement");
 
 export default function GrantFundDisbursementPage() {
   return (
@@ -27,8 +31,7 @@ export default function GrantFundDisbursementPage() {
         title="Grant Fund Disbursement Coordination"
         description="Learn how grant payments are safely triggered once KYC, signing, and approvals are complete. Explore best practices for coordinating fund disbursement at scale."
         url="/knowledge/grant-fund-disbursement"
-        datePublished="2025-01-15"
-        dateModified="2026-03-24"
+        datePublished={PUBLISHED_AT}
       />
       <BreadcrumbJsonLd
         items={[
@@ -38,7 +41,10 @@ export default function GrantFundDisbursementPage() {
         ]}
       />
       <article className="space-y-8">
-        <h1 className="text-3xl font-bold">Grant Fund Disbursement Coordination</h1>
+        <header className="space-y-2">
+          <h1 className="text-3xl font-bold">Grant Fund Disbursement Coordination</h1>
+          <ArticlePublishedDate date={PUBLISHED_AT} />
+        </header>
 
         <section className="space-y-4">
           <h2 className="text-xl font-semibold">In one sentence</h2>

--- a/app/knowledge/grant-kyc/page.tsx
+++ b/app/knowledge/grant-kyc/page.tsx
@@ -1,6 +1,8 @@
 import type { Metadata } from "next";
 import Link from "next/link";
+import { getKnowledgeArticleDate } from "@/app/knowledge/articleDates";
 import { Breadcrumbs } from "@/components/Breadcrumbs";
+import { ArticlePublishedDate } from "@/components/Knowledge/ArticlePublishedDate";
 import { ArticleJsonLd } from "@/components/Seo/ArticleJsonLd";
 import { BreadcrumbJsonLd } from "@/components/Seo/BreadcrumbJsonLd";
 import { customMetadata } from "@/utilities/meta";
@@ -12,6 +14,8 @@ export const metadata: Metadata = customMetadata({
   path: "/knowledge/grant-kyc",
   ogType: "article",
 });
+
+const PUBLISHED_AT = getKnowledgeArticleDate("grant-kyc");
 
 export default function GrantKycPage() {
   return (
@@ -27,8 +31,7 @@ export default function GrantKycPage() {
         title="KYC in Grant and Funding Programs"
         description="Learn how identity verification integrates into grant workflows without slowing down funding. Explore KYC best practices for compliance and operational efficiency."
         url="/knowledge/grant-kyc"
-        datePublished="2025-01-15"
-        dateModified="2026-03-24"
+        datePublished={PUBLISHED_AT}
       />
       <BreadcrumbJsonLd
         items={[
@@ -38,7 +41,10 @@ export default function GrantKycPage() {
         ]}
       />
       <article className="space-y-8">
-        <h1 className="text-3xl font-bold">KYC in Grant and Funding Programs</h1>
+        <header className="space-y-2">
+          <h1 className="text-3xl font-bold">KYC in Grant and Funding Programs</h1>
+          <ArticlePublishedDate date={PUBLISHED_AT} />
+        </header>
 
         <section className="space-y-4">
           <h2 className="text-xl font-semibold">In one sentence</h2>

--- a/app/knowledge/grant-lifecycle/page.tsx
+++ b/app/knowledge/grant-lifecycle/page.tsx
@@ -1,6 +1,8 @@
 import type { Metadata } from "next";
 import Link from "next/link";
+import { getKnowledgeArticleDate } from "@/app/knowledge/articleDates";
 import { Breadcrumbs } from "@/components/Breadcrumbs";
+import { ArticlePublishedDate } from "@/components/Knowledge/ArticlePublishedDate";
 import { ArticleJsonLd } from "@/components/Seo/ArticleJsonLd";
 import { BreadcrumbJsonLd } from "@/components/Seo/BreadcrumbJsonLd";
 import { HowToJsonLd } from "@/components/Seo/HowToJsonLd";
@@ -13,6 +15,8 @@ export const metadata: Metadata = customMetadata({
   path: "/knowledge/grant-lifecycle",
   ogType: "article",
 });
+
+const PUBLISHED_AT = getKnowledgeArticleDate("grant-lifecycle");
 
 export default function GrantLifecyclePage() {
   return (
@@ -28,8 +32,7 @@ export default function GrantLifecyclePage() {
         title="The Grant Lifecycle: From Proposal to Verified Impact"
         description="Follow the complete grant process from proposal submission to verified impact. Learn the 10 stages every funding program needs to track and coordinate."
         url="/knowledge/grant-lifecycle"
-        datePublished="2025-01-15"
-        dateModified="2026-03-24"
+        datePublished={PUBLISHED_AT}
       />
       <BreadcrumbJsonLd
         items={[
@@ -85,9 +88,12 @@ export default function GrantLifecyclePage() {
         ]}
       />
       <article className="space-y-8">
-        <h1 className="text-3xl font-bold">
-          The Grant Lifecycle: From Proposal to Verified Impact
-        </h1>
+        <header className="space-y-2">
+          <h1 className="text-3xl font-bold">
+            The Grant Lifecycle: From Proposal to Verified Impact
+          </h1>
+          <ArticlePublishedDate date={PUBLISHED_AT} />
+        </header>
 
         <section className="space-y-4">
           <h2 className="text-xl font-semibold">In one sentence</h2>

--- a/app/knowledge/how-funders-use-project-profiles/page.tsx
+++ b/app/knowledge/how-funders-use-project-profiles/page.tsx
@@ -1,6 +1,8 @@
 import type { Metadata } from "next";
 import Link from "next/link";
+import { getKnowledgeArticleDate } from "@/app/knowledge/articleDates";
 import { Breadcrumbs } from "@/components/Breadcrumbs";
+import { ArticlePublishedDate } from "@/components/Knowledge/ArticlePublishedDate";
 import { ArticleJsonLd } from "@/components/Seo/ArticleJsonLd";
 import { BreadcrumbJsonLd } from "@/components/Seo/BreadcrumbJsonLd";
 import { customMetadata } from "@/utilities/meta";
@@ -15,6 +17,8 @@ export const metadata: Metadata = customMetadata({
   path: "/knowledge/how-funders-use-project-profiles",
   ogType: "article",
 });
+
+const PUBLISHED_AT = getKnowledgeArticleDate("how-funders-use-project-profiles");
 
 export default function HowFundersUseProjectProfilesPage() {
   return (
@@ -33,8 +37,7 @@ export default function HowFundersUseProjectProfilesPage() {
         title={title}
         description={description}
         url="/knowledge/how-funders-use-project-profiles"
-        datePublished="2025-01-15"
-        dateModified="2026-03-24"
+        datePublished={PUBLISHED_AT}
       />
       <BreadcrumbJsonLd
         items={[
@@ -47,7 +50,10 @@ export default function HowFundersUseProjectProfilesPage() {
         ]}
       />
       <article className="space-y-8">
-        <h1 className="text-3xl font-bold">How Funders Use Project Profiles to Evaluate Work</h1>
+        <header className="space-y-2">
+          <h1 className="text-3xl font-bold">How Funders Use Project Profiles to Evaluate Work</h1>
+          <ArticlePublishedDate date={PUBLISHED_AT} />
+        </header>
 
         <section className="space-y-4">
           <h2 className="text-xl font-semibold">In one sentence</h2>

--- a/app/knowledge/impact-measurement/page.tsx
+++ b/app/knowledge/impact-measurement/page.tsx
@@ -1,6 +1,8 @@
 import type { Metadata } from "next";
 import Link from "next/link";
+import { getKnowledgeArticleDate } from "@/app/knowledge/articleDates";
 import { Breadcrumbs } from "@/components/Breadcrumbs";
+import { ArticlePublishedDate } from "@/components/Knowledge/ArticlePublishedDate";
 import { ArticleJsonLd } from "@/components/Seo/ArticleJsonLd";
 import { BreadcrumbJsonLd } from "@/components/Seo/BreadcrumbJsonLd";
 import { customMetadata } from "@/utilities/meta";
@@ -12,6 +14,8 @@ export const metadata: Metadata = customMetadata({
   path: "/knowledge/impact-measurement",
   ogType: "article",
 });
+
+const PUBLISHED_AT = getKnowledgeArticleDate("impact-measurement");
 
 export default function ImpactMeasurementPage() {
   return (
@@ -27,8 +31,7 @@ export default function ImpactMeasurementPage() {
         title="Impact Measurement for Funded Projects"
         description="Discover how funded work connects to verifiable outputs and outcomes. Learn practical approaches to measuring impact and improving capital allocation decisions."
         url="/knowledge/impact-measurement"
-        datePublished="2025-01-15"
-        dateModified="2026-03-24"
+        datePublished={PUBLISHED_AT}
       />
       <BreadcrumbJsonLd
         items={[
@@ -38,7 +41,10 @@ export default function ImpactMeasurementPage() {
         ]}
       />
       <article className="space-y-8">
-        <h1 className="text-3xl font-bold">Impact Measurement for Funded Projects</h1>
+        <header className="space-y-2">
+          <h1 className="text-3xl font-bold">Impact Measurement for Funded Projects</h1>
+          <ArticlePublishedDate date={PUBLISHED_AT} />
+        </header>
 
         <section className="space-y-4">
           <h2 className="text-xl font-semibold">In one sentence</h2>

--- a/app/knowledge/impact-verification/page.tsx
+++ b/app/knowledge/impact-verification/page.tsx
@@ -1,6 +1,8 @@
 import type { Metadata } from "next";
 import Link from "next/link";
+import { getKnowledgeArticleDate } from "@/app/knowledge/articleDates";
 import { Breadcrumbs } from "@/components/Breadcrumbs";
+import { ArticlePublishedDate } from "@/components/Knowledge/ArticlePublishedDate";
 import { ArticleJsonLd } from "@/components/Seo/ArticleJsonLd";
 import { BreadcrumbJsonLd } from "@/components/Seo/BreadcrumbJsonLd";
 import { customMetadata } from "@/utilities/meta";
@@ -12,6 +14,8 @@ export const metadata: Metadata = customMetadata({
   path: "/knowledge/impact-verification",
   ogType: "article",
 });
+
+const PUBLISHED_AT = getKnowledgeArticleDate("impact-verification");
 
 export default function ImpactVerificationPage() {
   return (
@@ -27,8 +31,7 @@ export default function ImpactVerificationPage() {
         title="How to Verify Impact Without Centralized Auditors"
         description="Learn how impact can be verified through transparent documentation, peer review, and public evidence instead of relying solely on centralized audits."
         url="/knowledge/impact-verification"
-        datePublished="2025-01-15"
-        dateModified="2026-03-24"
+        datePublished={PUBLISHED_AT}
       />
       <BreadcrumbJsonLd
         items={[
@@ -38,7 +41,10 @@ export default function ImpactVerificationPage() {
         ]}
       />
       <article className="space-y-8">
-        <h1 className="text-3xl font-bold">How to Verify Impact Without Centralized Auditors</h1>
+        <header className="space-y-2">
+          <h1 className="text-3xl font-bold">How to Verify Impact Without Centralized Auditors</h1>
+          <ArticlePublishedDate date={PUBLISHED_AT} />
+        </header>
 
         <section className="space-y-4">
           <h2 className="text-xl font-semibold">In one sentence</h2>

--- a/app/knowledge/manual-vs-platform-grant-tracking/page.tsx
+++ b/app/knowledge/manual-vs-platform-grant-tracking/page.tsx
@@ -1,6 +1,8 @@
 import type { Metadata } from "next";
 import Link from "next/link";
+import { getKnowledgeArticleDate } from "@/app/knowledge/articleDates";
 import { Breadcrumbs } from "@/components/Breadcrumbs";
+import { ArticlePublishedDate } from "@/components/Knowledge/ArticlePublishedDate";
 import { ArticleJsonLd } from "@/components/Seo/ArticleJsonLd";
 import { BreadcrumbJsonLd } from "@/components/Seo/BreadcrumbJsonLd";
 import { customMetadata } from "@/utilities/meta";
@@ -12,6 +14,8 @@ export const metadata: Metadata = customMetadata({
   path: "/knowledge/manual-vs-platform-grant-tracking",
   ogType: "article",
 });
+
+const PUBLISHED_AT = getKnowledgeArticleDate("manual-vs-platform-grant-tracking");
 
 export default function ManualVsPlatformGrantTrackingPage() {
   return (
@@ -30,8 +34,7 @@ export default function ManualVsPlatformGrantTrackingPage() {
         title="Manual vs Platform-Based Grant Tracking"
         description="Compare spreadsheets and documents with dedicated funding platforms for grant tracking. Learn when manual tools break down and when structured platforms scale better."
         url="/knowledge/manual-vs-platform-grant-tracking"
-        datePublished="2025-01-15"
-        dateModified="2026-03-24"
+        datePublished={PUBLISHED_AT}
       />
       <BreadcrumbJsonLd
         items={[
@@ -44,7 +47,10 @@ export default function ManualVsPlatformGrantTrackingPage() {
         ]}
       />
       <article className="space-y-8">
-        <h1 className="text-3xl font-bold">Manual vs Platform-Based Grant Tracking</h1>
+        <header className="space-y-2">
+          <h1 className="text-3xl font-bold">Manual vs Platform-Based Grant Tracking</h1>
+          <ArticlePublishedDate date={PUBLISHED_AT} />
+        </header>
 
         <section className="space-y-4">
           <h2 className="text-xl font-semibold">In one sentence</h2>

--- a/app/knowledge/milestones-vs-impact/page.tsx
+++ b/app/knowledge/milestones-vs-impact/page.tsx
@@ -1,6 +1,8 @@
 import type { Metadata } from "next";
 import Link from "next/link";
+import { getKnowledgeArticleDate } from "@/app/knowledge/articleDates";
 import { Breadcrumbs } from "@/components/Breadcrumbs";
+import { ArticlePublishedDate } from "@/components/Knowledge/ArticlePublishedDate";
 import { ArticleJsonLd } from "@/components/Seo/ArticleJsonLd";
 import { BreadcrumbJsonLd } from "@/components/Seo/BreadcrumbJsonLd";
 import { customMetadata } from "@/utilities/meta";
@@ -12,6 +14,8 @@ export const metadata: Metadata = customMetadata({
   path: "/knowledge/milestones-vs-impact",
   ogType: "article",
 });
+
+const PUBLISHED_AT = getKnowledgeArticleDate("milestones-vs-impact");
 
 export default function MilestonesVsImpactPage() {
   return (
@@ -27,8 +31,7 @@ export default function MilestonesVsImpactPage() {
         title="Grant Milestones vs Impact"
         description="Milestones track work done while impact tracks change created. Learn why separating these concepts is critical for honest evaluation of funded projects."
         url="/knowledge/milestones-vs-impact"
-        datePublished="2025-01-15"
-        dateModified="2026-03-24"
+        datePublished={PUBLISHED_AT}
       />
       <BreadcrumbJsonLd
         items={[
@@ -38,7 +41,10 @@ export default function MilestonesVsImpactPage() {
         ]}
       />
       <article className="space-y-8">
-        <h1 className="text-3xl font-bold">Grant Milestones vs Impact</h1>
+        <header className="space-y-2">
+          <h1 className="text-3xl font-bold">Grant Milestones vs Impact</h1>
+          <ArticlePublishedDate date={PUBLISHED_AT} />
+        </header>
 
         <section className="space-y-4">
           <h2 className="text-xl font-semibold">In one sentence</h2>

--- a/app/knowledge/onchain-project-profiles/page.tsx
+++ b/app/knowledge/onchain-project-profiles/page.tsx
@@ -1,6 +1,8 @@
 import type { Metadata } from "next";
 import Link from "next/link";
+import { getKnowledgeArticleDate } from "@/app/knowledge/articleDates";
 import { Breadcrumbs } from "@/components/Breadcrumbs";
+import { ArticlePublishedDate } from "@/components/Knowledge/ArticlePublishedDate";
 import { ArticleJsonLd } from "@/components/Seo/ArticleJsonLd";
 import { BreadcrumbJsonLd } from "@/components/Seo/BreadcrumbJsonLd";
 import { customMetadata } from "@/utilities/meta";
@@ -16,6 +18,8 @@ export const metadata: Metadata = customMetadata({
   ogType: "article",
 });
 
+const PUBLISHED_AT = getKnowledgeArticleDate("onchain-project-profiles");
+
 export default function OnchainProjectProfilesPage() {
   return (
     <main className="container mx-auto max-w-3xl px-4 py-12">
@@ -30,8 +34,7 @@ export default function OnchainProjectProfilesPage() {
         title={title}
         description={description}
         url="/knowledge/onchain-project-profiles"
-        datePublished="2025-01-15"
-        dateModified="2026-03-24"
+        datePublished={PUBLISHED_AT}
       />
       <BreadcrumbJsonLd
         items={[
@@ -41,9 +44,12 @@ export default function OnchainProjectProfilesPage() {
         ]}
       />
       <article className="space-y-8">
-        <h1 className="text-3xl font-bold">
-          Onchain Project Profiles (Without Blockchain Complexity)
-        </h1>
+        <header className="space-y-2">
+          <h1 className="text-3xl font-bold">
+            Onchain Project Profiles (Without Blockchain Complexity)
+          </h1>
+          <ArticlePublishedDate date={PUBLISHED_AT} />
+        </header>
 
         <section className="space-y-4">
           <h2 className="text-xl font-semibold">In one sentence</h2>

--- a/app/knowledge/onchain-reputation/page.tsx
+++ b/app/knowledge/onchain-reputation/page.tsx
@@ -1,6 +1,8 @@
 import type { Metadata } from "next";
 import Link from "next/link";
+import { getKnowledgeArticleDate } from "@/app/knowledge/articleDates";
 import { Breadcrumbs } from "@/components/Breadcrumbs";
+import { ArticlePublishedDate } from "@/components/Knowledge/ArticlePublishedDate";
 import { ArticleJsonLd } from "@/components/Seo/ArticleJsonLd";
 import { BreadcrumbJsonLd } from "@/components/Seo/BreadcrumbJsonLd";
 import { customMetadata } from "@/utilities/meta";
@@ -16,6 +18,8 @@ export const metadata: Metadata = customMetadata({
   ogType: "article",
 });
 
+const PUBLISHED_AT = getKnowledgeArticleDate("onchain-reputation");
+
 export default function OnchainReputationPage() {
   return (
     <main className="container mx-auto max-w-3xl px-4 py-12">
@@ -30,8 +34,7 @@ export default function OnchainReputationPage() {
         title={title}
         description={description}
         url="/knowledge/onchain-reputation"
-        datePublished="2025-01-15"
-        dateModified="2026-03-24"
+        datePublished={PUBLISHED_AT}
       />
       <BreadcrumbJsonLd
         items={[
@@ -41,7 +44,10 @@ export default function OnchainReputationPage() {
         ]}
       />
       <article className="space-y-8">
-        <h1 className="text-3xl font-bold">What Is Onchain Reputation in Open Funding?</h1>
+        <header className="space-y-2">
+          <h1 className="text-3xl font-bold">What Is Onchain Reputation in Open Funding?</h1>
+          <ArticlePublishedDate date={PUBLISHED_AT} />
+        </header>
 
         <section className="space-y-4">
           <h2 className="text-xl font-semibold">In one sentence</h2>

--- a/app/knowledge/project-profiles-as-resumes/page.tsx
+++ b/app/knowledge/project-profiles-as-resumes/page.tsx
@@ -1,6 +1,8 @@
 import type { Metadata } from "next";
 import Link from "next/link";
+import { getKnowledgeArticleDate } from "@/app/knowledge/articleDates";
 import { Breadcrumbs } from "@/components/Breadcrumbs";
+import { ArticlePublishedDate } from "@/components/Knowledge/ArticlePublishedDate";
 import { ArticleJsonLd } from "@/components/Seo/ArticleJsonLd";
 import { BreadcrumbJsonLd } from "@/components/Seo/BreadcrumbJsonLd";
 import { customMetadata } from "@/utilities/meta";
@@ -16,6 +18,8 @@ export const metadata: Metadata = customMetadata({
   ogType: "article",
 });
 
+const PUBLISHED_AT = getKnowledgeArticleDate("project-profiles-as-resumes");
+
 export default function ProjectProfilesAsResumesPage() {
   return (
     <main className="container mx-auto max-w-3xl px-4 py-12">
@@ -30,8 +34,7 @@ export default function ProjectProfilesAsResumesPage() {
         title={title}
         description={description}
         url="/knowledge/project-profiles-as-resumes"
-        datePublished="2025-01-15"
-        dateModified="2026-03-24"
+        datePublished={PUBLISHED_AT}
       />
       <BreadcrumbJsonLd
         items={[
@@ -41,7 +44,12 @@ export default function ProjectProfilesAsResumesPage() {
         ]}
       />
       <article className="space-y-8">
-        <h1 className="text-3xl font-bold">Project Profiles as a Global Resume for Funded Work</h1>
+        <header className="space-y-2">
+          <h1 className="text-3xl font-bold">
+            Project Profiles as a Global Resume for Funded Work
+          </h1>
+          <ArticlePublishedDate date={PUBLISHED_AT} />
+        </header>
 
         <section className="space-y-4">
           <h2 className="text-xl font-semibold">In one sentence</h2>

--- a/app/knowledge/project-profiles-software-vs-nonsoftware/page.tsx
+++ b/app/knowledge/project-profiles-software-vs-nonsoftware/page.tsx
@@ -1,6 +1,8 @@
 import type { Metadata } from "next";
 import Link from "next/link";
+import { getKnowledgeArticleDate } from "@/app/knowledge/articleDates";
 import { Breadcrumbs } from "@/components/Breadcrumbs";
+import { ArticlePublishedDate } from "@/components/Knowledge/ArticlePublishedDate";
 import { ArticleJsonLd } from "@/components/Seo/ArticleJsonLd";
 import { BreadcrumbJsonLd } from "@/components/Seo/BreadcrumbJsonLd";
 import { customMetadata } from "@/utilities/meta";
@@ -15,6 +17,8 @@ export const metadata: Metadata = customMetadata({
   path: "/knowledge/project-profiles-software-vs-nonsoftware",
   ogType: "article",
 });
+
+const PUBLISHED_AT = getKnowledgeArticleDate("project-profiles-software-vs-nonsoftware");
 
 export default function ProjectProfilesSoftwareVsNonsoftwarePage() {
   return (
@@ -33,8 +37,7 @@ export default function ProjectProfilesSoftwareVsNonsoftwarePage() {
         title={title}
         description={description}
         url="/knowledge/project-profiles-software-vs-nonsoftware"
-        datePublished="2025-01-15"
-        dateModified="2026-03-24"
+        datePublished={PUBLISHED_AT}
       />
       <BreadcrumbJsonLd
         items={[
@@ -47,9 +50,12 @@ export default function ProjectProfilesSoftwareVsNonsoftwarePage() {
         ]}
       />
       <article className="space-y-8">
-        <h1 className="text-3xl font-bold">
-          Project Profiles for Software vs Non-Software Projects
-        </h1>
+        <header className="space-y-2">
+          <h1 className="text-3xl font-bold">
+            Project Profiles for Software vs Non-Software Projects
+          </h1>
+          <ArticlePublishedDate date={PUBLISHED_AT} />
+        </header>
 
         <section className="space-y-4">
           <h2 className="text-xl font-semibold">In one sentence</h2>

--- a/app/knowledge/project-profiles/page.tsx
+++ b/app/knowledge/project-profiles/page.tsx
@@ -1,6 +1,8 @@
 import type { Metadata } from "next";
 import Link from "next/link";
+import { getKnowledgeArticleDate } from "@/app/knowledge/articleDates";
 import { Breadcrumbs } from "@/components/Breadcrumbs";
+import { ArticlePublishedDate } from "@/components/Knowledge/ArticlePublishedDate";
 import { ArticleJsonLd } from "@/components/Seo/ArticleJsonLd";
 import { BreadcrumbJsonLd } from "@/components/Seo/BreadcrumbJsonLd";
 import { customMetadata } from "@/utilities/meta";
@@ -16,6 +18,8 @@ export const metadata: Metadata = customMetadata({
   ogType: "article",
 });
 
+const PUBLISHED_AT = getKnowledgeArticleDate("project-profiles");
+
 export default function ProjectProfilesPage() {
   return (
     <main className="container mx-auto max-w-3xl px-4 py-12">
@@ -30,8 +34,7 @@ export default function ProjectProfilesPage() {
         title={title}
         description={description}
         url="/knowledge/project-profiles"
-        datePublished="2025-01-15"
-        dateModified="2026-03-24"
+        datePublished={PUBLISHED_AT}
       />
       <BreadcrumbJsonLd
         items={[
@@ -41,7 +44,10 @@ export default function ProjectProfilesPage() {
         ]}
       />
       <article className="space-y-8">
-        <h1 className="text-3xl font-bold">What Are Project Profiles for Funded Work?</h1>
+        <header className="space-y-2">
+          <h1 className="text-3xl font-bold">What Are Project Profiles for Funded Work?</h1>
+          <ArticlePublishedDate date={PUBLISHED_AT} />
+        </header>
 
         <section className="space-y-4">
           <h2 className="text-xl font-semibold">In one sentence</h2>

--- a/app/knowledge/project-registry/page.tsx
+++ b/app/knowledge/project-registry/page.tsx
@@ -1,6 +1,8 @@
 import type { Metadata } from "next";
 import Link from "next/link";
+import { getKnowledgeArticleDate } from "@/app/knowledge/articleDates";
 import { Breadcrumbs } from "@/components/Breadcrumbs";
+import { ArticlePublishedDate } from "@/components/Knowledge/ArticlePublishedDate";
 import { ArticleJsonLd } from "@/components/Seo/ArticleJsonLd";
 import { BreadcrumbJsonLd } from "@/components/Seo/BreadcrumbJsonLd";
 import { customMetadata } from "@/utilities/meta";
@@ -16,6 +18,8 @@ export const metadata: Metadata = customMetadata({
   ogType: "article",
 });
 
+const PUBLISHED_AT = getKnowledgeArticleDate("project-registry");
+
 export default function ProjectRegistryPage() {
   return (
     <main className="container mx-auto max-w-3xl px-4 py-12">
@@ -30,8 +34,7 @@ export default function ProjectRegistryPage() {
         title={title}
         description={description}
         url="/knowledge/project-registry"
-        datePublished="2025-01-15"
-        dateModified="2026-03-24"
+        datePublished={PUBLISHED_AT}
       />
       <BreadcrumbJsonLd
         items={[
@@ -41,7 +44,10 @@ export default function ProjectRegistryPage() {
         ]}
       />
       <article className="space-y-8">
-        <h1 className="text-3xl font-bold">Public Project Registries for Funded Work</h1>
+        <header className="space-y-2">
+          <h1 className="text-3xl font-bold">Public Project Registries for Funded Work</h1>
+          <ArticlePublishedDate date={PUBLISHED_AT} />
+        </header>
 
         <section className="space-y-4">
           <h2 className="text-xl font-semibold">In one sentence</h2>

--- a/app/knowledge/project-reputation/page.tsx
+++ b/app/knowledge/project-reputation/page.tsx
@@ -1,6 +1,8 @@
 import type { Metadata } from "next";
 import Link from "next/link";
+import { getKnowledgeArticleDate } from "@/app/knowledge/articleDates";
 import { Breadcrumbs } from "@/components/Breadcrumbs";
+import { ArticlePublishedDate } from "@/components/Knowledge/ArticlePublishedDate";
 import { ArticleJsonLd } from "@/components/Seo/ArticleJsonLd";
 import { BreadcrumbJsonLd } from "@/components/Seo/BreadcrumbJsonLd";
 import { customMetadata } from "@/utilities/meta";
@@ -16,6 +18,8 @@ export const metadata: Metadata = customMetadata({
   ogType: "article",
 });
 
+const PUBLISHED_AT = getKnowledgeArticleDate("project-reputation");
+
 export default function ProjectReputationPage() {
   return (
     <main className="container mx-auto max-w-3xl px-4 py-12">
@@ -30,8 +34,7 @@ export default function ProjectReputationPage() {
         title={title}
         description={description}
         url="/knowledge/project-reputation"
-        datePublished="2025-01-15"
-        dateModified="2026-03-24"
+        datePublished={PUBLISHED_AT}
       />
       <BreadcrumbJsonLd
         items={[
@@ -41,7 +44,10 @@ export default function ProjectReputationPage() {
         ]}
       />
       <article className="space-y-8">
-        <h1 className="text-3xl font-bold">How Projects Build Reputation Through Funding</h1>
+        <header className="space-y-2">
+          <h1 className="text-3xl font-bold">How Projects Build Reputation Through Funding</h1>
+          <ArticlePublishedDate date={PUBLISHED_AT} />
+        </header>
 
         <section className="space-y-4">
           <h2 className="text-xl font-semibold">In one sentence</h2>

--- a/app/knowledge/project-updates-and-reputation/page.tsx
+++ b/app/knowledge/project-updates-and-reputation/page.tsx
@@ -1,6 +1,8 @@
 import type { Metadata } from "next";
 import Link from "next/link";
+import { getKnowledgeArticleDate } from "@/app/knowledge/articleDates";
 import { Breadcrumbs } from "@/components/Breadcrumbs";
+import { ArticlePublishedDate } from "@/components/Knowledge/ArticlePublishedDate";
 import { ArticleJsonLd } from "@/components/Seo/ArticleJsonLd";
 import { BreadcrumbJsonLd } from "@/components/Seo/BreadcrumbJsonLd";
 import { customMetadata } from "@/utilities/meta";
@@ -15,6 +17,8 @@ export const metadata: Metadata = customMetadata({
   path: "/knowledge/project-updates-and-reputation",
   ogType: "article",
 });
+
+const PUBLISHED_AT = getKnowledgeArticleDate("project-updates-and-reputation");
 
 export default function ProjectUpdatesAndReputationPage() {
   return (
@@ -33,8 +37,7 @@ export default function ProjectUpdatesAndReputationPage() {
         title={title}
         description={description}
         url="/knowledge/project-updates-and-reputation"
-        datePublished="2025-01-15"
-        dateModified="2026-03-24"
+        datePublished={PUBLISHED_AT}
       />
       <BreadcrumbJsonLd
         items={[
@@ -47,7 +50,12 @@ export default function ProjectUpdatesAndReputationPage() {
         ]}
       />
       <article className="space-y-8">
-        <h1 className="text-3xl font-bold">How Projects Build Reputation Through Public Updates</h1>
+        <header className="space-y-2">
+          <h1 className="text-3xl font-bold">
+            How Projects Build Reputation Through Public Updates
+          </h1>
+          <ArticlePublishedDate date={PUBLISHED_AT} />
+        </header>
 
         <section className="space-y-4">
           <h2 className="text-xl font-semibold">In one sentence</h2>

--- a/app/knowledge/reputation-compounding/page.tsx
+++ b/app/knowledge/reputation-compounding/page.tsx
@@ -1,6 +1,8 @@
 import type { Metadata } from "next";
 import Link from "next/link";
+import { getKnowledgeArticleDate } from "@/app/knowledge/articleDates";
 import { Breadcrumbs } from "@/components/Breadcrumbs";
+import { ArticlePublishedDate } from "@/components/Knowledge/ArticlePublishedDate";
 import { ArticleJsonLd } from "@/components/Seo/ArticleJsonLd";
 import { BreadcrumbJsonLd } from "@/components/Seo/BreadcrumbJsonLd";
 import { customMetadata } from "@/utilities/meta";
@@ -16,6 +18,8 @@ export const metadata: Metadata = customMetadata({
   ogType: "article",
 });
 
+const PUBLISHED_AT = getKnowledgeArticleDate("reputation-compounding");
+
 export default function ReputationCompoundingPage() {
   return (
     <main className="container mx-auto max-w-3xl px-4 py-12">
@@ -30,8 +34,7 @@ export default function ReputationCompoundingPage() {
         title={title}
         description={description}
         url="/knowledge/reputation-compounding"
-        datePublished="2025-01-15"
-        dateModified="2026-03-24"
+        datePublished={PUBLISHED_AT}
       />
       <BreadcrumbJsonLd
         items={[
@@ -41,7 +44,10 @@ export default function ReputationCompoundingPage() {
         ]}
       />
       <article className="space-y-8">
-        <h1 className="text-3xl font-bold">How Reputation Compounds in Open Funding Systems</h1>
+        <header className="space-y-2">
+          <h1 className="text-3xl font-bold">How Reputation Compounds in Open Funding Systems</h1>
+          <ArticlePublishedDate date={PUBLISHED_AT} />
+        </header>
 
         <section className="space-y-4">
           <h2 className="text-xl font-semibold">In one sentence</h2>

--- a/app/knowledge/whitelabel-funding-platforms/page.tsx
+++ b/app/knowledge/whitelabel-funding-platforms/page.tsx
@@ -1,6 +1,8 @@
 import type { Metadata } from "next";
 import Link from "next/link";
+import { getKnowledgeArticleDate } from "@/app/knowledge/articleDates";
 import { Breadcrumbs } from "@/components/Breadcrumbs";
+import { ArticlePublishedDate } from "@/components/Knowledge/ArticlePublishedDate";
 import { ArticleJsonLd } from "@/components/Seo/ArticleJsonLd";
 import { BreadcrumbJsonLd } from "@/components/Seo/BreadcrumbJsonLd";
 import { customMetadata } from "@/utilities/meta";
@@ -15,6 +17,8 @@ export const metadata: Metadata = customMetadata({
   path: "/knowledge/whitelabel-funding-platforms",
   ogType: "article",
 });
+
+const PUBLISHED_AT = getKnowledgeArticleDate("whitelabel-funding-platforms");
 
 export default function WhitelabelFundingPlatformsPage() {
   return (
@@ -33,8 +37,7 @@ export default function WhitelabelFundingPlatformsPage() {
         title={title}
         description={description}
         url="/knowledge/whitelabel-funding-platforms"
-        datePublished="2025-01-15"
-        dateModified="2026-03-24"
+        datePublished={PUBLISHED_AT}
       />
       <BreadcrumbJsonLd
         items={[
@@ -44,7 +47,10 @@ export default function WhitelabelFundingPlatformsPage() {
         ]}
       />
       <article className="space-y-8">
-        <h1 className="text-3xl font-bold">Whitelabel Funding Platforms for DAO Ecosystems</h1>
+        <header className="space-y-2">
+          <h1 className="text-3xl font-bold">Whitelabel Funding Platforms for DAO Ecosystems</h1>
+          <ArticlePublishedDate date={PUBLISHED_AT} />
+        </header>
 
         <section className="space-y-4">
           <h2 className="text-xl font-semibold">In one sentence</h2>

--- a/app/knowledge/why-grant-programs-fail/page.tsx
+++ b/app/knowledge/why-grant-programs-fail/page.tsx
@@ -1,6 +1,8 @@
 import type { Metadata } from "next";
 import Link from "next/link";
+import { getKnowledgeArticleDate } from "@/app/knowledge/articleDates";
 import { Breadcrumbs } from "@/components/Breadcrumbs";
+import { ArticlePublishedDate } from "@/components/Knowledge/ArticlePublishedDate";
 import { ArticleJsonLd } from "@/components/Seo/ArticleJsonLd";
 import { BreadcrumbJsonLd } from "@/components/Seo/BreadcrumbJsonLd";
 import { customMetadata } from "@/utilities/meta";
@@ -12,6 +14,8 @@ export const metadata: Metadata = customMetadata({
   path: "/knowledge/why-grant-programs-fail",
   ogType: "article",
 });
+
+const PUBLISHED_AT = getKnowledgeArticleDate("why-grant-programs-fail");
 
 export default function WhyGrantProgramsFailPage() {
   return (
@@ -27,8 +31,7 @@ export default function WhyGrantProgramsFailPage() {
         title="Why Most Grant Programs Fail After Funding"
         description="Grant programs fail at post-funding follow-through, not project selection. Learn the structural reasons and how to build systems that learn from outcomes."
         url="/knowledge/why-grant-programs-fail"
-        datePublished="2025-01-15"
-        dateModified="2026-03-24"
+        datePublished={PUBLISHED_AT}
       />
       <BreadcrumbJsonLd
         items={[
@@ -38,7 +41,10 @@ export default function WhyGrantProgramsFailPage() {
         ]}
       />
       <article className="space-y-8">
-        <h1 className="text-3xl font-bold">Why Most Grant Programs Fail After Funding</h1>
+        <header className="space-y-2">
+          <h1 className="text-3xl font-bold">Why Most Grant Programs Fail After Funding</h1>
+          <ArticlePublishedDate date={PUBLISHED_AT} />
+        </header>
 
         <section className="space-y-4">
           <h2 className="text-xl font-semibold">In one sentence</h2>

--- a/app/knowledge/why-grantees-need-project-profiles/page.tsx
+++ b/app/knowledge/why-grantees-need-project-profiles/page.tsx
@@ -1,6 +1,8 @@
 import type { Metadata } from "next";
 import Link from "next/link";
+import { getKnowledgeArticleDate } from "@/app/knowledge/articleDates";
 import { Breadcrumbs } from "@/components/Breadcrumbs";
+import { ArticlePublishedDate } from "@/components/Knowledge/ArticlePublishedDate";
 import { ArticleJsonLd } from "@/components/Seo/ArticleJsonLd";
 import { BreadcrumbJsonLd } from "@/components/Seo/BreadcrumbJsonLd";
 import { customMetadata } from "@/utilities/meta";
@@ -15,6 +17,8 @@ export const metadata: Metadata = customMetadata({
   path: "/knowledge/why-grantees-need-project-profiles",
   ogType: "article",
 });
+
+const PUBLISHED_AT = getKnowledgeArticleDate("why-grantees-need-project-profiles");
 
 export default function WhyGranteesNeedProjectProfilesPage() {
   return (
@@ -33,8 +37,7 @@ export default function WhyGranteesNeedProjectProfilesPage() {
         title={title}
         description={description}
         url="/knowledge/why-grantees-need-project-profiles"
-        datePublished="2025-01-15"
-        dateModified="2026-03-24"
+        datePublished={PUBLISHED_AT}
       />
       <BreadcrumbJsonLd
         items={[
@@ -47,7 +50,10 @@ export default function WhyGranteesNeedProjectProfilesPage() {
         ]}
       />
       <article className="space-y-8">
-        <h1 className="text-3xl font-bold">Why Grantees Need Project Profiles</h1>
+        <header className="space-y-2">
+          <h1 className="text-3xl font-bold">Why Grantees Need Project Profiles</h1>
+          <ArticlePublishedDate date={PUBLISHED_AT} />
+        </header>
 
         <section className="space-y-4">
           <h2 className="text-xl font-semibold">In one sentence</h2>

--- a/components/Knowledge/ArticlePublishedDate.tsx
+++ b/components/Knowledge/ArticlePublishedDate.tsx
@@ -1,0 +1,21 @@
+import { formatDate } from "@/utilities/formatDate";
+
+interface ArticlePublishedDateProps {
+  /** Publication date as `YYYY-MM-DD` (UTC), from `app/knowledge/articleDates.ts`. */
+  date: string;
+}
+
+/**
+ * Renders the visible publication line for a knowledge-base article.
+ *
+ * Knowledge pages emit `datePublished` in their Article JSON-LD; this keeps that
+ * fact visible on the page, so the structured data never claims something a
+ * reader cannot see.
+ */
+export function ArticlePublishedDate({ date }: ArticlePublishedDateProps) {
+  return (
+    <p className="text-sm text-gray-500 dark:text-gray-400">
+      Published <time dateTime={date}>{formatDate(date, "UTC")}</time>
+    </p>
+  );
+}


### PR DESCRIPTION
## Overview

Replaces the fabricated `datePublished` / `dateModified` values on the 25 static knowledge-base articles with dates taken from each page's first commit, and surfaces that date to readers.

Part of DEV-583 (AEO improvements). Resolves DEV-591 (AEO-08).

## Problem

Every page under `app/knowledge/` shipped the exact same two dates in its Article JSON-LD:

```tsx
datePublished="2025-01-15"
dateModified="2026-03-24"
```

Neither is true:

- The pages were added to the repository in January **2026**, not January 2025, so `datePublished` predates the articles by a year.
- `dateModified="2026-03-24"` is a copy-pasted literal, not a record of any edit. It claims freshness on 25 pages that were never revised, and it goes stale the moment nobody hand-bumps it.
- Both dates were invisible to readers — they existed only inside the structured data. Asserting a fact in JSON-LD that appears nowhere in the rendered content is exactly the pattern search engines treat as untrustworthy markup.

## Solution

**One provenance map, sourced from git.** `app/knowledge/articleDates.ts` records the UTC calendar date of the commit that first added each page. These articles are not CMS-backed (unlike `/blog/[slug]`, which carries Sanity's `publishedAt`), so the introducing commit is the only truthful per-article record. Dates were recovered from the GitHub commits API rather than a local `git log`, because clones of this repo are frequently shallow and grafted commits report every file as newly added. The three source commits and the exact query are documented in the file header.

**Unknown slugs fail loudly.** `getKnowledgeArticleDate(slug)` throws for an unrecorded slug, and each page calls it at module scope — so adding a knowledge page without recording its date breaks the build instead of silently shipping a missing or invented date.

**No `dateModified` at all.** Deriving one from git last-touch dates would fabricate freshness, since those timestamps are dominated by merges and mechanical reformatting. This matches the existing decision to keep `lastModified` off these routes in `app/sitemaps/static/sitemap.ts`. `ArticleJsonLd` already omits the key when the prop is absent, so the emitted schema simply has no `dateModified`.

**The date is visible.** `components/Knowledge/ArticlePublishedDate.tsx` renders `Published <time dateTime="…">Jan 6, 2026</time>` in a `<header>` beside each `<h1>`, using the shared `formatDate` helper pinned to UTC so the rendered day never drifts by timezone. The structured data and the page now assert the same fact.

## Testing steps

Automated:

```bash
pnpm vitest run --project unit \
  __tests__/integration/pages/knowledge-article-dates.test.tsx \
  __tests__/components/Seo/ArticleJsonLd.test.tsx --reporter=dot
```

19 tests, all passing. They cover:

- the date map has an entry for every directory under `app/knowledge/` and no orphan entries;
- recorded dates are plausible past dates and are not the two previously fabricated literals;
- `getKnowledgeArticleDate` throws for an unrecorded slug;
- no page source reintroduces a hardcoded date literal or a `dateModified` prop;
- each rendered page emits the recorded `datePublished`, emits no `dateModified`, and shows the same date in its server-rendered markup;
- `ArticleJsonLd` includes or omits each date key according to the props supplied.

Also run: `pnpm typecheck` (clean) and `pnpm biome check` over the changed paths (clean).

Manual:

1. `pnpm run dev`, open `/knowledge/grant-lifecycle`. A "Published Jan 6, 2026" line appears under the title.
2. View source and find the `application/ld+json` Article block: `datePublished` matches the visible date and there is no `dateModified` key.
3. Spot-check a page from each source commit — `/knowledge/grant-kyc` (Jan 7) and `/knowledge/onchain-project-profiles` (Jan 14) — to confirm dates differ per article rather than being uniform.

## Risk / scope notes

- Scope is limited to the static `app/knowledge/` routes. `/blog/[slug]` and other `ArticleJsonLd` callers are untouched; the component's props are unchanged and both date props remain optional.
- Search impact is the intended one: these pages lose a `dateModified` signal they were never entitled to, and gain a `datePublished` that matches both reality and the visible page. Rendering-wise the only change is one line of text per article.
- The throwing lookup is deliberate. It runs at module scope during build, so a missing entry surfaces as a build failure rather than a runtime error for users.
- Backfilling a real `dateModified` later remains possible, but it should come from an explicit editorial record (a per-article "last reviewed" field maintained by whoever edits the copy), not from git metadata.
