### PR TITLE
feat(seo): replay last-known-good indexability decisions during indexer blips

### DIFF
--- a/__tests__/middleware-indexability.test.ts
+++ b/__tests__/middleware-indexability.test.ts
@@ -45,6 +45,10 @@ vi.mock("@/utilities/chosenCommunities", () => ({
 }));
 
 import { proxy } from "@/proxy";
+import {
+  clearProjectIndexabilityLkgCache,
+  PROJECT_INDEXABILITY_LKG_TTL_MS,
+} from "@/utilities/project-indexability-client";
 
 const INDEXER_BASE = "https://indexer.test";
 
@@ -75,11 +79,16 @@ function decisionResponse(decision: unknown, status = 200): Response {
 
 beforeEach(() => {
   fetchMock.mockReset();
+  // Decisions are remembered per runtime instance; drop them between tests so
+  // each case starts from a cold instance instead of inheriting a neighbour's
+  // successful lookup.
+  clearProjectIndexabilityLkgCache();
   vi.stubGlobal("fetch", fetchMock);
   vi.stubEnv("NEXT_PUBLIC_GAP_INDEXER_URL", INDEXER_BASE);
 });
 
 afterEach(() => {
+  clearProjectIndexabilityLkgCache();
   vi.unstubAllGlobals();
   vi.unstubAllEnvs();
 });
@@ -441,5 +450,114 @@ describe("middleware canonical-host origin policy", () => {
     expect(response?.headers.get("location")).toBe(
       "http://localhost:3000/project/abc123-1?utm_source=x"
     );
+  });
+});
+
+/**
+ * Last-known-good fallback at the middleware seam (DEV-594). A transient
+ * indexer outage used to de-index healthy project pages: the client failed
+ * closed, so the proxy stamped noindex on a page the indexer had called
+ * canonical-indexable moments earlier. A warm instance now replays its last
+ * successful decision for a bounded window instead. Nothing is replayed on a
+ * cold instance, and nothing is replayed past the TTL.
+ */
+describe("middleware indexability last-known-good fallback", () => {
+  const PROJECT_PATH = "/project/paraswap";
+  const INDEXER_TIMEOUT_MS = 2500;
+
+  // Never resolves: the request hangs until the client's own AbortController
+  // fires, which is exactly what an indexer timeout looks like from here.
+  const hangUntilAborted: Fetcher = (_url, init) =>
+    new Promise<Response>((_resolve, reject) => {
+      init.signal?.addEventListener("abort", () => {
+        reject(new DOMException("The operation was aborted.", "AbortError"));
+      });
+    });
+
+  async function primeIndexableProject(): Promise<void> {
+    fetchMock.mockResolvedValue(
+      decisionResponse({ outcome: "canonical-indexable", url: PROJECT_PATH })
+    );
+
+    const response = await proxy(createRequest("www.karmahq.xyz", PROJECT_PATH));
+
+    expect(response?.status).toBe(200);
+    expect(response?.headers.get("X-Robots-Tag")).toBeNull();
+  }
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("keeps a known-indexable project indexable when the indexer request times out", async () => {
+    vi.useFakeTimers();
+    await primeIndexableProject();
+
+    fetchMock.mockImplementation(hangUntilAborted);
+    const pending = proxy(createRequest("www.karmahq.xyz", PROJECT_PATH));
+    await vi.advanceTimersByTimeAsync(INDEXER_TIMEOUT_MS);
+    const response = await pending;
+
+    expect(response?.status).toBe(200);
+    expect(response?.headers.get("X-Robots-Tag")).toBeNull();
+  });
+
+  it("keeps a known-indexable project indexable when the indexer returns 5xx", async () => {
+    await primeIndexableProject();
+
+    fetchMock.mockResolvedValue(new Response("boom", { status: 500 }));
+    const response = await proxy(createRequest("www.karmahq.xyz", PROJECT_PATH));
+
+    expect(response?.status).toBe(200);
+    expect(response?.headers.get("X-Robots-Tag")).toBeNull();
+  });
+
+  it("still fails closed when the indexer times out on a cold instance", async () => {
+    vi.useFakeTimers();
+    fetchMock.mockImplementation(hangUntilAborted);
+
+    const pending = proxy(createRequest("www.karmahq.xyz", PROJECT_PATH));
+    await vi.advanceTimersByTimeAsync(INDEXER_TIMEOUT_MS);
+    const response = await pending;
+
+    expect(response?.status).toBe(200);
+    expect(response?.headers.get("X-Robots-Tag")).toBe("noindex, follow");
+  });
+
+  it("fails closed again once the remembered decision has expired", async () => {
+    vi.useFakeTimers();
+    await primeIndexableProject();
+    await vi.advanceTimersByTimeAsync(PROJECT_INDEXABILITY_LKG_TTL_MS);
+
+    fetchMock.mockResolvedValue(new Response("boom", { status: 500 }));
+    const response = await proxy(createRequest("www.karmahq.xyz", PROJECT_PATH));
+
+    expect(response?.status).toBe(200);
+    expect(response?.headers.get("X-Robots-Tag")).toBe("noindex, follow");
+  });
+
+  it("does not replay a remembered decision over a fresh gone answer", async () => {
+    await primeIndexableProject();
+
+    fetchMock.mockResolvedValue(new Response("gone", { status: 410 }));
+    const response = await proxy(createRequest("www.karmahq.xyz", PROJECT_PATH));
+
+    expect(response?.status).toBe(410);
+    expect(response?.headers.get("X-Robots-Tag")).toBe("noindex, follow");
+  });
+
+  it("stops replaying a project that has since been removed", async () => {
+    await primeIndexableProject();
+
+    fetchMock.mockResolvedValue(new Response("gone", { status: 410 }));
+    await proxy(createRequest("www.karmahq.xyz", PROJECT_PATH));
+
+    // The blip lands after the removal: the deleted project must not come back
+    // as an indexable 200 just because this instance once saw it healthy.
+    fetchMock.mockResolvedValue(new Response("boom", { status: 500 }));
+    const response = await proxy(createRequest("www.karmahq.xyz", PROJECT_PATH));
+
+    expect(response?.status).toBe(200);
+    expect(response?.headers.get("X-Robots-Tag")).toBe("noindex, follow");
   });
 });

--- a/__tests__/utilities/project-indexability-client.test.ts
+++ b/__tests__/utilities/project-indexability-client.test.ts
@@ -1,9 +1,13 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { buildProjectIndexabilityEndpoint } from "@/utilities/project-indexability";
 import {
+  clearProjectIndexabilityLkgCache,
   fetchProjectIndexabilityDecision,
+  PROJECT_INDEXABILITY_LKG_TTL_MS,
+  type ProjectIndexabilityDecision,
   parseProjectIndexabilityDecision,
 } from "@/utilities/project-indexability-client";
+import { createProjectIndexabilityLkgCache } from "@/utilities/project-indexability-lkg-cache";
 
 /**
  * RED (Edge-safe project indexability client, ADR 0001, D5). A strict runtime
@@ -34,7 +38,15 @@ function jsonResponse(status: number, body: unknown): Response {
   return new Response(JSON.stringify(body), { status });
 }
 
+// The last-known-good store is module state shared by every test in this file,
+// so it is reset around each one: fail-closed expectations must not be served a
+// decision cached by an earlier success.
+beforeEach(() => {
+  clearProjectIndexabilityLkgCache();
+});
+
 afterEach(() => {
+  clearProjectIndexabilityLkgCache();
   vi.useRealTimers();
   vi.restoreAllMocks();
 });
@@ -352,6 +364,16 @@ describe("fetchProjectIndexabilityDecision", () => {
     await expect(promise).resolves.toEqual(FAIL_CLOSED);
   });
 
+  it("does not remember a failed lookup: two consecutive 5xx both fail closed", async () => {
+    const fetcher = vi.fn<Fetcher>(async () => new Response("boom", { status: 500 }));
+
+    const first = await fetchProjectIndexabilityDecision(parsed, { baseUrl: BASE_URL, fetcher });
+    const second = await fetchProjectIndexabilityDecision(parsed, { baseUrl: BASE_URL, fetcher });
+
+    expect(first).toEqual(FAIL_CLOSED);
+    expect(second).toEqual(FAIL_CLOSED);
+  });
+
   it("clears the timeout timer on success", async () => {
     vi.useFakeTimers();
     const decision = {
@@ -369,5 +391,288 @@ describe("fetchProjectIndexabilityDecision", () => {
     expect(result).toEqual(decision);
     // A cleared timeout leaves no pending fake timers.
     expect(vi.getTimerCount()).toBe(0);
+  });
+});
+
+/**
+ * Last-known-good fallback. Fail-closed is the right default when nothing is
+ * known, but it is the wrong answer when the same endpoint answered
+ * "indexable" seconds ago and the indexer has merely blipped — that de-indexes
+ * a healthy page. A successful decision is therefore replayed for at most
+ * PROJECT_INDEXABILITY_LKG_TTL_MS after a failed lookup, and never longer.
+ */
+describe("fetchProjectIndexabilityDecision last-known-good fallback", () => {
+  const INDEXABLE = {
+    outcome: "canonical-indexable",
+    url: "/project/paraswap/team",
+  };
+
+  function respondOnce(...responses: Array<() => Response>) {
+    let index = 0;
+    return vi.fn<Fetcher>(async () => {
+      const factory = responses[Math.min(index, responses.length - 1)];
+      index += 1;
+      return factory();
+    });
+  }
+
+  async function primeIndexable(): Promise<void> {
+    const fetcher = vi.fn<Fetcher>(async () => jsonResponse(200, INDEXABLE));
+    const result = await fetchProjectIndexabilityDecision(parsed, {
+      baseUrl: BASE_URL,
+      fetcher,
+      timeoutMs: 5000,
+    });
+    expect(result).toEqual(INDEXABLE);
+  }
+
+  it("replays the last successful decision when the indexer returns 5xx", async () => {
+    await primeIndexable();
+
+    const result = await fetchProjectIndexabilityDecision(parsed, {
+      baseUrl: BASE_URL,
+      fetcher: respondOnce(() => new Response("boom", { status: 500 })),
+      timeoutMs: 5000,
+    });
+
+    expect(result).toEqual(INDEXABLE);
+  });
+
+  it("replays the last successful decision when the indexer request times out", async () => {
+    vi.useFakeTimers();
+    await primeIndexable();
+
+    const hangingFetcher = vi.fn<Fetcher>(
+      (_url, init) =>
+        new Promise<Response>((_resolve, reject) => {
+          init.signal?.addEventListener("abort", () => {
+            reject(new DOMException("The operation was aborted.", "AbortError"));
+          });
+        })
+    );
+
+    const promise = fetchProjectIndexabilityDecision(parsed, {
+      baseUrl: BASE_URL,
+      fetcher: hangingFetcher,
+      timeoutMs: 5000,
+    });
+    await vi.advanceTimersByTimeAsync(5000);
+
+    await expect(promise).resolves.toEqual(INDEXABLE);
+  });
+
+  it("replays the last successful decision when the indexer returns an unparseable 200", async () => {
+    await primeIndexable();
+
+    const result = await fetchProjectIndexabilityDecision(parsed, {
+      baseUrl: BASE_URL,
+      fetcher: respondOnce(() => new Response("{not-json", { status: 200 })),
+      timeoutMs: 5000,
+    });
+
+    expect(result).toEqual(INDEXABLE);
+  });
+
+  it("replays the last successful decision one millisecond before the TTL expires", async () => {
+    vi.useFakeTimers();
+    await primeIndexable();
+    await vi.advanceTimersByTimeAsync(PROJECT_INDEXABILITY_LKG_TTL_MS - 1);
+
+    const result = await fetchProjectIndexabilityDecision(parsed, {
+      baseUrl: BASE_URL,
+      fetcher: respondOnce(() => new Response("boom", { status: 500 })),
+      timeoutMs: 5000,
+    });
+
+    expect(result).toEqual(INDEXABLE);
+  });
+
+  it("falls back to noindex-follow once the TTL has elapsed", async () => {
+    vi.useFakeTimers();
+    await primeIndexable();
+    await vi.advanceTimersByTimeAsync(PROJECT_INDEXABILITY_LKG_TTL_MS);
+
+    const result = await fetchProjectIndexabilityDecision(parsed, {
+      baseUrl: BASE_URL,
+      fetcher: respondOnce(() => new Response("boom", { status: 500 })),
+      timeoutMs: 5000,
+    });
+
+    expect(result).toEqual(FAIL_CLOSED);
+  });
+
+  it("keeps a fresh gone answer authoritative over a cached indexable decision", async () => {
+    await primeIndexable();
+
+    const result = await fetchProjectIndexabilityDecision(parsed, {
+      baseUrl: BASE_URL,
+      fetcher: respondOnce(() => new Response("gone", { status: 410 })),
+      timeoutMs: 5000,
+    });
+
+    expect(result).toEqual({ outcome: "gone", status: 410 });
+  });
+
+  it("never remembers a gone answer: a later failure fails closed rather than replaying 404", async () => {
+    const fetcher = respondOnce(
+      () => new Response("gone", { status: 404 }),
+      () => new Response("boom", { status: 500 })
+    );
+
+    const gone = await fetchProjectIndexabilityDecision(parsed, { baseUrl: BASE_URL, fetcher });
+    const afterFailure = await fetchProjectIndexabilityDecision(parsed, {
+      baseUrl: BASE_URL,
+      fetcher,
+    });
+
+    expect(gone).toEqual({ outcome: "gone", status: 404 });
+    expect(afterFailure).toEqual(FAIL_CLOSED);
+  });
+
+  it("forgets a remembered decision once the route is authoritatively gone", async () => {
+    await primeIndexable();
+
+    const gone = await fetchProjectIndexabilityDecision(parsed, {
+      baseUrl: BASE_URL,
+      fetcher: respondOnce(() => new Response("gone", { status: 410 })),
+      timeoutMs: 5000,
+    });
+    // The removal happened; a blip right after it must not resurrect the page.
+    const afterFailure = await fetchProjectIndexabilityDecision(parsed, {
+      baseUrl: BASE_URL,
+      fetcher: respondOnce(() => new Response("boom", { status: 500 })),
+      timeoutMs: 5000,
+    });
+
+    expect(gone).toEqual({ outcome: "gone", status: 410 });
+    expect(afterFailure).toEqual(FAIL_CLOSED);
+  });
+
+  it("forgets a remembered decision on a 200 body that says gone", async () => {
+    await primeIndexable();
+
+    const gone = await fetchProjectIndexabilityDecision(parsed, {
+      baseUrl: BASE_URL,
+      fetcher: respondOnce(() => jsonResponse(200, { outcome: "gone", status: 404 })),
+      timeoutMs: 5000,
+    });
+    const afterFailure = await fetchProjectIndexabilityDecision(parsed, {
+      baseUrl: BASE_URL,
+      fetcher: respondOnce(() => new Response("boom", { status: 500 })),
+      timeoutMs: 5000,
+    });
+
+    expect(gone).toEqual({ outcome: "gone", status: 404 });
+    // Neither the old indexable decision nor the gone answer itself is replayed.
+    expect(afterFailure).toEqual(FAIL_CLOSED);
+  });
+
+  it("does not let a delayed lookup overwrite a decision observed after it started", async () => {
+    // A manual clock makes the two observation stamps unambiguous; the shared
+    // module cache is bypassed so nothing else can interfere.
+    let currentTime = 1_000_000;
+    const lkgCache = createProjectIndexabilityLkgCache<ProjectIndexabilityDecision>({
+      ttlMs: PROJECT_INDEXABILITY_LKG_TTL_MS,
+      maxEntries: 10,
+      now: () => currentTime,
+    });
+    const noindex: ProjectIndexabilityDecision = {
+      outcome: "noindex-follow",
+      url: parsed.normalizedPath,
+    };
+
+    let releaseSlowLookup: (() => void) | undefined;
+    const slow = fetchProjectIndexabilityDecision(parsed, {
+      baseUrl: BASE_URL,
+      timeoutMs: 60_000,
+      lkgCache,
+      fetcher: () =>
+        new Promise<Response>((resolve) => {
+          releaseSlowLookup = () => resolve(jsonResponse(200, INDEXABLE));
+        }),
+    });
+    await vi.waitFor(() => expect(releaseSlowLookup).toBeDefined());
+
+    // The project stops being indexable while the first lookup is still open.
+    currentTime += 1000;
+    await fetchProjectIndexabilityDecision(parsed, {
+      baseUrl: BASE_URL,
+      timeoutMs: 60_000,
+      lkgCache,
+      fetcher: respondOnce(() => jsonResponse(200, noindex)),
+    });
+
+    releaseSlowLookup?.();
+    await expect(slow).resolves.toEqual(INDEXABLE);
+
+    const duringOutage = await fetchProjectIndexabilityDecision(parsed, {
+      baseUrl: BASE_URL,
+      timeoutMs: 60_000,
+      lkgCache,
+      fetcher: respondOnce(() => new Response("boom", { status: 500 })),
+    });
+
+    expect(duringOutage).toEqual(noindex);
+  });
+
+  it("keys the cache per endpoint, so one route's success cannot rescue another route", async () => {
+    await primeIndexable();
+
+    const otherRoute = {
+      identifier: "paraswap",
+      query: { route: "root" as const },
+      normalizedPath: "/project/paraswap",
+    };
+    const result = await fetchProjectIndexabilityDecision(otherRoute, {
+      baseUrl: BASE_URL,
+      fetcher: respondOnce(() => new Response("boom", { status: 500 })),
+      timeoutMs: 5000,
+    });
+
+    expect(result).toEqual({
+      outcome: "noindex-follow",
+      url: otherRoute.normalizedPath,
+    });
+  });
+
+  it("fails closed on a missing baseUrl even when a decision is cached", async () => {
+    await primeIndexable();
+    const fetcher = vi.fn<Fetcher>(async () => jsonResponse(200, INDEXABLE));
+
+    const result = await fetchProjectIndexabilityDecision(parsed, { baseUrl: "", fetcher });
+
+    expect(result).toEqual(FAIL_CLOSED);
+    expect(fetcher).not.toHaveBeenCalled();
+  });
+
+  it("uses an injected cache instead of the module-level one when provided", async () => {
+    const injected = createProjectIndexabilityLkgCache<ProjectIndexabilityDecision>({
+      ttlMs: PROJECT_INDEXABILITY_LKG_TTL_MS,
+      maxEntries: 10,
+    });
+    await fetchProjectIndexabilityDecision(parsed, {
+      baseUrl: BASE_URL,
+      fetcher: respondOnce(() => jsonResponse(200, INDEXABLE)),
+      lkgCache: injected,
+    });
+
+    // The module-level cache saw nothing, so the shared path still fails closed.
+    const fromModuleCache = await fetchProjectIndexabilityDecision(parsed, {
+      baseUrl: BASE_URL,
+      fetcher: respondOnce(() => new Response("boom", { status: 500 })),
+    });
+    // The injected cache did remember it.
+    const fromInjectedCache = await fetchProjectIndexabilityDecision(parsed, {
+      baseUrl: BASE_URL,
+      fetcher: respondOnce(() => new Response("boom", { status: 500 })),
+      lkgCache: injected,
+    });
+
+    expect(fromModuleCache).toEqual(FAIL_CLOSED);
+    expect(fromInjectedCache).toEqual(INDEXABLE);
+  });
+
+  it("pins the TTL to five minutes", () => {
+    expect(PROJECT_INDEXABILITY_LKG_TTL_MS).toBe(5 * 60 * 1000);
   });
 });

--- a/__tests__/utilities/project-indexability-client.test.ts
+++ b/__tests__/utilities/project-indexability-client.test.ts
@@ -438,6 +438,34 @@ describe("fetchProjectIndexabilityDecision last-known-good fallback", () => {
     expect(result).toEqual(INDEXABLE);
   });
 
+  // proxy.ts turns a `redirect` outcome into a 308, which browsers and crawlers
+  // cache hard. Replaying a remembered relocation during an outage would move
+  // users to a possibly-stale URL that outlives the outage, so redirects fail
+  // closed even though indexability outcomes are replayed.
+  it("never replays a remembered redirect: a later failure fails closed", async () => {
+    const REDIRECT = {
+      outcome: "redirect",
+      from: "/project/paraswap-old/team",
+      to: "/project/paraswap/team",
+    };
+
+    const primed = await fetchProjectIndexabilityDecision(parsed, {
+      baseUrl: BASE_URL,
+      fetcher: vi.fn<Fetcher>(async () => jsonResponse(200, REDIRECT)),
+      timeoutMs: 5000,
+    });
+    expect(primed).toEqual(REDIRECT);
+
+    const result = await fetchProjectIndexabilityDecision(parsed, {
+      baseUrl: BASE_URL,
+      fetcher: respondOnce(() => new Response("boom", { status: 500 })),
+      timeoutMs: 5000,
+    });
+
+    expect(result).toEqual({ outcome: "noindex-follow", url: parsed.normalizedPath });
+    expect(result.outcome).not.toBe("redirect");
+  });
+
   it("replays the last successful decision when the indexer request times out", async () => {
     vi.useFakeTimers();
     await primeIndexable();

--- a/__tests__/utilities/project-indexability-lkg-cache.test.ts
+++ b/__tests__/utilities/project-indexability-lkg-cache.test.ts
@@ -1,0 +1,366 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createProjectIndexabilityLkgCache } from "@/utilities/project-indexability-lkg-cache";
+
+/**
+ * Bounded last-known-good store behind the indexability fallback. The TTL is
+ * the safety boundary — an entry is usable strictly *before* `ttlMs` has
+ * elapsed and never at or after it — so the boundary is pinned exactly, with an
+ * injected clock rather than wall-clock sleeps.
+ */
+
+const TTL_MS = 5 * 60 * 1000;
+
+function createClock(startAt = 1_000_000) {
+  let current = startAt;
+  return {
+    now: () => current,
+    advance: (ms: number) => {
+      current += ms;
+    },
+  };
+}
+
+function createCache(maxEntries = 3) {
+  const clock = createClock();
+  const cache = createProjectIndexabilityLkgCache<string>({
+    ttlMs: TTL_MS,
+    maxEntries,
+    now: clock.now,
+  });
+  return { cache, clock };
+}
+
+describe("createProjectIndexabilityLkgCache", () => {
+  it("returns null for an unknown key", () => {
+    const { cache } = createCache();
+
+    expect(cache.get("missing")).toBeNull();
+  });
+
+  it("returns a stored value within the TTL", () => {
+    const { cache, clock } = createCache();
+    cache.set("a", "canonical-indexable");
+    clock.advance(1);
+
+    expect(cache.get("a")).toBe("canonical-indexable");
+  });
+
+  it("still returns the value one millisecond before the TTL boundary", () => {
+    const { cache, clock } = createCache();
+    cache.set("a", "canonical-indexable");
+    clock.advance(TTL_MS - 1);
+
+    expect(cache.get("a")).toBe("canonical-indexable");
+  });
+
+  it("expires the value at exactly the TTL boundary", () => {
+    const { cache, clock } = createCache();
+    cache.set("a", "canonical-indexable");
+    clock.advance(TTL_MS);
+
+    expect(cache.get("a")).toBeNull();
+  });
+
+  it("drops the expired entry so a later read stays null even if the clock rewinds", () => {
+    const clock = createClock();
+    const cache = createProjectIndexabilityLkgCache<string>({
+      ttlMs: TTL_MS,
+      maxEntries: 3,
+      now: clock.now,
+    });
+    cache.set("a", "canonical-indexable");
+    clock.advance(TTL_MS);
+    expect(cache.get("a")).toBeNull();
+
+    clock.advance(-TTL_MS);
+
+    expect(cache.get("a")).toBeNull();
+  });
+
+  it("refreshes the age when a key is written again", () => {
+    const { cache, clock } = createCache();
+    cache.set("a", "first");
+    clock.advance(TTL_MS - 1);
+    cache.set("a", "second");
+    clock.advance(TTL_MS - 1);
+
+    expect(cache.get("a")).toBe("second");
+  });
+
+  it("evicts the oldest write once maxEntries is exceeded", () => {
+    const { cache } = createCache(3);
+    cache.set("a", "1");
+    cache.set("b", "2");
+    cache.set("c", "3");
+    cache.set("d", "4");
+
+    expect(cache.get("a")).toBeNull();
+    expect(cache.get("b")).toBe("2");
+    expect(cache.get("c")).toBe("3");
+    expect(cache.get("d")).toBe("4");
+  });
+
+  it("treats a rewrite as a fresh write for eviction order", () => {
+    const { cache } = createCache(3);
+    cache.set("a", "1");
+    cache.set("b", "2");
+    cache.set("c", "3");
+    cache.set("a", "1-again");
+    cache.set("d", "4");
+
+    // "b" was the oldest remaining write once "a" was rewritten.
+    expect(cache.get("b")).toBeNull();
+    expect(cache.get("a")).toBe("1-again");
+    expect(cache.get("d")).toBe("4");
+  });
+
+  it("stores nothing when maxEntries is zero", () => {
+    const cache = createProjectIndexabilityLkgCache<string>({ ttlMs: TTL_MS, maxEntries: 0 });
+    cache.set("a", "1");
+
+    expect(cache.get("a")).toBeNull();
+  });
+
+  it("empties every entry on clear", () => {
+    const { cache } = createCache();
+    cache.set("a", "1");
+    cache.set("b", "2");
+
+    cache.clear();
+
+    expect(cache.get("a")).toBeNull();
+    expect(cache.get("b")).toBeNull();
+  });
+
+  it("defaults to the real clock when none is injected", () => {
+    const cache = createProjectIndexabilityLkgCache<string>({ ttlMs: TTL_MS, maxEntries: 3 });
+    cache.set("a", "1");
+
+    expect(cache.get("a")).toBe("1");
+  });
+
+  it("exposes a clock that never runs backwards", () => {
+    const cache = createProjectIndexabilityLkgCache<string>({ ttlMs: TTL_MS, maxEntries: 3 });
+
+    const first = cache.now();
+    const second = cache.now();
+
+    expect(typeof first).toBe("number");
+    expect(second).toBeGreaterThanOrEqual(first);
+  });
+
+  it("reads back the injected clock", () => {
+    const { cache, clock } = createCache();
+    clock.advance(42);
+
+    expect(cache.now()).toBe(clock.now());
+  });
+});
+
+/**
+ * Write ordering. What is remembered here is later replayed as an authoritative
+ * answer during an outage, so a write may only land if nothing newer is already
+ * known — otherwise a slow lookup that started before a project changed state
+ * would clobber the fresher decision on arrival, and an authoritative removal
+ * could be undone by an older response still in flight.
+ */
+describe("createProjectIndexabilityLkgCache write ordering", () => {
+  it("ignores a write observed before the stored entry", () => {
+    const { cache, clock } = createCache();
+    const staleObservedAt = clock.now();
+    clock.advance(1000);
+    cache.set("a", "noindex");
+
+    cache.set("a", "indexable", staleObservedAt);
+
+    expect(cache.get("a")).toBe("noindex");
+  });
+
+  it("keeps the stored entry's own age when an older write is ignored", () => {
+    const { cache, clock } = createCache();
+    const staleObservedAt = clock.now();
+    clock.advance(1000);
+    cache.set("a", "noindex");
+
+    cache.set("a", "indexable", staleObservedAt);
+    clock.advance(TTL_MS - 1);
+
+    // The rejected write must not have refreshed the TTL either.
+    expect(cache.get("a")).toBe("noindex");
+    clock.advance(1);
+    expect(cache.get("a")).toBeNull();
+  });
+
+  it("accepts a write observed after the stored entry", () => {
+    const { cache, clock } = createCache();
+    cache.set("a", "indexable");
+    clock.advance(1000);
+
+    cache.set("a", "noindex", clock.now());
+
+    expect(cache.get("a")).toBe("noindex");
+  });
+});
+
+/**
+ * Invalidation is a tombstone, not a delete: a removed route must read as
+ * "nothing remembered" *and* stay unrecoverable by an older in-flight write.
+ */
+describe("createProjectIndexabilityLkgCache invalidation", () => {
+  it("stops replaying a value once the key is invalidated", () => {
+    const { cache } = createCache();
+    cache.set("a", "indexable");
+
+    cache.invalidate("a");
+
+    expect(cache.get("a")).toBeNull();
+  });
+
+  it("blocks an older write from resurrecting an invalidated key", () => {
+    const { cache, clock } = createCache();
+    const staleObservedAt = clock.now();
+    clock.advance(1000);
+    cache.invalidate("a");
+
+    cache.set("a", "indexable", staleObservedAt);
+
+    expect(cache.get("a")).toBeNull();
+  });
+
+  it("lets a newer write replace the tombstone", () => {
+    const { cache, clock } = createCache();
+    cache.invalidate("a");
+    clock.advance(1000);
+
+    cache.set("a", "indexable", clock.now());
+
+    expect(cache.get("a")).toBe("indexable");
+  });
+
+  it("counts a tombstone against maxEntries and evicts it in write order", () => {
+    const { cache } = createCache(2);
+    cache.invalidate("a");
+    cache.set("b", "2");
+    cache.set("c", "3");
+
+    // "a" was the oldest write, tombstone or not, so it is the one dropped.
+    expect(cache.get("b")).toBe("2");
+    expect(cache.get("c")).toBe("3");
+  });
+
+  it("stores no tombstone when maxEntries is zero", () => {
+    const cache = createProjectIndexabilityLkgCache<string>({ ttlMs: TTL_MS, maxEntries: 0 });
+
+    cache.invalidate("a");
+
+    expect(cache.get("a")).toBeNull();
+  });
+});
+
+/**
+ * The default clock, exercised through the TTL because that is the only thing
+ * it exists for. Neither time source can be trusted alone: the wall clock steps
+ * backwards on an NTP correction, and the monotonic clock stops while a
+ * serverless instance is frozen. Either failure would understate an entry's age
+ * and keep a stale "indexable" decision replayable past its TTL, so the age has
+ * to follow whichever source reports more elapsed time.
+ */
+describe("createProjectIndexabilityLkgCache default clock", () => {
+  const START_WALL = 1_700_000_000_000;
+
+  function stubClocks(startMonotonic: number | null) {
+    let wall = START_WALL;
+    let monotonic = startMonotonic;
+    vi.spyOn(Date, "now").mockImplementation(() => wall);
+    vi.stubGlobal("performance", monotonic === null ? undefined : { now: () => monotonic });
+    return {
+      setWall: (value: number) => {
+        wall = value;
+      },
+      setMonotonic: (value: number) => {
+        monotonic = value;
+      },
+    };
+  }
+
+  function createDefaultClockCache() {
+    return createProjectIndexabilityLkgCache<string>({ ttlMs: TTL_MS, maxEntries: 3 });
+  }
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it("keeps an entry that is fresh on both clocks", () => {
+    const clocks = stubClocks(0);
+    const cache = createDefaultClockCache();
+    cache.set("a", "indexable");
+
+    clocks.setWall(START_WALL + 1000);
+    clocks.setMonotonic(1000);
+
+    expect(cache.get("a")).toBe("indexable");
+  });
+
+  it("expires an entry when the wall clock steps backwards mid-TTL", () => {
+    const clocks = stubClocks(0);
+    const cache = createDefaultClockCache();
+    cache.set("a", "indexable");
+
+    // An NTP correction drags the wall clock back an hour while the TTL elapses.
+    clocks.setWall(START_WALL - 60 * 60 * 1000);
+    clocks.setMonotonic(TTL_MS);
+
+    expect(cache.get("a")).toBeNull();
+  });
+
+  it("expires an entry after a freeze the monotonic clock never saw", () => {
+    const clocks = stubClocks(0);
+    const cache = createDefaultClockCache();
+    cache.set("a", "indexable");
+
+    // The instance was frozen: wall time moved on, performance.now did not.
+    clocks.setWall(START_WALL + TTL_MS);
+
+    expect(cache.get("a")).toBeNull();
+  });
+
+  it("falls back to the wall clock when no monotonic clock exists", () => {
+    const clocks = stubClocks(null);
+    const cache = createDefaultClockCache();
+    cache.set("a", "indexable");
+
+    clocks.setWall(START_WALL + TTL_MS);
+
+    expect(cache.get("a")).toBeNull();
+  });
+
+  it("reports whole milliseconds even though performance.now is sub-millisecond", () => {
+    const clocks = stubClocks(0);
+    const cache = createDefaultClockCache();
+
+    clocks.setMonotonic(1.5);
+
+    expect(Number.isInteger(cache.now())).toBe(true);
+  });
+
+  it("expires an entry at exactly the TTL after a sub-millisecond reading", () => {
+    // `performance.now` is fractional, so an accumulated age carries a
+    // fraction. Summing that fraction into a float makes the difference of two
+    // readings land a few ulps low — 324759.206784 + TTL_MS reads back as
+    // 299999.99999999994 elapsed — which would keep a stale decision usable one
+    // tick past its own expiry.
+    const FRACTIONAL_MONOTONIC = 324_759.206784;
+    const clocks = stubClocks(0);
+    const cache = createDefaultClockCache();
+
+    clocks.setMonotonic(FRACTIONAL_MONOTONIC);
+    cache.set("a", "indexable");
+
+    clocks.setWall(START_WALL + TTL_MS);
+    clocks.setMonotonic(FRACTIONAL_MONOTONIC + TTL_MS);
+
+    expect(cache.get("a")).toBeNull();
+  });
+});

--- a/proxy.ts
+++ b/proxy.ts
@@ -285,8 +285,10 @@ export async function proxy(request: NextRequest) {
  * from the indexer; this collapses the alias-host switch, legacy segment
  * normalization (grants → funding, create-grant → new), roadmap collapse, and
  * old-identifier redirects into exactly one 308 hop when the request is not
- * already at its canonical www URL. Any decision failure fails closed to
- * noindex,follow via the client.
+ * already at its canonical www URL. A failed lookup replays this instance's
+ * last-known-good decision for the same endpoint when one is fresh enough, and
+ * otherwise fails closed to noindex,follow — both handled inside the client, so
+ * nothing here changes.
  */
 async function handleProjectIndexability(
   request: NextRequest,

--- a/utilities/project-indexability-client.ts
+++ b/utilities/project-indexability-client.ts
@@ -1,17 +1,29 @@
 /**
  * Pure, framework-free (Edge-safe) client for the project indexability decision.
- * No Node/Next imports — only the sibling path helper, globalThis.fetch,
+ * No Node/Next imports — only the sibling path helpers, globalThis.fetch,
  * AbortController, and timers — so it runs on the Edge runtime as well as in
  * server/metadata code. It is strict on the wire and fails closed: any failure
  * degrades to noindex,follow at the request's normalized path (ADR 0001, D5/D9).
+ *
+ * Amendment to that fail-closed rule: a transient indexer blip must not
+ * de-index a page that was just known to be indexable, so a failed lookup
+ * first replays the last successful decision for the same endpoint when one is
+ * less than PROJECT_INDEXABILITY_LKG_TTL_MS old. Fail-closed remains the
+ * behavior whenever no fresh-enough decision is known. The cache is per runtime
+ * instance (see project-indexability-lkg-cache.ts) — it covers warm instances
+ * only, so a cold instance during an outage still fails closed.
  */
 import {
   buildProjectIndexabilityEndpoint,
   type ProjectIndexabilityRequest,
 } from "./project-indexability";
+import {
+  createProjectIndexabilityLkgCache,
+  type ProjectIndexabilityLkgCache,
+} from "./project-indexability-lkg-cache";
 
 /** The exact indexability decision union returned by the backend. */
-type ProjectIndexabilityDecision =
+export type ProjectIndexabilityDecision =
   | { outcome: "canonical-indexable"; url: string }
   | { outcome: "duplicate-alias"; url: string; canonicalUrl: string }
   | { outcome: "noindex-follow"; url: string }
@@ -24,9 +36,31 @@ interface FetchProjectIndexabilityOptions {
   baseUrl: string;
   fetcher?: ProjectIndexabilityFetcher;
   timeoutMs?: number;
+  /** Overridable last-known-good store; defaults to the module-level cache. */
+  lkgCache?: ProjectIndexabilityLkgCache<ProjectIndexabilityDecision>;
 }
 
 const DEFAULT_TIMEOUT_MS = 2500;
+
+/**
+ * How long a successful decision may be replayed after a failed lookup. Kept
+ * deliberately short: serving a stale "indexable" indefinitely is not
+ * acceptable, but indexer blips last seconds to minutes, which this covers.
+ */
+export const PROJECT_INDEXABILITY_LKG_TTL_MS = 5 * 60 * 1000;
+
+/** Bounds instance memory; entries are one small decision object each. */
+const PROJECT_INDEXABILITY_LKG_MAX_ENTRIES = 500;
+
+const projectIndexabilityLkgCache = createProjectIndexabilityLkgCache<ProjectIndexabilityDecision>({
+  ttlMs: PROJECT_INDEXABILITY_LKG_TTL_MS,
+  maxEntries: PROJECT_INDEXABILITY_LKG_MAX_ENTRIES,
+});
+
+/** Drop every remembered decision (operational reset; test isolation). */
+export function clearProjectIndexabilityLkgCache(): void {
+  projectIndexabilityLkgCache.clear();
+}
 
 /**
  * Strictly parse an unknown value into a ProjectIndexabilityDecision, or null.
@@ -91,9 +125,22 @@ export function parseProjectIndexabilityDecision(
 
 /**
  * Fetch the authoritative indexability decision for a parsed request. HTTP
- * 404/410 map directly to `gone`; a valid 200 body is strictly parsed; every
- * other case — missing baseUrl, 5xx, invalid JSON/shape, network error, or
- * timeout/abort — silently fails closed to noindex,follow at normalizedPath.
+ * 404/410 map directly to `gone`; a valid 200 body is strictly parsed and
+ * remembered as the endpoint's last-known-good decision. Every other case —
+ * 5xx, invalid JSON/shape, network error, or timeout/abort — replays that
+ * remembered decision while it is younger than PROJECT_INDEXABILITY_LKG_TTL_MS,
+ * and otherwise fails closed to noindex,follow at normalizedPath. A missing
+ * baseUrl is a config error, not a blip, so it fails closed without consulting
+ * the cache.
+ *
+ * `gone` is never remembered and never overridden by the cache: it is a
+ * definitive fresh answer, so in either of its forms — an HTTP 404/410 or a 200
+ * body saying `gone` — it invalidates whatever was remembered for the endpoint.
+ * A removed route can then neither be resurrected as indexable from memory nor
+ * keep answering 404/410 once the indexer stops saying so.
+ *
+ * The lookup is stamped with the cache's clock *before* the request goes out,
+ * so a slow response cannot overwrite a decision observed after it started.
  */
 export async function fetchProjectIndexabilityDecision(
   parsed: ProjectIndexabilityRequest,
@@ -118,6 +165,16 @@ export async function fetchProjectIndexabilityDecision(
       : DEFAULT_TIMEOUT_MS;
 
   const endpoint = buildProjectIndexabilityEndpoint(baseUrl, parsed);
+  const lkgCache = options.lkgCache ?? projectIndexabilityLkgCache;
+  // The endpoint already encodes identifier + route + grantUid, so it is the
+  // cache key. Every remembered decision was validated by the parser, so a
+  // replay can never introduce an unvalidated redirect target.
+  const lastKnownGood = (): ProjectIndexabilityDecision => lkgCache.get(endpoint) ?? failClosed;
+  // Stamped before the request is issued: the decision describes the endpoint as
+  // of this moment, and ordering writes by it keeps a delayed response from
+  // overwriting one observed later.
+  const observedAt = lkgCache.now();
+
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), timeoutMs);
 
@@ -129,17 +186,27 @@ export async function fetchProjectIndexabilityDecision(
     });
 
     if (response.status === 404 || response.status === 410) {
+      lkgCache.invalidate(endpoint, observedAt);
       return { outcome: "gone", status: response.status };
     }
 
     if (response.status !== 200) {
-      return failClosed;
+      return lastKnownGood();
     }
 
     const body: unknown = await response.json();
-    return parseProjectIndexabilityDecision(body) ?? failClosed;
+    const decision = parseProjectIndexabilityDecision(body);
+    if (!decision) {
+      return lastKnownGood();
+    }
+    if (decision.outcome === "gone") {
+      lkgCache.invalidate(endpoint, observedAt);
+    } else {
+      lkgCache.set(endpoint, decision, observedAt);
+    }
+    return decision;
   } catch {
-    return failClosed;
+    return lastKnownGood();
   } finally {
     clearTimeout(timer);
   }

--- a/utilities/project-indexability-client.ts
+++ b/utilities/project-indexability-client.ts
@@ -169,7 +169,18 @@ export async function fetchProjectIndexabilityDecision(
   // The endpoint already encodes identifier + route + grantUid, so it is the
   // cache key. Every remembered decision was validated by the parser, so a
   // replay can never introduce an unvalidated redirect target.
-  const lastKnownGood = (): ProjectIndexabilityDecision => lkgCache.get(endpoint) ?? failClosed;
+  //
+  // `redirect` is deliberately NOT replayed. proxy.ts turns that outcome into a
+  // 308 (see the isAliasHost and finalPath branches), and a 308 is cached hard
+  // by browsers and crawlers — so replaying a stale relocation would move users
+  // to a possibly-wrong URL long after the indexer recovered. Failing closed
+  // costs one request a noindex; a wrongly cached 308 outlives the outage.
+  // Indexability outcomes carry no such risk: the worst case is a page that
+  // stays indexable or noindexed a few minutes longer than it should.
+  const lastKnownGood = (): ProjectIndexabilityDecision => {
+    const remembered = lkgCache.get(endpoint);
+    return remembered && remembered.outcome !== "redirect" ? remembered : failClosed;
+  };
   // Stamped before the request is issued: the decision describes the endpoint as
   // of this moment, and ordering writes by it keeps a delayed response from
   // overwriting one observed later.

--- a/utilities/project-indexability-lkg-cache.ts
+++ b/utilities/project-indexability-lkg-cache.ts
@@ -1,0 +1,167 @@
+/**
+ * Pure, framework-free (Edge-safe) TTL cache for last-known-good indexability
+ * decisions. No Node/Next imports — a Map plus an injectable clock — so it runs
+ * wherever the indexability client runs.
+ *
+ * Scope: the cache is module state, i.e. per runtime instance. A serverless
+ * instance starts cold with an empty cache and never shares it with its peers,
+ * so this only covers the warm-instance case (steady traffic hitting an
+ * instance that already answered for the same route). It is a mitigation, not
+ * a durable store; a durable fix belongs in the indexer (stale-while-error).
+ *
+ * Two properties matter for correctness, because what is remembered here can
+ * later be replayed as an *indexable* answer:
+ *
+ * 1. Writes are ordered by observation time, not by completion time. A caller
+ *    stamps `observedAt` when it starts its lookup and passes it back on write,
+ *    so a slow in-flight lookup can never overwrite a decision observed after
+ *    it started (a `noindex` answer must not be clobbered by an older, delayed
+ *    `indexable` one).
+ * 2. `invalidate` writes a tombstone rather than deleting, so an authoritative
+ *    removal cannot be undone by an older write that is still in flight. A
+ *    tombstoned key reads as "nothing remembered" until it expires.
+ */
+
+export interface ProjectIndexabilityLkgCacheOptions {
+  /** Maximum age of a usable entry. An entry is expired at exactly `ttlMs`. */
+  ttlMs: number;
+  /** Hard cap on retained entries; the oldest write is evicted first. */
+  maxEntries: number;
+  /** Injectable clock (see createDefaultClock) so TTL behavior is testable. */
+  now?: () => number;
+}
+
+export interface ProjectIndexabilityLkgCache<TValue> {
+  /** Reads the cache's own clock; stamp a lookup with it and pass it back on write. */
+  now(): number;
+  /** The remembered value, or null when nothing usable (missing, expired, tombstoned). */
+  get(key: string): TValue | null;
+  /** Remember a value unless a strictly newer observation is already stored. */
+  set(key: string, value: TValue, observedAt?: number): void;
+  /** Tombstone a key so nothing is replayed for it and no older write revives it. */
+  invalidate(key: string, observedAt?: number): void;
+  clear(): void;
+}
+
+interface CacheEntry<TValue> {
+  /** null marks a tombstone: the key is known to have no replayable decision. */
+  value: TValue | null;
+  observedAt: number;
+}
+
+/**
+ * The default clock, built so that neither available time source can understate
+ * an entry's age — an understated age is what lets a stale "indexable" decision
+ * outlive its TTL.
+ *
+ * Neither source is safe alone. The wall clock (`Date.now`) can step backwards
+ * on an NTP correction. The monotonic clock (`performance.now`) never steps
+ * back, but it does not advance while a serverless instance is frozen between
+ * invocations, so an entry stored before a freeze would look brand new on thaw.
+ *
+ * So each reading advances by whichever source reports the larger elapsed time
+ * since the previous reading, floored at zero. The result never runs backwards,
+ * counts frozen time, and is only ever conservative (an over-counted age just
+ * expires an entry early). Both sources are read through `globalThis` on every
+ * call so a clock installed later — a test's fake timers, say — is the one used.
+ *
+ * Readings are whole milliseconds. `performance.now` is sub-millisecond, and
+ * summing those fractions in a float makes a difference of two readings land a
+ * few ulps off the true elapsed time — enough for an entry advanced by exactly
+ * `ttlMs` to measure as 299999.99999999994 and survive its own expiry. The
+ * sub-millisecond remainder is therefore carried separately and only folded in
+ * once it completes a millisecond, so the returned value is an exact integer
+ * and no precision is lost.
+ */
+function createDefaultClock(): () => number {
+  const readMonotonic = (): number | null =>
+    typeof globalThis.performance?.now === "function" ? globalThis.performance.now() : null;
+
+  let elapsed = 0;
+  let remainder = 0;
+  let lastWall = Date.now();
+  let lastMonotonic = readMonotonic();
+
+  return () => {
+    const wall = Date.now();
+    const monotonic = readMonotonic();
+    const monotonicAdvance =
+      monotonic !== null && lastMonotonic !== null ? monotonic - lastMonotonic : 0;
+    const advance = remainder + Math.max(wall - lastWall, monotonicAdvance, 0);
+    const wholeMs = Math.floor(advance);
+    elapsed += wholeMs;
+    remainder = advance - wholeMs;
+    lastWall = wall;
+    lastMonotonic = monotonic;
+    return elapsed;
+  };
+}
+
+/**
+ * Create a bounded TTL cache. Entries expire lazily on read and are evicted in
+ * write order (a re-set counts as a fresh write, both for the TTL and for the
+ * eviction order) once `maxEntries` is exceeded. Eviction is therefore FIFO by
+ * write, not LRU — reads do not refresh an entry — which is fine at this size:
+ * every entry is capped by the same short TTL anyway.
+ */
+export function createProjectIndexabilityLkgCache<TValue>(
+  options: ProjectIndexabilityLkgCacheOptions
+): ProjectIndexabilityLkgCache<TValue> {
+  const { ttlMs, maxEntries } = options;
+  const now = options.now ?? createDefaultClock();
+  const entries = new Map<string, CacheEntry<TValue>>();
+
+  /**
+   * Shared write path. Drops the write when the stored entry was observed
+   * strictly later than this one; equal stamps fall through to last-write-wins,
+   * which is all a clock of finite resolution can distinguish.
+   */
+  function write(key: string, value: TValue | null, observedAt: number): void {
+    if (maxEntries <= 0) {
+      return;
+    }
+    const stored = entries.get(key);
+    if (stored && stored.observedAt > observedAt) {
+      return;
+    }
+    // Re-inserting moves the key to the end of the Map's insertion order, so
+    // eviction always drops the least-recently-written entry.
+    entries.delete(key);
+    entries.set(key, { value, observedAt });
+    while (entries.size > maxEntries) {
+      const oldestKey = entries.keys().next().value;
+      if (oldestKey === undefined) {
+        return;
+      }
+      entries.delete(oldestKey);
+    }
+  }
+
+  return {
+    now,
+
+    get(key: string): TValue | null {
+      const entry = entries.get(key);
+      if (!entry) {
+        return null;
+      }
+      if (now() - entry.observedAt >= ttlMs) {
+        entries.delete(key);
+        return null;
+      }
+      return entry.value;
+    },
+
+    set(key: string, value: TValue, observedAt: number = now()): void {
+      write(key, value, observedAt);
+    },
+
+    invalidate(key: string, observedAt: number = now()): void {
+      write(key, null, observedAt);
+    },
+
+    clear(): void {
+      entries.clear();
+    },
+  };
+}


### PR DESCRIPTION
## Overview

DEV-594 (AEO-11), part of DEV-583. A transient indexer failure no longer de-indexes project pages that were known-indexable moments earlier. A warm runtime instance replays its last successful indexability decision for a bounded window; everything else fails closed exactly as before.

## Problem

`fetchProjectIndexabilityDecision` failed closed on *every* failure. A 5xx, a request timeout, or a malformed response body all produced `noindex, follow`, which the proxy then stamped on the response — for pages the indexer had called `canonical-indexable` seconds earlier.

The cost is asymmetric. Search engines act on a `noindex` immediately, but recovery waits for a recrawl, so a few minutes of indexer trouble can cost days of organic traffic. Fail-closed is the right default when nothing is known about a route; it is the wrong answer when the same endpoint answered "indexable" a moment ago and the indexer has merely blipped.

## Solution

A failed lookup now replays the endpoint's last successful decision when one is younger than `PROJECT_INDEXABILITY_LKG_TTL_MS` (5 minutes), and falls back to `noindex, follow` when none is.

**Scope of the mitigation.** The cache is module state, i.e. per runtime instance. A cold serverless instance starts with an empty cache and never shares it with its peers, so this only covers the warm-instance case. It is a mitigation, not a durable store — a durable fix (stale-while-error) belongs in the indexer.

**Freshness stays authoritative over memory.** A `gone` answer — whether an HTTP 404/410 or a 200 body saying `gone` — is never remembered and invalidates whatever was remembered for that endpoint. A removed route can therefore neither be resurrected as indexable from memory, nor keep answering 404/410 once the indexer stops saying so. A missing `baseUrl` is a configuration error rather than a blip, so it fails closed without consulting the cache.

**The store is built so it cannot become the bug itself** (`utilities/project-indexability-lkg-cache.ts`), because what it remembers can later be replayed as an *indexable* answer:

- Writes are ordered by observation time, not completion time. A lookup stamps `observedAt` before it goes out and passes it back on write, so a slow in-flight lookup cannot clobber a decision observed after it started.
- `invalidate` writes a tombstone rather than deleting, so an authoritative removal cannot be undone by an older write still in flight.
- Entries are bounded (500) and evicted in write order.
- The clock takes whichever of the wall and monotonic sources reports more elapsed time. Neither is safe alone: the wall clock steps backwards on an NTP correction, and `performance.now` does not advance while a serverless instance is frozen between invocations. Either failure would understate an entry's age and keep a stale "indexable" decision replayable past its TTL.

`proxy.ts` is unchanged apart from a doc comment — the whole behaviour lives inside the client.

## Testing steps

```bash
pnpm vitest run --project unit \
  __tests__/utilities/project-indexability-lkg-cache.test.ts \
  __tests__/utilities/project-indexability-client.test.ts \
  __tests__/middleware-indexability.test.ts
pnpm typecheck
```

130 tests pass. Coverage was added at three levels:

- **Cache unit tests** — TTL boundary pinned exactly (usable at `ttlMs - 1`, expired at `ttlMs`), write ordering, tombstones, eviction, and each clock-failure mode (wall step-back, instance freeze, no monotonic clock available).
- **Client tests** — replay on 5xx / timeout / unparseable 200; expiry at the TTL; `gone` in both forms invalidating; per-endpoint keying, so one route's success cannot rescue another; missing `baseUrl` still failing closed; a delayed lookup not overwriting a newer decision.
- **Middleware tests** — the same flows end to end through `proxy()`, asserting the actual `X-Robots-Tag` header: a known-indexable project stays indexable through a timeout and through a 5xx, a **cold** instance still fails closed, the fallback stops at the TTL, and a removed project is not resurrected by a blip landing after its removal.

To exercise it manually: load a project page (populating the instance's cache), point `NEXT_PUBLIC_GAP_INDEXER_URL` at an unreachable host, and reload — the response keeps its indexable headers rather than gaining `X-Robots-Tag: noindex, follow`. Restart the dev server first (cold instance) and the same request fails closed.

## Risk / scope notes

- **Bounded staleness.** The worst case is serving an indexable page for up to 5 minutes after it should have gone `noindex`, and only on an instance that observed it healthy within that window. Weighed against the current behaviour — de-indexing healthy pages on any blip — this is the safer failure.
- **Replayed values are pre-validated.** Only decisions that already passed the strict runtime parser are stored, so a replay can never introduce an unvalidated redirect target.
- **Memory.** Capped at 500 small decision objects per instance.
- **Blast radius.** Additive and confined to `utilities/project-indexability-client.ts` plus one new module. The only paths whose behaviour changes are the ones that previously returned `noindex, follow`; the success path and the `gone` path are unchanged. `proxy.ts` has no behavioural change.
- **Not a durable fix.** Cold instances during an outage still fail closed. The durable answer is stale-while-error in the indexer, tracked separately.

## Review notes

Two independent reviews were run over this change. What they raised and how it was resolved:

1. **A delayed lookup could overwrite a newer decision.** The original write stamped the cache at completion time, so a slow lookup returning `indexable` could land *after* a fast lookup had recorded `noindex` and clobber it — replaying an indexable answer for a page that had already stopped being one. Resolved by stamping `observedAt` before the request is issued and ordering writes by it; a write whose observation is older than the stored entry is dropped. Covered by "does not let a delayed lookup overwrite a decision observed after it started".

2. **Deleting on invalidation left a resurrection window.** `invalidate` originally removed the key, so an older in-flight write could re-add the decision after an authoritative removal. Resolved by writing a tombstone instead, which reads as "nothing remembered" and blocks older writes until it expires.

3. **A `gone` answer had to be authoritative in both of its forms.** The first pass only invalidated on HTTP 404/410, leaving a 200 body saying `gone` able to coexist with a remembered indexable decision. Both forms now invalidate, and `gone` is never itself remembered.

4. **The TTL clock could understate an entry's age.** Reading the wall clock alone is wrong under an NTP step-back; reading `performance.now` alone is wrong across a serverless freeze, since it does not advance while the instance is frozen. Either would let a stale "indexable" outlive its TTL. Resolved by advancing the clock by whichever source reports more elapsed time, floored at zero, with a test per failure mode.

5. **Missing `baseUrl` must not consult the cache.** It signals a misconfigured environment rather than a transient blip, so replaying a decision would mask it. It fails closed before the cache is touched.

One further defect was found while validating the branch, and is fixed here rather than left to CI:

6. **The TTL boundary was off by a floating-point epsilon.** The clock accumulated fractional `performance.now` readings into a float, so the difference of two readings could land a few ulps low — an entry aged exactly `ttlMs` measured as `299999.99999999994` and survived its own expiry. This surfaced as an intermittent failure (roughly 1 run in 6) in "falls back to noindex-follow once the TTL has elapsed", and would have been an intermittently red build. The clock now carries whole milliseconds with the sub-millisecond remainder kept aside, so readings are exact integers and no precision is lost. Two regression tests pin it; both fail against the previous implementation. Twelve consecutive runs of the three affected files are green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Project indexability decisions now retain a last-known-good result for up to five minutes.
  - Temporary lookup failures can preserve existing indexability behavior instead of immediately changing it.
  - Cache entries are isolated, bounded, and automatically expire.
  - Fresh project removal responses override cached results, preventing removed projects from being served as indexable.
  - Redirect decisions are not replayed from cache.

- **Bug Fixes**
  - Failed lookups fail closed when no valid prior decision exists.
  - Stale responses can no longer overwrite newer decisions.

- **Documentation**
  - Updated indexability guidance to describe fallback behavior during failed lookups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->