### PR TITLE
feat(seo): server-render community project entities

### DIFF
--- a/__tests__/app/ssr-server-components.test.tsx
+++ b/__tests__/app/ssr-server-components.test.tsx
@@ -43,15 +43,21 @@ vi.mock("@/components/CommunityGrants", () => ({
     communityUid,
     categoriesOptions,
     initialProjects,
+    initialPage,
+    paginationBasePath,
   }: {
     communityUid: string;
     categoriesOptions: string[];
     initialProjects: { payload: unknown[] };
+    initialPage?: number;
+    paginationBasePath: string;
   }) => (
     <div data-testid="community-grants">
       <span data-testid="community-uid">{communityUid}</span>
       <span data-testid="categories-count">{categoriesOptions.length}</span>
       <span data-testid="projects-count">{initialProjects.payload.length}</span>
+      <span data-testid="initial-page">{initialPage}</span>
+      <span data-testid="pagination-base-path">{paginationBasePath}</span>
     </div>
   ),
 }));
@@ -158,6 +164,7 @@ describe("SSR Server Components", () => {
       const CommunityProjectsPage = await importPage();
       const jsx = await CommunityProjectsPage({
         params: Promise.resolve({ communityId: "test-community" }),
+        searchParams: Promise.resolve({}),
       });
 
       render(jsx);
@@ -170,6 +177,80 @@ describe("SSR Server Components", () => {
 
       // Verify projects were fetched
       expect(screen.getByTestId("projects-count")).toHaveTextContent("1");
+    });
+
+    /**
+     * The seed is only usable if the server asks the indexer for exactly what
+     * the client's first query would ask for. Pins page/limit/sortBy on the wire
+     * (the server used to omit sortBy while the client sent sortBy=milestones)
+     * and the ?page= pass-through that makes the crawlable links resolvable.
+     */
+    const renderProjectsPageCapturingIndexerUrl = async (
+      searchParams: Record<string, string | string[] | undefined>
+    ) => {
+      const community = createMockCommunity({
+        uid: "0xpagedcommunity" as `0x${string}`,
+        details: { name: "Paged Community", slug: "paged-community" },
+      });
+      let projectsRequestUrl = "";
+
+      server.use(
+        http.get(`${BASE}/v2/communities/:slug`, () => HttpResponse.json(community)),
+        http.get(`${BASE}/communities/:slug/categories`, () => HttpResponse.json([])),
+        http.get(`${BASE}/v2/communities/:slug/projects`, ({ request }) => {
+          projectsRequestUrl = request.url;
+          return HttpResponse.json({
+            payload: [createMockProject({ details: { title: "Paged", slug: "paged" } })],
+            pagination: {
+              totalCount: 24,
+              page: 1,
+              limit: 12,
+              totalPages: 2,
+              nextPage: 2,
+              prevPage: null,
+              hasNextPage: true,
+              hasPrevPage: false,
+            },
+          });
+        })
+      );
+
+      const CommunityProjectsPage = await importPage();
+      const jsx = await CommunityProjectsPage({
+        params: Promise.resolve({ communityId: "paged-community" }),
+        searchParams: Promise.resolve(searchParams),
+      });
+      render(jsx);
+
+      return new URL(projectsRequestUrl).searchParams;
+    };
+
+    it("fetches page 1 with the explicit default sort when no page param is present", async () => {
+      const query = await renderProjectsPageCapturingIndexerUrl({});
+
+      expect(query.get("page")).toBe("1");
+      expect(query.get("limit")).toBe("12");
+      expect(query.get("sortBy")).toBe("milestones");
+      expect(screen.getByTestId("initial-page")).toHaveTextContent("1");
+      expect(screen.getByTestId("pagination-base-path")).toHaveTextContent(
+        "/community/paged-community/projects"
+      );
+    });
+
+    it("forwards ?page=2 to the indexer and to CommunityGrants", async () => {
+      const query = await renderProjectsPageCapturingIndexerUrl({ page: "2" });
+
+      expect(query.get("page")).toBe("2");
+      expect(query.get("limit")).toBe("12");
+      expect(query.get("sortBy")).toBe("milestones");
+      expect(screen.getByTestId("initial-page")).toHaveTextContent("2");
+    });
+
+    it("falls back to page 1 for a malformed page param", async () => {
+      const query = await renderProjectsPageCapturingIndexerUrl({ page: "-3" });
+
+      expect(query.get("page")).toBe("1");
+      expect(screen.getByTestId("initial-page")).toHaveTextContent("1");
     });
 
     it("calls notFound when community details are null", async () => {
@@ -198,6 +279,7 @@ describe("SSR Server Components", () => {
       await expect(
         CommunityProjectsPage({
           params: Promise.resolve({ communityId: "nonexistent" }),
+          searchParams: Promise.resolve({}),
         })
       ).rejects.toThrow("NEXT_NOT_FOUND");
 
@@ -240,6 +322,7 @@ describe("SSR Server Components", () => {
       const CommunityProjectsPage = await importPage();
       const jsx = await CommunityProjectsPage({
         params: Promise.resolve({ communityId: "empty-community" }),
+        searchParams: Promise.resolve({}),
       });
 
       render(jsx);
@@ -329,6 +412,7 @@ describe("SSR Server Components", () => {
       const CommunityMainPage = await importPage();
       const jsx = await CommunityMainPage({
         params: Promise.resolve({ communityId: "main-community" }),
+        searchParams: Promise.resolve({}),
       });
 
       render(jsx);
@@ -364,6 +448,7 @@ describe("SSR Server Components", () => {
       await expect(
         CommunityMainPage({
           params: Promise.resolve({ communityId: "missing" }),
+          searchParams: Promise.resolve({}),
         })
       ).rejects.toThrow("NEXT_NOT_FOUND");
     });

--- a/__tests__/components/CommunityGrants/CommunityGrants-ssr.test.tsx
+++ b/__tests__/components/CommunityGrants/CommunityGrants-ssr.test.tsx
@@ -1,0 +1,303 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { screen, waitFor } from "@testing-library/react";
+import type { ComponentProps, ReactNode } from "react";
+import { renderToString } from "react-dom/server";
+import { renderWithProviders } from "@/__tests__/utils/render";
+import { CommunityGrants } from "@/components/CommunityGrants";
+import type { CommunityProject, CommunityProjects } from "@/types/v2/community";
+import { PAGES } from "@/utilities/pages";
+import { getCommunityProjects } from "@/utilities/queries/v2/getCommunityData";
+
+/**
+ * DEV-584 acceptance: a crawler (or a JavaScript-disabled fetch) must receive the
+ * server-fetched project entities in the initial HTML. These tests render the
+ * component through `renderToString` — no effects, no client fetch, exactly what
+ * a bot sees — with the REAL `useCommunityProjectsInfinite` hook, so the seeding
+ * decision and the `isFilterLoading` gate are both exercised for real.
+ */
+
+const COMMUNITY_ID = "test-community";
+const BASE_PATH = PAGES.COMMUNITY.ALL_GRANTS(COMMUNITY_ID);
+
+vi.mock("@/utilities/queries/v2/getCommunityData", () => ({
+  getCommunityProjects: vi.fn(),
+}));
+
+const mockGetCommunityProjects = vi.mocked(getCommunityProjects);
+
+// nuqs query state backed by a mutable URL-state map the test can mutate, so the
+// "filters are at their defaults" decision can be flipped per test.
+const urlState = new Map<string, string>();
+vi.mock("nuqs", () => ({
+  useQueryState: <T,>(
+    key: string,
+    options?: { defaultValue?: T; parse?: (value: string) => T | null }
+  ) => {
+    const raw = urlState.get(key);
+    const parsed = raw !== undefined && options?.parse ? options.parse(raw) : null;
+    const value = parsed ?? options?.defaultValue ?? null;
+    const setValue = (next: T | null) => {
+      if (next === null) {
+        urlState.delete(key);
+      } else {
+        urlState.set(key, String(next));
+      }
+      return Promise.resolve(new URLSearchParams());
+    };
+    return [value, setValue];
+  },
+}));
+
+vi.mock("next/navigation", () => ({
+  useParams: () => ({ communityId: COMMUNITY_ID }),
+  useSearchParams: () => new URLSearchParams(),
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn() }),
+  usePathname: () => BASE_PATH,
+}));
+
+vi.mock("next/link", () => ({
+  default: ({ children, href, ...props }: ComponentProps<"a">) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+vi.mock("next/image", () => ({
+  default: ({
+    fill: _fill,
+    priority: _priority,
+    alt = "",
+    ...props
+  }: ComponentProps<"img"> & { fill?: boolean; priority?: boolean }) => (
+    <img {...props} alt={alt} />
+  ),
+}));
+
+vi.mock("@/components/Utilities/MarkdownPreview", () => ({
+  MarkdownPreview: ({ source }: { source?: string }) => <span>{source}</span>,
+}));
+
+// Filter chrome is not part of the SSR entity contract — stub it so the test
+// pins the seeding path rather than the dropdowns.
+vi.mock("@/components/CommunityGrants/CategoryFilter", () => ({
+  CategoryFilter: () => <div data-testid="category-filter" />,
+}));
+vi.mock("@/components/CommunityGrants/SortFilter", () => ({
+  SortFilter: () => <div data-testid="sort-filter" />,
+}));
+vi.mock("@/components/CommunityGrants/MaturityStageFilter", () => ({
+  MaturityStageFilter: () => <div data-testid="maturity-filter" />,
+}));
+vi.mock("@/components/Pages/Communities/Impact/ProgramFilter", () => ({
+  ProgramFilter: () => <div data-testid="program-filter" />,
+}));
+vi.mock("@/components/Pages/Communities/Impact/TrackFilter", () => ({
+  TrackFilter: () => <div data-testid="track-filter" />,
+}));
+vi.mock("@/components/ProgramBanner", () => ({
+  ProgramBanner: () => <div data-testid="program-banner" />,
+}));
+
+const makeProject = (index: number): CommunityProject => ({
+  uid: `0xproject${index}`,
+  details: {
+    title: `Seeded Project ${index}`,
+    description: `Description for project ${index}`,
+    logoUrl: "",
+    slug: `seeded-project-${index}`,
+  },
+  categories: [],
+  regions: [],
+  grantNames: [],
+  members: [],
+  links: [],
+  endorsements: [],
+  contractAddresses: [],
+  numMilestones: 0,
+  numCompletedMilestones: 0,
+  numUpdates: 0,
+  percentCompleted: 0,
+  numTransactions: 0,
+  createdAt: "2025-01-01T00:00:00.000Z",
+});
+
+const makeServerPage = (
+  options: { page?: number; totalPages?: number; count?: number } = {}
+): CommunityProjects => {
+  const { page = 1, totalPages = 3, count = 12 } = options;
+  const hasNextPage = page < totalPages;
+  return {
+    payload: Array.from({ length: count }, (_, index) => makeProject(index + 1)),
+    pagination: {
+      totalCount: totalPages * 12,
+      page,
+      limit: 12,
+      totalPages,
+      nextPage: hasNextPage ? page + 1 : null,
+      prevPage: page > 1 ? page - 1 : null,
+      hasNextPage,
+      hasPrevPage: page > 1,
+    },
+  };
+};
+
+const defaultProps = {
+  categoriesOptions: ["DeFi", "Infrastructure"],
+  defaultSelectedCategories: [] as string[],
+  defaultSortBy: "milestones" as const,
+  defaultSelectedMaturityStage: "all" as const,
+  communityUid: "0xcommunity",
+  paginationBasePath: BASE_PATH,
+};
+
+/** Render exactly what the server emits: no effects, no client fetch. */
+const renderServerHtml = (ui: ReactNode) => {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return renderToString(<QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>);
+};
+
+beforeEach(() => {
+  urlState.clear();
+  vi.clearAllMocks();
+  // Never resolves: the mount revalidation stays in flight, which is precisely
+  // the state that used to blank the grid to a skeleton.
+  mockGetCommunityProjects.mockReturnValue(new Promise<CommunityProjects>(() => {}));
+});
+
+describe("CommunityGrants server-rendered project entities", () => {
+  it("emits all 12 server-fetched project names in the initial HTML", () => {
+    const initialProjects = makeServerPage();
+
+    const html = renderServerHtml(
+      <CommunityGrants {...defaultProps} initialProjects={initialProjects} />
+    );
+
+    for (const project of initialProjects.payload) {
+      expect(html).toContain(project.details.title);
+      expect(html).toContain(`/project/${project.details.slug}`);
+    }
+    expect(html).not.toContain("project-block-skeleton");
+  });
+
+  it("keeps the seeded projects visible while the mount revalidation is in flight", async () => {
+    const initialProjects = makeServerPage();
+
+    renderWithProviders(<CommunityGrants {...defaultProps} initialProjects={initialProjects} />);
+
+    // Synchronously present — no waitFor, no skeleton flash.
+    expect(screen.getAllByTestId("project-block")).toHaveLength(12);
+    expect(screen.queryAllByTestId("project-block-skeleton")).toHaveLength(0);
+
+    await waitFor(() => expect(mockGetCommunityProjects).toHaveBeenCalled());
+  });
+
+  it("server-renders a crawlable next link when more pages exist", () => {
+    const html = renderServerHtml(
+      <CommunityGrants {...defaultProps} initialProjects={makeServerPage({ page: 1 })} />
+    );
+
+    expect(html).toContain(`href="${BASE_PATH}?page=2"`);
+    expect(html).toContain('rel="next"');
+    expect(html).not.toContain('rel="prev"');
+  });
+
+  it("server-renders both crawlable links from a deep page", () => {
+    const html = renderServerHtml(
+      <CommunityGrants
+        {...defaultProps}
+        initialProjects={makeServerPage({ page: 2 })}
+        initialPage={2}
+      />
+    );
+
+    expect(html).toContain(`href="${BASE_PATH}"`);
+    expect(html).toContain('rel="prev"');
+    expect(html).toContain(`href="${BASE_PATH}?page=3"`);
+    expect(html).toContain('rel="next"');
+  });
+
+  it("omits crawlable pagination on a single-page community", () => {
+    const html = renderServerHtml(
+      <CommunityGrants
+        {...defaultProps}
+        initialProjects={makeServerPage({ page: 1, totalPages: 1 })}
+      />
+    );
+
+    expect(html).not.toContain('rel="next"');
+    expect(html).not.toContain('rel="prev"');
+  });
+
+  it("drops the seed when the URL carries a non-default filter", () => {
+    urlState.set("categories", "DeFi");
+
+    const html = renderServerHtml(
+      <CommunityGrants {...defaultProps} initialProjects={makeServerPage()} />
+    );
+
+    expect(html).not.toContain("Seeded Project 1");
+    expect(html).toContain("project-block-skeleton");
+  });
+
+  it("does not seed an empty server payload (a swallowed fetch error stays a skeleton)", () => {
+    const html = renderServerHtml(
+      <CommunityGrants
+        {...defaultProps}
+        initialProjects={{
+          payload: [],
+          pagination: {
+            totalCount: 0,
+            page: 1,
+            limit: 12,
+            totalPages: 0,
+            nextPage: null,
+            prevPage: null,
+            hasNextPage: false,
+            hasPrevPage: false,
+          },
+        }}
+      />
+    );
+
+    expect(html).toContain("project-block-skeleton");
+    expect(html).not.toContain("No projects found");
+  });
+
+  it("renders the empty state once the query resolves with no projects", async () => {
+    mockGetCommunityProjects.mockResolvedValue({
+      payload: [],
+      pagination: {
+        totalCount: 0,
+        page: 1,
+        limit: 12,
+        totalPages: 0,
+        nextPage: null,
+        prevPage: null,
+        hasNextPage: false,
+        hasPrevPage: false,
+      },
+    });
+
+    renderWithProviders(
+      <CommunityGrants
+        {...defaultProps}
+        initialProjects={{
+          payload: [],
+          pagination: {
+            totalCount: 0,
+            page: 1,
+            limit: 12,
+            totalPages: 0,
+            nextPage: null,
+            prevPage: null,
+            hasNextPage: false,
+            hasPrevPage: false,
+          },
+        }}
+      />
+    );
+
+    expect(await screen.findByText("No projects found")).toBeInTheDocument();
+  });
+});

--- a/__tests__/utilities/communityProjectsRequest.test.ts
+++ b/__tests__/utilities/communityProjectsRequest.test.ts
@@ -1,0 +1,44 @@
+import {
+  buildCommunityProjectsPageHref,
+  parseCommunityProjectsPage,
+} from "@/utilities/queries/v2/communityProjectsRequest";
+
+describe("parseCommunityProjectsPage", () => {
+  it("defaults to page 1 when the param is absent or the record is missing", () => {
+    expect(parseCommunityProjectsPage()).toBe(1);
+    expect(parseCommunityProjectsPage({})).toBe(1);
+  });
+
+  it("reads a positive integer page", () => {
+    expect(parseCommunityProjectsPage({ page: "7" })).toBe(7);
+  });
+
+  it("falls back to page 1 for values that are not a positive integer", () => {
+    expect(parseCommunityProjectsPage({ page: "0" })).toBe(1);
+    expect(parseCommunityProjectsPage({ page: "-2" })).toBe(1);
+    expect(parseCommunityProjectsPage({ page: "1.5" })).toBe(1);
+    expect(parseCommunityProjectsPage({ page: "abc" })).toBe(1);
+    expect(parseCommunityProjectsPage({ page: "" })).toBe(1);
+    expect(parseCommunityProjectsPage({ page: "99999999999999999999" })).toBe(1);
+    expect(parseCommunityProjectsPage({ page: ["2", "3"] })).toBe(1);
+  });
+});
+
+describe("buildCommunityProjectsPageHref", () => {
+  it("omits the page param for page 1 so the canonical URL stays bare", () => {
+    expect(buildCommunityProjectsPageHref("/community/celo", 1)).toBe("/community/celo");
+    expect(buildCommunityProjectsPageHref("/community/celo", 0)).toBe("/community/celo");
+  });
+
+  it("appends the page param for deeper pages", () => {
+    expect(buildCommunityProjectsPageHref("/community/celo/projects", 2)).toBe(
+      "/community/celo/projects?page=2"
+    );
+  });
+
+  it("preserves an existing query string on the base path", () => {
+    expect(buildCommunityProjectsPageHref("/community/celo?programId=abc", 3)).toBe(
+      "/community/celo?programId=abc&page=3"
+    );
+  });
+});

--- a/app/community/[communityId]/(with-header)/page.tsx
+++ b/app/community/[communityId]/(with-header)/page.tsx
@@ -4,7 +4,15 @@ import { notFound } from "next/navigation";
 import { CommunityGrants } from "@/components/CommunityGrants";
 import { PROJECT_NAME } from "@/constants/brand";
 import type { MaturityStageOptions, SortByOptions } from "@/types";
+import { PAGES } from "@/utilities/pages";
 import { pagesOnRoot } from "@/utilities/pagesOnRoot";
+import {
+  COMMUNITY_PROJECTS_PAGE_SIZE,
+  type CommunityProjectsSearchParams,
+  DEFAULT_COMMUNITY_SORT,
+  mapSortToApiValue,
+  parseCommunityProjectsPage,
+} from "@/utilities/queries/v2/communityProjectsRequest";
 import {
   getCommunityCategories,
   getCommunityDetails,
@@ -15,6 +23,7 @@ type Props = {
   params: Promise<{
     communityId: string;
   }>;
+  searchParams: Promise<CommunityProjectsSearchParams>;
 };
 
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
@@ -35,10 +44,19 @@ export default async function Page(props: Props) {
     return undefined;
   }
 
+  // Fetch the exact request the client's first query would issue (page + explicit
+  // sort) so the server payload can seed React Query instead of being replaced by
+  // a differently-ordered refetch.
+  const page = parseCommunityProjectsPage(await props.searchParams);
+
   const [communityDetails, categories, initialProjects] = await Promise.all([
     getCommunityDetails(communityId),
     getCommunityCategories(communityId),
-    getCommunityProjects(communityId, { page: 1, limit: 12 }),
+    getCommunityProjects(communityId, {
+      page,
+      limit: COMMUNITY_PROJECTS_PAGE_SIZE,
+      sortBy: mapSortToApiValue(DEFAULT_COMMUNITY_SORT),
+    }),
   ]);
 
   // Extract category names for the filter
@@ -50,7 +68,7 @@ export default async function Page(props: Props) {
     notFound();
   }
 
-  const defaultSortBy = "milestones" as SortByOptions;
+  const defaultSortBy: SortByOptions = DEFAULT_COMMUNITY_SORT;
   const defaultSelectedCategories: string[] = [];
   const defaultSelectedMaturityStage = "all" as MaturityStageOptions;
 
@@ -63,6 +81,8 @@ export default async function Page(props: Props) {
         defaultSelectedMaturityStage={defaultSelectedMaturityStage}
         communityUid={communityDetails.uid}
         initialProjects={initialProjects}
+        initialPage={page}
+        paginationBasePath={PAGES.COMMUNITY.ALL_GRANTS(communityId)}
       />
     </div>
   );

--- a/app/community/[communityId]/(with-header)/projects/page.tsx
+++ b/app/community/[communityId]/(with-header)/projects/page.tsx
@@ -1,6 +1,14 @@
 import { notFound } from "next/navigation";
 import { CommunityGrants } from "@/components/CommunityGrants";
 import type { MaturityStageOptions, SortByOptions } from "@/types";
+import { PAGES } from "@/utilities/pages";
+import {
+  COMMUNITY_PROJECTS_PAGE_SIZE,
+  type CommunityProjectsSearchParams,
+  DEFAULT_COMMUNITY_SORT,
+  mapSortToApiValue,
+  parseCommunityProjectsPage,
+} from "@/utilities/queries/v2/communityProjectsRequest";
 import {
   getCommunityCategories,
   getCommunityDetails,
@@ -11,15 +19,24 @@ type Props = {
   params: Promise<{
     communityId: string;
   }>;
+  searchParams: Promise<CommunityProjectsSearchParams>;
 };
 
 export default async function CommunityProjectsPage(props: Props) {
   const { communityId } = await props.params;
+  // Fetch the exact request the client's first query would issue (page + explicit
+  // sort) so the server payload can seed React Query instead of being replaced by
+  // a differently-ordered refetch.
+  const page = parseCommunityProjectsPage(await props.searchParams);
 
   const [communityDetails, categories, initialProjects] = await Promise.all([
     getCommunityDetails(communityId),
     getCommunityCategories(communityId),
-    getCommunityProjects(communityId, { page: 1, limit: 12 }),
+    getCommunityProjects(communityId, {
+      page,
+      limit: COMMUNITY_PROJECTS_PAGE_SIZE,
+      sortBy: mapSortToApiValue(DEFAULT_COMMUNITY_SORT),
+    }),
   ]);
 
   const categoriesOptions = categories
@@ -30,7 +47,7 @@ export default async function CommunityProjectsPage(props: Props) {
     notFound();
   }
 
-  const defaultSortBy = "milestones" as SortByOptions;
+  const defaultSortBy: SortByOptions = DEFAULT_COMMUNITY_SORT;
   const defaultSelectedCategories: string[] = [];
   const defaultSelectedMaturityStage = "all" as MaturityStageOptions;
 
@@ -43,6 +60,8 @@ export default async function CommunityProjectsPage(props: Props) {
         defaultSelectedMaturityStage={defaultSelectedMaturityStage}
         communityUid={communityDetails.uid}
         initialProjects={initialProjects}
+        initialPage={page}
+        paginationBasePath={PAGES.COMMUNITY.PROJECTS(communityId)}
       />
     </div>
   );

--- a/components/CommunityGrants.tsx
+++ b/components/CommunityGrants.tsx
@@ -1,4 +1,5 @@
 "use client";
+import type { InfiniteData } from "@tanstack/react-query";
 import { useParams } from "next/navigation";
 import { useCallback, useEffect, useMemo } from "react";
 import InfiniteScroll from "react-infinite-scroll-component";
@@ -8,6 +9,7 @@ import { useCommunityStore } from "@/store/community";
 import type { MaturityStageOptions, SortByOptions } from "@/types";
 import type { CommunityProjects } from "@/types/v2/community";
 import { CategoryFilter } from "./CommunityGrants/CategoryFilter";
+import { CrawlableCommunityPagination } from "./CommunityGrants/CrawlableCommunityPagination";
 import { MaturityStageFilter } from "./CommunityGrants/MaturityStageFilter";
 import { ProjectsGrid } from "./CommunityGrants/ProjectsGrid";
 import { ProjectsGridSkeleton } from "./CommunityGrants/ProjectsGridSkeleton";
@@ -24,7 +26,14 @@ interface CommunityGrantsProps {
   defaultSelectedMaturityStage: MaturityStageOptions;
   communityUid: string;
   initialProjects: CommunityProjects;
+  /** Page the server fetched `initialProjects` for. Defaults to 1. */
+  initialPage?: number;
+  /** `PAGES.COMMUNITY.*` route the crawlable Previous/Next links point at. */
+  paginationBasePath: string;
 }
+
+const sameStringList = (a: readonly string[], b: readonly string[]) =>
+  a.length === b.length && a.every((value, index) => value === b[index]);
 
 export const CommunityGrants = ({
   categoriesOptions,
@@ -33,6 +42,8 @@ export const CommunityGrants = ({
   defaultSelectedMaturityStage,
   communityUid,
   initialProjects,
+  initialPage = 1,
+  paginationBasePath,
 }: CommunityGrantsProps) => {
   const params = useParams();
   const communityId = params.communityId as string;
@@ -55,6 +66,27 @@ export const CommunityGrants = ({
     defaultSelectedMaturityStage,
   });
 
+  // The server renders the hub with the filters at their defaults. Only seed the
+  // cache while the live URL state still matches, otherwise a filtered view
+  // would show the unfiltered server payload.
+  const matchesInitialState =
+    selectedSort === defaultSortBy &&
+    selectedMaturityStage === defaultSelectedMaturityStage &&
+    !selectedProgramId &&
+    !selectedTrackIds?.length &&
+    sameStringList(selectedCategories, defaultSelectedCategories);
+
+  // `getCommunityProjects` swallows every failure into an empty page, so an
+  // empty payload is indistinguishable from an indexer blip — don't seed it, and
+  // let the client refetch decide between "no projects" and real data.
+  const seededData: InfiniteData<CommunityProjects, number> | undefined = useMemo(
+    () =>
+      matchesInitialState && initialProjects.payload.length > 0
+        ? { pages: [initialProjects], pageParams: [initialPage] }
+        : undefined,
+    [matchesInitialState, initialProjects, initialPage]
+  );
+
   const { data, error, fetchNextPage, hasNextPage, isFetchingNextPage, isLoading, isRefetching } =
     useCommunityProjectsInfinite({
       communityId,
@@ -64,10 +96,18 @@ export const CommunityGrants = ({
       programId: selectedProgramId,
       trackIds: selectedTrackIds,
       enabled: !!communityId,
+      initialData: seededData,
+      initialPage: matchesInitialState ? initialPage : 1,
     });
 
-  // Check if we're loading due to filter changes
-  const isFilterLoading = isLoading || (isRefetching && !isFetchingNextPage);
+  // Check if we're loading due to filter changes. Every filter is part of the
+  // query key, so any data we hold already belongs to the current filters —
+  // keep rendering it through a same-key refetch instead of blanking to a
+  // skeleton. Without this the server-seeded page is never visible: React Query
+  // reports `isRefetching` optimistically on the very first render because of
+  // `refetchOnMount: "always"`.
+  const isFilterLoading =
+    (isLoading || (isRefetching && !isFetchingNextPage)) && !data?.pages?.length;
 
   const projects = useMemo(() => {
     // Don't show stale data when filters are changing
@@ -86,6 +126,12 @@ export const CommunityGrants = ({
     }
     return data.pages[0].pagination.totalCount;
   }, [data?.pages, initialProjects.pagination.totalCount]);
+
+  // Crawlable Previous/Next is only meaningful for the unfiltered, server-rendered
+  // view — filtered views stay client-only.
+  const totalPages =
+    data?.pages?.[0]?.pagination.totalPages ?? initialProjects.pagination.totalPages;
+  const showCrawlablePagination = matchesInitialState && projects.length > 0;
 
   useEffect(() => {
     // Update loading state in the store
@@ -222,6 +268,15 @@ export const CommunityGrants = ({
               <ProjectsGrid projects={projects} />
             </InfiniteScroll>
           ) : null}
+
+          {showCrawlablePagination && (
+            <CrawlableCommunityPagination
+              basePath={paginationBasePath}
+              currentPage={initialPage}
+              hasPrev={initialPage > 1}
+              hasNext={initialPage < totalPages}
+            />
+          )}
 
           {(isFilterLoading || isFetchingNextPage) && (
             <div className="w-full flex items-center justify-center">

--- a/components/CommunityGrants/CrawlableCommunityPagination.tsx
+++ b/components/CommunityGrants/CrawlableCommunityPagination.tsx
@@ -1,0 +1,55 @@
+import { buildCommunityProjectsPageHref } from "@/utilities/queries/v2/communityProjectsRequest";
+
+interface CrawlableCommunityPaginationProps {
+  /** Route-constant base path for the hub (no query string of our own). */
+  basePath: string;
+  /** The server-rendered page the links are relative to. */
+  currentPage: number;
+  hasPrev: boolean;
+  hasNext: boolean;
+}
+
+const LINK_CLASS =
+  "px-4 py-2 rounded-md border border-zinc-300 dark:border-zinc-700 text-sm font-medium text-zinc-700 dark:text-zinc-300 hover:bg-zinc-50 dark:hover:bg-zinc-800 transition-colors";
+
+/**
+ * Crawlable pagination — plain native `<a>` anchors so bots (and users without
+ * JavaScript) can walk the full project list with real SSR navigations. A
+ * Next.js `<Link>` client-intercepts the click into a soft navigation, and in
+ * the observed QA on /projects that interception swallowed it, so ordinary
+ * anchors are deliberate here. Infinite scroll remains the progressive
+ * enhancement for humans with JavaScript.
+ */
+export const CrawlableCommunityPagination = ({
+  basePath,
+  currentPage,
+  hasPrev,
+  hasNext,
+}: CrawlableCommunityPaginationProps) => {
+  if (!hasPrev && !hasNext) {
+    return null;
+  }
+
+  return (
+    <nav aria-label="Pagination" className="flex justify-center items-center gap-4 py-8">
+      {hasPrev && (
+        <a
+          href={buildCommunityProjectsPageHref(basePath, currentPage - 1)}
+          rel="prev"
+          className={LINK_CLASS}
+        >
+          Previous
+        </a>
+      )}
+      {hasNext && (
+        <a
+          href={buildCommunityProjectsPageHref(basePath, currentPage + 1)}
+          rel="next"
+          className={LINK_CLASS}
+        >
+          Next
+        </a>
+      )}
+    </nav>
+  );
+};

--- a/hooks/__tests__/useCommunityProjectsInfinite.test.tsx
+++ b/hooks/__tests__/useCommunityProjectsInfinite.test.tsx
@@ -1,0 +1,169 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import type { CommunityProject, CommunityProjects } from "@/types/v2/community";
+import { getCommunityProjects } from "@/utilities/queries/v2/getCommunityData";
+import { useCommunityProjectsInfinite } from "../useCommunityProjectsInfinite";
+
+/**
+ * SSR seeding contract for the community project hubs (DEV-584). The server
+ * already fetches the first page; the hook must accept it as `initialData` so
+ * the very first render — including the server render — has the project
+ * entities, while still revalidating on mount.
+ */
+
+vi.mock("@/utilities/queries/v2/getCommunityData", () => ({
+  getCommunityProjects: vi.fn(),
+}));
+
+const mockGetCommunityProjects = vi.mocked(getCommunityProjects);
+
+const makeProject = (uid: string): CommunityProject => ({
+  uid,
+  details: {
+    title: `Project ${uid}`,
+    description: `Description for ${uid}`,
+    logoUrl: "",
+    slug: `project-${uid}`,
+  },
+  categories: [],
+  regions: [],
+  grantNames: [],
+  members: [],
+  links: [],
+  endorsements: [],
+  contractAddresses: [],
+  numMilestones: 0,
+  numCompletedMilestones: 0,
+  numUpdates: 0,
+  percentCompleted: 0,
+  numTransactions: 0,
+  createdAt: "2025-01-01T00:00:00.000Z",
+});
+
+const makePage = (page: number, hasNextPage: boolean): CommunityProjects => ({
+  payload: [makeProject(`p${page}-a`), makeProject(`p${page}-b`)],
+  pagination: {
+    totalCount: 24,
+    page,
+    limit: 12,
+    totalPages: 2,
+    nextPage: hasNextPage ? page + 1 : null,
+    prevPage: page > 1 ? page - 1 : null,
+    hasNextPage,
+    hasPrevPage: page > 1,
+  },
+});
+
+const baseOptions = {
+  communityId: "test-community",
+  sortBy: "milestones" as const,
+  categories: [] as string[],
+  maturityStage: "all" as const,
+  programId: null,
+  trackIds: null,
+};
+
+describe("useCommunityProjectsInfinite", () => {
+  let queryClient: QueryClient;
+
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+
+  beforeEach(() => {
+    queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    vi.clearAllMocks();
+    // Never resolves: keeps the mount revalidation permanently in flight so the
+    // assertions describe the *first* render, not the post-fetch state.
+    mockGetCommunityProjects.mockReturnValue(new Promise<CommunityProjects>(() => {}));
+  });
+
+  afterEach(() => {
+    queryClient.clear();
+  });
+
+  it("exposes the seeded page synchronously on the first render", () => {
+    const seed = makePage(1, true);
+
+    const { result } = renderHook(
+      () =>
+        useCommunityProjectsInfinite({
+          ...baseOptions,
+          initialData: { pages: [seed], pageParams: [1] },
+        }),
+      { wrapper }
+    );
+
+    expect(result.current.data?.pages[0]).toEqual(seed);
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.hasNextPage).toBe(true);
+  });
+
+  it("stays pending on the first render without a seed (unseeded behavior is unchanged)", () => {
+    const { result } = renderHook(() => useCommunityProjectsInfinite(baseOptions), { wrapper });
+
+    expect(result.current.data).toBeUndefined();
+    expect(result.current.isLoading).toBe(true);
+  });
+
+  it("revalidates the seeded page exactly once on mount", async () => {
+    const seed = makePage(1, true);
+
+    renderHook(
+      () =>
+        useCommunityProjectsInfinite({
+          ...baseOptions,
+          initialData: { pages: [seed], pageParams: [1] },
+        }),
+      { wrapper }
+    );
+
+    await waitFor(() => expect(mockGetCommunityProjects).toHaveBeenCalledTimes(1));
+    expect(mockGetCommunityProjects).toHaveBeenCalledWith(
+      "test-community",
+      expect.objectContaining({ page: 1, limit: 12, sortBy: "milestones" })
+    );
+  });
+
+  it("keeps a page-2 seed in its own cache entry and paginates onwards from it", async () => {
+    const pageOne = makePage(1, true);
+    const pageTwo = makePage(2, true);
+
+    const { result: first } = renderHook(
+      () =>
+        useCommunityProjectsInfinite({
+          ...baseOptions,
+          initialData: { pages: [pageOne], pageParams: [1] },
+        }),
+      { wrapper }
+    );
+    const { result: second } = renderHook(
+      () =>
+        useCommunityProjectsInfinite({
+          ...baseOptions,
+          initialData: { pages: [pageTwo], pageParams: [2] },
+          initialPage: 2,
+        }),
+      { wrapper }
+    );
+
+    // Distinct cache entries — a page-2 seed cannot overwrite the page-1 view.
+    expect(
+      queryClient.getQueryCache().findAll({ queryKey: ["community-projects-infinite"] })
+    ).toHaveLength(2);
+    expect(first.current.data?.pages[0].pagination.page).toBe(1);
+    expect(second.current.data?.pages[0].pagination.page).toBe(2);
+
+    mockGetCommunityProjects.mockClear();
+    second.current.fetchNextPage();
+
+    await waitFor(() => expect(mockGetCommunityProjects).toHaveBeenCalled());
+    expect(mockGetCommunityProjects).toHaveBeenCalledWith(
+      "test-community",
+      expect.objectContaining({ page: 3 })
+    );
+  });
+});

--- a/hooks/useCommunityProjectsInfinite.ts
+++ b/hooks/useCommunityProjectsInfinite.ts
@@ -1,5 +1,5 @@
 "use client";
-import { useInfiniteQuery } from "@tanstack/react-query";
+import { type InfiniteData, useInfiniteQuery } from "@tanstack/react-query";
 import type { MaturityStageOptions, SortByOptions } from "@/types";
 import type { CommunityProjects } from "@/types/v2/community";
 import {
@@ -18,6 +18,10 @@ interface UseInfiniteCommunityProjectsOptions {
   trackIds: string[] | null;
   limit?: number;
   enabled?: boolean;
+  /** SSR seed: the server-rendered page wrapped as InfiniteData. */
+  initialData?: InfiniteData<CommunityProjects, number>;
+  /** Page the seed (and any client retry) starts from. Defaults to 1. */
+  initialPage?: number;
 }
 
 export function useCommunityProjectsInfinite({
@@ -29,7 +33,11 @@ export function useCommunityProjectsInfinite({
   trackIds,
   limit = COMMUNITY_PROJECTS_PAGE_SIZE,
   enabled = true,
+  initialData,
+  initialPage = 1,
 }: UseInfiniteCommunityProjectsOptions) {
+  // initialPage is part of the key so a ?page=2 seed can never bleed into the
+  // page-1 cache entry (same policy as the /projects explorer).
   const queryKey = [
     "community-projects-infinite",
     communityId,
@@ -38,13 +46,20 @@ export function useCommunityProjectsInfinite({
     maturityStage,
     programId,
     trackIds,
+    initialPage,
   ];
 
-  return useInfiniteQuery<CommunityProjects, Error>({
+  return useInfiniteQuery<
+    CommunityProjects,
+    Error,
+    InfiniteData<CommunityProjects, number>,
+    readonly unknown[],
+    number
+  >({
     queryKey,
-    queryFn: async ({ pageParam = 1 }) => {
+    queryFn: async ({ pageParam }) => {
       const response = await getCommunityProjects(communityId, {
-        page: pageParam as number,
+        page: pageParam,
         limit,
         sortBy: mapSortToApiValue(sortBy),
         status: getStatusFromMaturityStage(maturityStage),
@@ -58,7 +73,8 @@ export function useCommunityProjectsInfinite({
     getNextPageParam: (lastPage) => {
       return lastPage.pagination.hasNextPage ? lastPage.pagination.page + 1 : undefined;
     },
-    initialPageParam: 1,
+    initialData,
+    initialPageParam: initialPage,
     enabled: enabled && !!communityId,
     staleTime: 0, // Always consider data stale when filters change
     gcTime: 1000 * 60 * 10, // 10 minutes (formerly cacheTime)

--- a/hooks/useCommunityProjectsInfinite.ts
+++ b/hooks/useCommunityProjectsInfinite.ts
@@ -1,23 +1,13 @@
 "use client";
 import { useInfiniteQuery } from "@tanstack/react-query";
-import type { MaturityStageOptions, SortByOptions, StatusOptions } from "@/types";
+import type { MaturityStageOptions, SortByOptions } from "@/types";
 import type { CommunityProjects } from "@/types/v2/community";
+import {
+  COMMUNITY_PROJECTS_PAGE_SIZE,
+  getStatusFromMaturityStage,
+  mapSortToApiValue,
+} from "@/utilities/queries/v2/communityProjectsRequest";
 import { getCommunityProjects } from "@/utilities/queries/v2/getCommunityData";
-
-const getStatusFromMaturityStage = (stage: MaturityStageOptions): StatusOptions | undefined => {
-  if (stage === "all") return undefined;
-  return `maturity-stage-${stage}` as StatusOptions;
-};
-
-const mapSortToApiValue = (sortOption: SortByOptions): string => {
-  const sortMappings: Record<SortByOptions, string> = {
-    recent: "recent",
-    completed: "completed",
-    milestones: "milestones",
-    txnCount: "transactions_desc",
-  };
-  return sortMappings[sortOption];
-};
 
 interface UseInfiniteCommunityProjectsOptions {
   communityId: string;
@@ -37,7 +27,7 @@ export function useCommunityProjectsInfinite({
   maturityStage,
   programId,
   trackIds,
-  limit = 12,
+  limit = COMMUNITY_PROJECTS_PAGE_SIZE,
   enabled = true,
 }: UseInfiniteCommunityProjectsOptions) {
   const queryKey = [

--- a/utilities/queries/v2/communityProjectsRequest.ts
+++ b/utilities/queries/v2/communityProjectsRequest.ts
@@ -1,0 +1,66 @@
+/**
+ * Pure, framework-free helpers for the community project hubs
+ * (`/community/[communityId]` and `/community/[communityId]/projects`).
+ *
+ * These live outside the `"use client"` hook so the server pages can call them
+ * to build the exact same indexer request the client's first fetch would issue,
+ * which is what lets the server response be handed to React Query as a seed
+ * (ADR 0001, mirroring `utilities/projects-explorer-request.ts`).
+ */
+import type { MaturityStageOptions, SortByOptions, StatusOptions } from "@/types";
+
+/** Shape of Next.js `searchParams` once resolved. */
+export type CommunityProjectsSearchParams = Record<string, string | string[] | undefined>;
+
+/** Page size shared by the server seed fetch and the client infinite query. */
+export const COMMUNITY_PROJECTS_PAGE_SIZE = 12;
+
+/** Sort the hubs render with when no `sortBy` query param is present. */
+export const DEFAULT_COMMUNITY_SORT: SortByOptions = "milestones";
+
+const SORT_MAPPINGS: Record<SortByOptions, string> = {
+  recent: "recent",
+  completed: "completed",
+  milestones: "milestones",
+  txnCount: "transactions_desc",
+};
+
+/** Translate a UI sort option into the indexer's `sortBy` value. */
+export function mapSortToApiValue(sortOption: SortByOptions): string {
+  return SORT_MAPPINGS[sortOption];
+}
+
+/** Translate a maturity-stage filter into the indexer's `status` value. */
+export function getStatusFromMaturityStage(stage: MaturityStageOptions): StatusOptions | undefined {
+  if (stage === "all") return undefined;
+  return `maturity-stage-${stage}` as StatusOptions;
+}
+
+/**
+ * Read the effective page from a search-param record. Missing, array-valued,
+ * non-numeric, zero, negative and oversized values all fall back to page 1.
+ */
+export function parseCommunityProjectsPage(params?: CommunityProjectsSearchParams): number {
+  const raw = params?.page;
+  if (typeof raw !== "string" || !/^\d+$/.test(raw)) {
+    return 1;
+  }
+  const page = Number(raw);
+  if (!Number.isSafeInteger(page) || page < 1) {
+    return 1;
+  }
+  return page;
+}
+
+/**
+ * Build a crawlable href for a target page of a community hub. `basePath` must
+ * come from the `PAGES.COMMUNITY.*` route constants. Page 1 keeps the bare path
+ * so the canonical URL never gains a redundant `?page=1`.
+ */
+export function buildCommunityProjectsPageHref(basePath: string, targetPage: number): string {
+  if (targetPage <= 1) {
+    return basePath;
+  }
+  const separator = basePath.includes("?") ? "&" : "?";
+  return `${basePath}${separator}page=${targetPage}`;
+}


### PR DESCRIPTION
## Overview

Makes the community project hubs — `/community/[communityId]` and
`/community/[communityId]/projects` — actually ship their project entities in the
server-rendered HTML, and makes the full paginated list reachable without
JavaScript.

Part of DEV-583. Implements DEV-584 (AEO-01).

## Problem

Both hubs already fetched page 1 on the server and passed it into
`CommunityGrants` as `initialProjects`, but that payload never reached the
rendered grid:

- The server asked the indexer for `{ page: 1, limit: 12 }` with no `sortBy`,
  while the client's first `useCommunityProjectsInfinite` call asked for
  `sortBy=milestones`. Different request, different ordering — the client
  response replaced the server one wholesale.
- `initialProjects` was only used for the total count. The grid itself rendered
  from React Query, which starts empty, so the initial HTML contained a skeleton
  and zero project names, titles, or links.
- `refetchOnMount: "always"` means React Query reports `isRefetching` on the very
  first render, and `isFilterLoading` blanked the grid to a skeleton whenever
  that was true — so even a seeded cache would have been hidden.
- There was no non-JS path past page 1. Everything beyond the first 12 projects
  lived behind an infinite-scroll observer, so crawlers only ever saw 12 of them.

Net effect: answer engines and crawlers indexed a loading state for every
community hub.

## Solution

**Shared request helpers** (`utilities/queries/v2/communityProjectsRequest.ts`)

The sort/status mappers and the page size lived inside the `"use client"` hook, so
server components could not reuse them. They now live in a framework-free module
(mirroring `utilities/projects-explorer-request.ts`), alongside page-param parsing
and page-href building. The first commit is a pure move with no behaviour change.

**Server fetches the client's exact first request**

Both pages now call `getCommunityProjects` with `{ page, limit, sortBy }` built
from those shared helpers, so the response is byte-for-byte the request the client
would have issued and can legitimately seed the cache.

**Seeding is conditional, and deliberately conservative**

- The seed is only applied while the live filter state still matches the server
  defaults (sort, maturity stage, categories, program, tracks). A user landing on
  a filtered URL never sees the unfiltered server payload.
- An empty payload is never seeded. `getCommunityProjects` swallows failures into
  an empty page, so "no projects" and "indexer blip" are indistinguishable —
  seeding an empty page would render a permanent false empty state. The client
  refetch decides instead.
- `initialPage` is part of the query key, so a `?page=2` seed cannot bleed into
  the page-1 cache entry (same policy the `/projects` explorer uses).
- `isFilterLoading` no longer blanks the grid when data is already held. Every
  filter is in the query key, so any data in hand already belongs to the current
  filters.

**Crawlable pagination**

`?page=N` is now honoured server-side (malformed, zero, negative, and
array-valued params fall back to page 1), and the grid renders `rel="prev"` /
`rel="next"` anchors built from `PAGES.COMMUNITY.*` constants. Page 1 keeps the
bare path so the canonical URL never gains a redundant `?page=1`. These are plain
`<a>` anchors, not `<Link>` — in QA on `/projects`, client interception swallowed
the navigation. Infinite scroll remains the progressive enhancement for humans
with JavaScript, and the links only render on the unfiltered view.

No structured-data facts were added; everything here is content that is now
genuinely present in the rendered HTML.

## Testing steps

Automated (all green):

```bash
pnpm vitest run --project unit \
  __tests__/utilities/communityProjectsRequest.test.ts \
  hooks/__tests__/useCommunityProjectsInfinite.test.tsx \
  __tests__/components/CommunityGrants/CommunityGrants-ssr.test.tsx \
  __tests__/app/ssr-server-components.test.tsx
pnpm typecheck
```

28 tests covering: helper parsing/href edge cases; the hook's seed and query-key
behaviour; all 12 project names present in the initial HTML; seeded projects
staying visible through the mount revalidation; crawlable links on first, deep,
and single-page communities; the seed being dropped under a non-default filter;
an empty server payload not being seeded; and the empty state still resolving.
Page-level tests assert the indexer receives `page`/`limit`/`sortBy` and that
`?page=2` and malformed params are handled.

Manual:

1. `pnpm run dev`, then `curl -s http://localhost:3000/community/<slug>/projects | grep -c '<project title>'` — project names should appear in the raw HTML.
2. Same for `?page=2`; confirm the HTML shows the second page and carries both prev and next anchors.
3. With JavaScript disabled, click Previous/Next and confirm full page navigations resolve.
4. With JavaScript enabled, confirm the grid does not flash a skeleton on load and that infinite scroll still appends pages.
5. Apply a category or sort filter and confirm results are filtered (not the server payload) and the crawlable links disappear.

## Risk / scope notes

- Scope is limited to the two community hub pages, `CommunityGrants`, and its
  infinite-query hook. No API, schema, or indexer changes.
- Highest-risk area is the cache seed. It is gated on an exact filter-state match
  and a non-empty payload, and `initialPage` is in the query key, so the failure
  mode of a bad seed (stale or mismatched data) is structurally excluded rather
  than assumed away.
- The `isFilterLoading` change is the one behaviour users will notice: switching
  filters no longer blanks the grid on the very first render when data is already
  held. Subsequent genuine filter changes still show the skeleton because the
  query key changes and there is no data for the new key.
- `?page=N` is new public surface on these routes. Invalid values degrade to page
  1 rather than erroring, and page 1 renders at the bare canonical path.
