### PR TITLE
feat(seo): server-render and hydrate funding program details

### DIFF
--- a/__tests__/app/program-detail-ssr.test.tsx
+++ b/__tests__/app/program-detail-ssr.test.tsx
@@ -1,0 +1,204 @@
+/**
+ * AEO acceptance tests for the funding-program detail route (DEV-585).
+ *
+ * These URLs ship in the funding-programs sitemap, so the core facts have to be
+ * in the server-rendered HTML rather than behind a client fetch. Every test
+ * here renders through `react-dom/server`'s `renderToString`, which runs no
+ * effects — whatever it produces is exactly what a crawler or a reader with
+ * JavaScript disabled receives.
+ */
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type React from "react";
+import { renderToString } from "react-dom/server";
+import type { FundingProgram } from "@/types/whitelabel-entities";
+import { HttpError } from "@/utilities/api/errors";
+
+const mockGet = vi.fn();
+
+vi.mock("@/utilities/api/client", () => ({
+  api: {
+    get: (...args: unknown[]) => mockGet(...args),
+    post: vi.fn(),
+    put: vi.fn(),
+    patch: vi.fn(),
+    delete: vi.fn(),
+    request: vi.fn(),
+    getPaginated: vi.fn(),
+  },
+}));
+
+vi.mock("next/navigation", () => ({
+  useParams: () => ({ communityId: "c1", programId: "prog-1" }),
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn() }),
+  usePathname: () => "/community/c1/programs/prog-1",
+}));
+
+// The real provider depends on the Privy bridge, which has no server-side
+// equivalent. Guest defaults (`isLoading: true`) are what actually resolves
+// during SSR, so mirror them rather than granting permissions.
+vi.mock("@/src/core/rbac/context/permission-context", () => ({
+  PermissionProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  usePermissionContext: () => ({
+    isLoading: true,
+    isCommunityAdmin: false,
+    isReviewer: false,
+    can: () => false,
+  }),
+}));
+
+vi.mock("@/src/components/navigation/Link", () => ({
+  Link: ({ children, ...props }: { children: React.ReactNode } & Record<string, unknown>) => (
+    <a {...(props as React.AnchorHTMLAttributes<HTMLAnchorElement>)}>{children}</a>
+  ),
+}));
+
+vi.mock("next-themes", () => ({
+  useTheme: () => ({ resolvedTheme: "light", theme: "light", setTheme: vi.fn() }),
+}));
+
+const PROGRAM_DESCRIPTION =
+  "Funding for open-source public goods teams building on the Celo network.";
+
+function createMockProgram(overrides: Partial<FundingProgram> = {}): FundingProgram {
+  return {
+    programId: "prog-1",
+    chainID: 42220,
+    name: "Public Goods Fund",
+    communitySlug: "celo",
+    metadata: {
+      title: "Public Goods Fund",
+      description: PROGRAM_DESCRIPTION,
+      startsAt: "2099-01-01T00:00:00.000Z",
+      endsAt: "2099-12-31T00:00:00.000Z",
+      programBudget: "500000",
+      minGrantSize: "5000",
+      maxGrantSize: "50000",
+      grantTypes: ["Infrastructure", "Research"],
+    },
+    applicationConfig: {
+      isEnabled: true,
+      formSchema: {
+        title: "Apply",
+        fields: [{ id: "f1", label: "Name", type: "text", required: true }],
+      },
+    },
+    ...overrides,
+  } as FundingProgram;
+}
+
+async function renderPageToHtml(): Promise<string> {
+  const { default: Page } = await import(
+    "@/app/community/[communityId]/(whitelabel)/programs/[programId]/page"
+  );
+  const ui = await Page({ params: Promise.resolve({ communityId: "c1", programId: "prog-1" }) });
+  // A fresh client per render, mirroring the per-request client the app
+  // provider creates — nothing is carried over between tests.
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return renderToString(<QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("funding-program detail page — server-rendered content", () => {
+  it("renders title, status, description and key facts without client JavaScript", async () => {
+    mockGet.mockResolvedValue(createMockProgram());
+
+    const html = await renderPageToHtml();
+
+    // Title
+    expect(html).toContain("Public Goods Fund");
+    // Status — stated in the body, not merely implied by the apply button
+    expect(html).toContain("Coming Soon");
+    // Description
+    expect(html).toContain(PROGRAM_DESCRIPTION);
+    // Key facts from the details sidebar
+    expect(html).toContain("Program Budget");
+    expect(html).toContain("$500,000");
+    expect(html).toContain("Funding Range");
+    expect(html).toContain("$5,000 - $50,000");
+    expect(html).toContain("Grant Types");
+    expect(html).toContain("Infrastructure");
+    expect(html).toContain("Starts");
+    expect(html).toContain("Jan 1, 2099");
+    expect(html).toContain("Ends");
+    expect(html).toContain("Dec 31, 2099");
+
+    // No loading skeleton — the content is real, not a placeholder.
+    expect(html).not.toContain("animate-pulse");
+  });
+
+  it("serves the hydrated program without a second fetch on the client", async () => {
+    mockGet.mockResolvedValue(createMockProgram());
+
+    await renderPageToHtml();
+
+    // One server-side fetch, deduped across generateMetadata and the render
+    // path by React.cache. The hydrated entry is inside its staleTime, so the
+    // client mounts against cached data instead of refetching.
+    expect(mockGet).toHaveBeenCalledTimes(1);
+    expect(mockGet).toHaveBeenCalledWith("/v2/funding-program-configs/prog-1", {
+      isAuthorized: false,
+    });
+  });
+
+  it("renders the open-for-applications status for a live program", async () => {
+    mockGet.mockResolvedValue(
+      createMockProgram({
+        metadata: {
+          title: "Live Program",
+          description: PROGRAM_DESCRIPTION,
+          startsAt: "2020-01-01T00:00:00.000Z",
+          endsAt: "2099-12-31T00:00:00.000Z",
+        },
+      })
+    );
+
+    const html = await renderPageToHtml();
+
+    expect(html).toContain("Live Program");
+    expect(html).toContain("Open for Applications");
+  });
+
+  it("renders the closed status and disabled apply copy for a disabled program", async () => {
+    mockGet.mockResolvedValue(
+      createMockProgram({
+        applicationConfig: {
+          isEnabled: false,
+          formSchema: { title: "Apply", fields: [] },
+        } as FundingProgram["applicationConfig"],
+      })
+    );
+
+    const html = await renderPageToHtml();
+
+    expect(html).toContain("Applications Closed");
+    expect(html).toContain("Applications are currently closed");
+  });
+
+  it("renders the not-found state server-side when the indexer returns 404", async () => {
+    mockGet.mockRejectedValue(
+      new HttpError(404, { endpoint: "/v2/funding-program-configs/prog-1", method: "GET" })
+    );
+
+    const html = await renderPageToHtml();
+
+    expect(html).toContain("Program not found");
+    expect(html).not.toContain("animate-pulse");
+  });
+
+  it("falls back to the client fetch path when the indexer fails", async () => {
+    mockGet.mockRejectedValue(
+      new HttpError(500, { endpoint: "/v2/funding-program-configs/prog-1", method: "GET" })
+    );
+
+    const html = await renderPageToHtml();
+
+    // A transient upstream failure must never be hydrated as a definitive
+    // "Program not found" — the page degrades to the skeleton and the client
+    // retries.
+    expect(html).toContain("animate-pulse");
+    expect(html).not.toContain("Program not found");
+  });
+});

--- a/__tests__/integration/pages/smoke/whitelabel-pages.test.tsx
+++ b/__tests__/integration/pages/smoke/whitelabel-pages.test.tsx
@@ -67,6 +67,13 @@ vi.mock("@/utilities/queries/v2/getCommunityData", () => ({
 
 vi.mock("@/utilities/funding-programs", () => ({
   isProgramEnabled: () => true,
+  getProgramStatusInfo: () => ({
+    status: "open",
+    label: "Open for Applications",
+    color: "success",
+    dotColor: "bg-green-600",
+    endsSoon: false,
+  }),
 }));
 
 vi.mock("@/utilities/community-flags", () => ({

--- a/__tests__/integration/pages/smoke/whitelabel-pages.test.tsx
+++ b/__tests__/integration/pages/smoke/whitelabel-pages.test.tsx
@@ -284,9 +284,36 @@ describe("Whitelabel programs/[programId]/apply page", () => {
   });
 });
 
-describe("Whitelabel programs/[programId] client page", () => {
-  it("/programs/[programId] renders loading state when useProgram is loading", async () => {
+describe("Whitelabel programs/[programId] page", () => {
+  // The page is an async server component that prefetches the program and
+  // hands it to the client tree as a hydrated React Query entry, so it is
+  // driven the same way as the other server components in this file.
+  const importProgramPage = async () => {
+    vi.doMock("next/navigation", () => ({
+      useParams: () => ({ communityId: "c1", programId: "prog-1" }),
+    }));
+    vi.resetModules();
+    return import("@/app/community/[communityId]/(whitelabel)/programs/[programId]/page");
+  };
+
+  afterEach(() => {
+    vi.doUnmock("@/features/programs/hooks/use-program");
+    vi.doUnmock("next/navigation");
+  });
+
+  it("/programs/[programId] renders the prefetched program instead of a skeleton", async () => {
+    const { default: Page } = await importProgramPage();
+    const result = await Page({
+      params: Promise.resolve({ communityId: "c1", programId: "prog-1" }),
+    });
+    const { container } = renderInQueryClient(result);
+    expect(screen.getByRole("heading", { name: "Test Program" })).toBeInTheDocument();
+    expect(container.querySelector(".animate-pulse")).toBeNull();
+  });
+
+  it("/programs/[programId] still renders the loading skeleton while the client fetches", async () => {
     vi.doMock("@/features/programs/hooks/use-program", () => ({
+      PROGRAM_DETAIL_STALE_TIME: 5 * 60 * 1000,
       useProgram: () => ({
         program: null,
         loading: true,
@@ -294,17 +321,12 @@ describe("Whitelabel programs/[programId] client page", () => {
         refetch: vi.fn(),
       }),
     }));
-    vi.doMock("next/navigation", () => ({
-      useParams: () => ({ communityId: "c1", programId: "prog-1" }),
-    }));
-    vi.resetModules();
-    const { default: Page } = await import(
-      "@/app/community/[communityId]/(whitelabel)/programs/[programId]/page"
-    );
-    const { container } = renderInQueryClient(<Page />);
+    const { default: Page } = await importProgramPage();
+    const result = await Page({
+      params: Promise.resolve({ communityId: "c1", programId: "prog-1" }),
+    });
+    const { container } = renderInQueryClient(result);
     expect(container.querySelector(".animate-pulse")).not.toBeNull();
-    vi.doUnmock("@/features/programs/hooks/use-program");
-    vi.doUnmock("next/navigation");
   });
 });
 

--- a/__tests__/integration/pages/smoke/whitelabel-pages.test.tsx
+++ b/__tests__/integration/pages/smoke/whitelabel-pages.test.tsx
@@ -85,6 +85,11 @@ vi.mock("@/utilities/indexer", () => ({
     KYC: {
       GET_CONFIG: (id: string) => `/communities/${id}/kyc/config`,
     },
+    V2: {
+      FUNDING_PROGRAMS: {
+        GET: (programId: string) => `/v2/funding-program-configs/${programId}`,
+      },
+    },
   },
 }));
 

--- a/__tests__/lib/query-keys.test.ts
+++ b/__tests__/lib/query-keys.test.ts
@@ -79,4 +79,23 @@ describe("wlQueryKeys.programs", () => {
       wlQueryKeys.programs.list("arbitrum", "0xdef")
     );
   });
+
+  // The server prefetch in programs/[programId]/page.tsx and the client
+  // `useProgram` hook both build their key from this factory — the hydrated
+  // cache entry is only picked up when the two hashes match, so the shape is
+  // pinned here.
+  it("detail returns the ['wl-program', programId] key shared with the server prefetch", () => {
+    expect(wlQueryKeys.programs.detail("prog-1")).toEqual(["wl-program", "prog-1"]);
+  });
+
+  it("detail keys differ per program", () => {
+    expect(wlQueryKeys.programs.detail("prog-1")).not.toEqual(
+      wlQueryKeys.programs.detail("prog-2")
+    );
+  });
+
+  it("detail and list keys have different prefixes", () => {
+    expect(wlQueryKeys.programs.detail("prog-1")[0]).toBe("wl-program");
+    expect(wlQueryKeys.programs.list("optimism")[0]).toBe("wl-programs-list");
+  });
 });

--- a/app/community/[communityId]/(whitelabel)/programs/[programId]/ProgramDetailClient.tsx
+++ b/app/community/[communityId]/(whitelabel)/programs/[programId]/ProgramDetailClient.tsx
@@ -8,7 +8,8 @@ import { ProgramDetailsSidebar } from "@/features/programs/components/ProgramDet
 import { useProgram } from "@/features/programs/hooks/use-program";
 import { Link } from "@/src/components/navigation/Link";
 import { PermissionProvider } from "@/src/core/rbac/context/permission-context";
-import { isProgramEnabled } from "@/utilities/funding-programs";
+import { getProgramStatusInfo, isProgramEnabled } from "@/utilities/funding-programs";
+import { cn } from "@/utilities/tailwind";
 
 function ProgramDetailContent() {
   const { communityId, programId } = useParams<{
@@ -81,6 +82,7 @@ function ProgramDetailContent() {
   }
 
   const isEnabled = isProgramEnabled(program);
+  const statusInfo = getProgramStatusInfo(program);
   const description = program.metadata?.description || "No description available";
 
   return (
@@ -112,6 +114,13 @@ function ProgramDetailContent() {
           <h1 className="mb-2 text-3xl font-bold text-foreground">
             {program.metadata?.title || program.name}
           </h1>
+
+          {/* Application status — stated in the page body, not just implied by
+              the sidebar's apply button, so it survives with JS disabled. */}
+          <p className="mb-4 inline-flex items-center gap-2 rounded-full bg-muted px-3 py-1 text-sm font-medium text-foreground">
+            <span className={cn("h-2 w-2 rounded-full", statusInfo.dotColor)} aria-hidden="true" />
+            {statusInfo.label}
+          </p>
 
           {/* Byline */}
           {program.communitySlug ? (

--- a/app/community/[communityId]/(whitelabel)/programs/[programId]/page.tsx
+++ b/app/community/[communityId]/(whitelabel)/programs/[programId]/page.tsx
@@ -62,9 +62,12 @@ export async function generateMetadata({ params }: { params: Params }): Promise<
     ? `/programs/${programId}`
     : `/community/${communityId}/programs/${programId}`;
 
-  // Metadata degrades to generic copy on any fetch failure — the canonical
-  // above does not depend on the program body.
-  const program = await getProgramDetails(programId).catch(() => null);
+  const program = await getProgramDetails(programId).catch(() => {
+    // SUPPRESSED: metadata must still render when the indexer is unavailable.
+    // The canonical above does not depend on the program body, so the page
+    // degrades to generic copy rather than failing the whole route.
+    return null;
+  });
   const programName = program?.metadata?.title || program?.name || "Funding Program";
   const description =
     cleanMarkdownForPlainText(

--- a/app/community/[communityId]/(whitelabel)/programs/[programId]/page.tsx
+++ b/app/community/[communityId]/(whitelabel)/programs/[programId]/page.tsx
@@ -1,11 +1,17 @@
+import { dehydrate, HydrationBoundary, QueryClient } from "@tanstack/react-query";
 import type { Metadata } from "next";
 import { cache } from "react";
 import { PROJECT_NAME } from "@/constants/brand";
+import { PROGRAM_DETAIL_STALE_TIME } from "@/features/programs/hooks/use-program";
+import { wlQueryKeys } from "@/src/lib/query-keys";
 import type { FundingProgram } from "@/types/whitelabel-entities";
 import { api } from "@/utilities/api/client";
+import { HttpError } from "@/utilities/api/errors";
 import { envVars } from "@/utilities/enviromentVars";
+import { INDEXER } from "@/utilities/indexer";
 import { cleanMarkdownForPlainText } from "@/utilities/markdown";
 import { DEFAULT_DESCRIPTION, SITE_URL, twitterMeta } from "@/utilities/meta";
+import { defaultQueryOptions } from "@/utilities/queries/defaultOptions";
 import { getWhitelabelContext } from "@/utilities/whitelabel-server";
 import ProgramDetailClient from "./ProgramDetailClient";
 
@@ -20,20 +26,27 @@ type Params = Promise<{
   programId: string;
 }>;
 
-// Server-side program fetch for metadata only. Public endpoint (isAuthorized
-// false) — these pages ship in the funding-programs sitemap. Reuses fetchData
-// (base-URL resolution + error shaping) and React.cache, matching the sibling
-// apply/ route. A failed fetch falls back to generic copy — the canonical
-// below does not depend on it.
+// Server-side program fetch, shared by generateMetadata and the render-path
+// prefetch below (React.cache makes that one indexer round-trip, not two).
+// Public endpoint (isAuthorized false) — these pages ship in the
+// funding-programs sitemap.
+//
+// The 404-vs-everything-else split mirrors `useProgram` exactly: a missing
+// program resolves to null (the client renders its not-found empty state),
+// anything else throws so a transient indexer 5xx is never hydrated into the
+// client cache as a false "Program not found".
 const getProgramDetails = cache(async (programId: string): Promise<FundingProgram | null> => {
   try {
     // TODO(#1775): add zod schema
     return await api.get<FundingProgram>(
-      `/v2/funding-program-configs/${encodeURIComponent(programId)}`,
+      INDEXER.V2.FUNDING_PROGRAMS.GET(encodeURIComponent(programId)),
       { isAuthorized: false }
     );
-  } catch {
-    return null;
+  } catch (err) {
+    if (err instanceof HttpError && err.status === 404) {
+      return null;
+    }
+    throw err;
   }
 });
 
@@ -49,7 +62,9 @@ export async function generateMetadata({ params }: { params: Params }): Promise<
     ? `/programs/${programId}`
     : `/community/${communityId}/programs/${programId}`;
 
-  const program = await getProgramDetails(programId);
+  // Metadata degrades to generic copy on any fetch failure — the canonical
+  // above does not depend on the program body.
+  const program = await getProgramDetails(programId).catch(() => null);
   const programName = program?.metadata?.title || program?.name || "Funding Program";
   const description =
     cleanMarkdownForPlainText(
@@ -83,6 +98,33 @@ export async function generateMetadata({ params }: { params: Params }): Promise<
   };
 }
 
-export default function ProgramDetailPage() {
-  return <ProgramDetailClient />;
+// The program body is prefetched here and handed to the client tree as a
+// hydrated React Query cache entry, so the title, status, description and
+// sidebar facts are in the initial HTML instead of behind a client fetch —
+// crawlers and no-JS readers see the real page, not the loading skeleton.
+//
+// `prefetchQuery` swallows a rejected fetch and `dehydrate` omits failed
+// queries, so an indexer outage degrades to exactly today's behaviour: the
+// client fetches and shows the skeleton. `retry: false` keeps a failing
+// prefetch from blocking the response on React Query's backoff — the client
+// still retries under its own defaults.
+export default async function ProgramDetailPage({ params }: { params: Params }) {
+  const { programId } = await params;
+
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: defaultQueryOptions },
+  });
+
+  await queryClient.prefetchQuery({
+    queryKey: wlQueryKeys.programs.detail(programId),
+    queryFn: () => getProgramDetails(programId),
+    staleTime: PROGRAM_DETAIL_STALE_TIME,
+    retry: false,
+  });
+
+  return (
+    <HydrationBoundary state={dehydrate(queryClient)}>
+      <ProgramDetailClient />
+    </HydrationBoundary>
+  );
 }

--- a/src/features/programs/hooks/use-program.ts
+++ b/src/features/programs/hooks/use-program.ts
@@ -1,16 +1,27 @@
 import { useQuery } from "@tanstack/react-query";
+import { wlQueryKeys } from "@/src/lib/query-keys";
 import type { FundingProgram } from "@/types/whitelabel-entities";
 import { api } from "@/utilities/api/client";
 import { HttpError } from "@/utilities/api/errors";
+import { INDEXER } from "@/utilities/indexer";
 import type { UseProgramReturn } from "../types";
+
+/**
+ * Shared with the server prefetch in `programs/[programId]/page.tsx`. The
+ * hydrated cache entry is only considered fresh — and therefore not refetched
+ * on mount — while both sides agree on this window.
+ */
+export const PROGRAM_DETAIL_STALE_TIME = 5 * 60 * 1000;
 
 export function useProgram(programId: string): UseProgramReturn {
   const { data, isLoading, error, refetch } = useQuery({
-    queryKey: ["wl-program", programId],
+    queryKey: wlQueryKeys.programs.detail(programId),
     queryFn: async () => {
       // TODO(#1775): add zod schema
       try {
-        return await api.get<FundingProgram>(`/v2/funding-program-configs/${programId}`);
+        return await api.get<FundingProgram>(
+          INDEXER.V2.FUNDING_PROGRAMS.GET(encodeURIComponent(programId))
+        );
       } catch (err) {
         // A missing program is an expected "not found" outcome, not a
         // failure — resolve to null so the component renders its
@@ -22,7 +33,7 @@ export function useProgram(programId: string): UseProgramReturn {
       }
     },
     enabled: !!programId,
-    staleTime: 5 * 60 * 1000,
+    staleTime: PROGRAM_DETAIL_STALE_TIME,
   });
 
   return {

--- a/src/lib/query-keys.ts
+++ b/src/lib/query-keys.ts
@@ -36,5 +36,11 @@ export const wlQueryKeys = {
      */
     list: (communityId: string, address?: string | null) =>
       ["wl-programs-list", communityId, address ?? null] as const,
+    /**
+     * A single funding program. Shared by the server prefetch in
+     * `programs/[programId]/page.tsx` and the client `useProgram` hook — the
+     * hydrated cache entry only lands if both sides produce the same key.
+     */
+    detail: (programId: string) => ["wl-program", programId] as const,
   },
 };


### PR DESCRIPTION
## Overview

Server-renders the whitelabel funding-program detail route (`/community/[communityId]/programs/[programId]` and its whitelabel-domain equivalent) so the program's core facts are in the initial HTML instead of behind a client fetch.

Part of DEV-583 (AEO improvements); implements DEV-585 / AEO-02.

## Problem

The route's `page.tsx` was a thin sync server component that rendered `ProgramDetailClient` and nothing else. Everything a reader cares about — title, description, budget, funding range, grant types, dates — was fetched client-side by `useProgram`, so the server response contained only a `animate-pulse` skeleton.

These URLs ship in the funding-programs sitemap, which means:

- crawlers and answer engines that do not execute JavaScript index a placeholder, not the program;
- a reader with JS disabled or still loading sees a skeleton for the full round-trip;
- the server was already fetching the same program in `generateMetadata` and throwing the body away after reading the title and description.

Separately, whether applications are open, closed, or not yet started was only *implied* by the sidebar's apply button. There was no statement of the status anywhere in the page copy.

## Solution

**Prefetch and hydrate.** `page.tsx` is now an async server component that prefetches the program into a `QueryClient` and hands it to the client tree through a `HydrationBoundary`. The fetch is the same `React.cache`-wrapped `getProgramDetails` that `generateMetadata` calls, so it stays one indexer round-trip per request rather than two.

**Shared key and freshness window.** The prefetch and `useProgram` now build their key from `wlQueryKeys.programs.detail(programId)` and share an exported `PROGRAM_DETAIL_STALE_TIME`. A hydrated entry is only picked up when both hashes match and it is inside its stale time, so both are pinned in `__tests__/lib/query-keys.test.ts`.

**Error handling mirrors the hook.** The server fetch previously collapsed every failure to `null`. It now returns `null` only on a 404 and rethrows anything else, so a transient indexer 5xx is never hydrated into the client cache as a definitive "Program not found". `prefetchQuery` swallows the rejection and `dehydrate` omits failed queries, so an indexer outage degrades to exactly today's behaviour: skeleton plus a client retry. `retry: false` keeps a failing prefetch from blocking the response on React Query's backoff. `generateMetadata` keeps its own `.catch(() => null)` and still degrades to generic copy.

**Status is stated, not implied.** `ProgramDetailClient` renders `getProgramStatusInfo(program).label` as a pill next to the title, so "Open for Applications" / "Applications Closed" / "Coming Soon" is real text in the body. No structured-data or metadata fact is added that is not visible in the rendered content.

The endpoint path in both the server fetch and the hook now comes from `INDEXER.V2.FUNDING_PROGRAMS.GET` instead of being written inline.

Three commits: the key/endpoint refactor, the status pill, then the SSR change.

## Testing steps

Automated:

```bash
pnpm vitest run --project unit __tests__/app/program-detail-ssr.test.tsx --reporter=dot
pnpm vitest run --project unit __tests__/lib/query-keys.test.ts --reporter=dot
pnpm vitest run --project unit __tests__/integration/pages/smoke/whitelabel-pages.test.tsx --reporter=dot
pnpm typecheck
```

`__tests__/app/program-detail-ssr.test.tsx` is the acceptance suite. It renders the page through `react-dom/server`'s `renderToString`, which runs no effects — whatever it asserts on is literally what a no-JS client receives. It covers:

- title, status, description, budget, funding range, grant types and both dates present, with no `animate-pulse` in the output;
- exactly one indexer call across `generateMetadata` and the render path;
- open / closed / coming-soon status copy;
- a 404 rendering the not-found state server-side;
- a 500 degrading to the skeleton and *not* to "Program not found".

Manual:

1. `pnpm run dev`, open a community program detail page.
2. `curl` the same URL (or view-source) and confirm the program title, status label, description and sidebar facts are in the HTML payload.
3. Disable JavaScript and reload — the page content is there, only the interactive controls are inert.
4. Confirm no client request to `/v2/funding-program-configs/:id` fires on first load (the hydrated entry is fresh); a hard reload after 5 minutes refetches as before.

## Risk / scope notes

- Scoped to one route plus the program detail query key. `useProgram` behaviour is unchanged apart from the shared constants — its consumers see the same return shape.
- The page now awaits an indexer call before responding. It was already awaiting the same call in `generateMetadata`, and `React.cache` dedupes them, so TTFB is unchanged in the happy path.
- Failure mode is a strict superset of today's: prefetch failures are dropped from the dehydrated state and the client fetches exactly as it does on `main`.
- `getProgramDetails` is stricter than before (rethrows non-404s). That error surfaces inside `prefetchQuery`, which catches it; `generateMetadata` catches it explicitly. Neither path can now produce an unhandled rejection.
- The status pill is additive UI above the byline; no existing element moved or changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Funding program detail pages now render program information on the initial page load when available, reducing reliance on loading placeholders.
  - Program status is displayed prominently, including “Open for Applications” and “Applications Closed.”
  - Program details are reused between initial loading and subsequent interactions for a smoother experience.

- **Bug Fixes**
  - Missing programs now show a clear “Program not found” state.
  - Temporary service errors gracefully fall back to the existing loading experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->