### PR TITLE
feat(analytics): answer-engine referrer classification and AEO release log

### DIFF
--- a/__tests__/unit/components/AiReferrerTracker.test.tsx
+++ b/__tests__/unit/components/AiReferrerTracker.test.tsx
@@ -1,0 +1,189 @@
+/**
+ * @file Tests for AiReferrerTracker — the one-shot mount tracker that captures
+ * first-touch answer-engine attribution and emits the landing event.
+ */
+
+import { sendGAEvent } from "@next/third-parties/google";
+import { render } from "@testing-library/react";
+import { AiReferrerTracker } from "@/components/Utilities/AiReferrerTracker";
+import {
+  __resetAiFirstTouchCacheForTests,
+  AI_FIRST_TOUCH_STORAGE_KEY,
+  type AiFirstTouch,
+} from "@/utilities/aiReferrer";
+import { mixpanelEvent } from "@/utilities/mixpanelEvent";
+
+vi.mock("@next/third-parties/google", () => ({
+  sendGAEvent: vi.fn(),
+}));
+
+vi.mock("@/utilities/mixpanelEvent", () => ({
+  mixpanelEvent: vi.fn(),
+}));
+
+const mockMixpanelEvent = vi.mocked(mixpanelEvent);
+const mockSendGAEvent = vi.mocked(sendGAEvent);
+
+describe("AiReferrerTracker", () => {
+  const originalEnv = process.env;
+  let referrerSpy: ReturnType<typeof vi.spyOn> | undefined;
+
+  const setReferrer = (referrer: string) => {
+    referrerSpy = vi.spyOn(document, "referrer", "get").mockReturnValue(referrer);
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env = { ...originalEnv };
+    window.localStorage.clear();
+    __resetAiFirstTouchCacheForTests();
+  });
+
+  afterEach(() => {
+    referrerSpy?.mockRestore();
+    referrerSpy = undefined;
+    process.env = originalEnv;
+  });
+
+  it("renders nothing", () => {
+    setReferrer("https://chatgpt.com/c/abc");
+
+    const { container } = render(<AiReferrerTracker />);
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("captures the first touch and fires the landing event once on an AI referral", () => {
+    setReferrer("https://www.perplexity.ai/search?q=karma");
+
+    const { rerender } = render(<AiReferrerTracker />);
+    rerender(<AiReferrerTracker />);
+
+    expect(mockMixpanelEvent).toHaveBeenCalledTimes(1);
+    expect(mockMixpanelEvent).toHaveBeenCalledWith({
+      event: "ai-referral-landing",
+      properties: {
+        ai_source: "perplexity",
+        ai_source_medium: "referral",
+        ai_landing_path: window.location.pathname,
+      },
+    });
+
+    const stored = JSON.parse(
+      window.localStorage.getItem(AI_FIRST_TOUCH_STORAGE_KEY) ?? "null"
+    ) as AiFirstTouch;
+    expect(stored.source).toBe("perplexity");
+  });
+
+  it("fires no landing event for non-AI traffic and stores nothing", () => {
+    setReferrer("https://www.google.com/");
+
+    render(<AiReferrerTracker />);
+
+    expect(mockMixpanelEvent).not.toHaveBeenCalled();
+    expect(window.localStorage.getItem(AI_FIRST_TOUCH_STORAGE_KEY)).toBeNull();
+  });
+
+  it("does not re-fire — or overwrite — when a first touch is already stored", () => {
+    const existing: AiFirstTouch = {
+      source: "claude",
+      medium: "referral",
+      landingPath: "/project/my-project",
+      firstSeenAt: "2026-07-31T10:00:00.000Z",
+    };
+    window.localStorage.setItem(AI_FIRST_TOUCH_STORAGE_KEY, JSON.stringify(existing));
+    setReferrer("https://chatgpt.com/c/abc");
+
+    render(<AiReferrerTracker />);
+
+    expect(mockMixpanelEvent).not.toHaveBeenCalled();
+    expect(JSON.parse(window.localStorage.getItem(AI_FIRST_TOUCH_STORAGE_KEY) ?? "null")).toEqual(
+      existing
+    );
+  });
+
+  it("does not send a GA event when no GA tracking id is configured", () => {
+    delete process.env.NEXT_PUBLIC_GA_TRACKING_ID;
+    process.env.NEXT_PUBLIC_ENV = "production";
+    setReferrer("https://chatgpt.com/c/abc");
+
+    render(<AiReferrerTracker />);
+
+    expect(mockSendGAEvent).not.toHaveBeenCalled();
+  });
+
+  it("does not send a GA event outside production", () => {
+    process.env.NEXT_PUBLIC_GA_TRACKING_ID = "G-TEST";
+    process.env.NEXT_PUBLIC_ENV = "staging";
+    setReferrer("https://chatgpt.com/c/abc");
+
+    render(<AiReferrerTracker />);
+
+    expect(mockSendGAEvent).not.toHaveBeenCalled();
+  });
+
+  it("sends the GA landing event when GA is configured in production", () => {
+    process.env.NEXT_PUBLIC_GA_TRACKING_ID = "G-TEST";
+    process.env.NEXT_PUBLIC_ENV = "production";
+    setReferrer("https://gemini.google.com/app");
+
+    render(<AiReferrerTracker />);
+
+    expect(mockSendGAEvent).toHaveBeenCalledWith("event", "ai_referral_landing", {
+      ai_source: "gemini",
+      ai_source_medium: "referral",
+      ai_landing_path: window.location.pathname,
+    });
+  });
+
+  describe("GA user properties", () => {
+    const enableGa = () => {
+      process.env.NEXT_PUBLIC_GA_TRACKING_ID = "G-TEST";
+      process.env.NEXT_PUBLIC_ENV = "production";
+    };
+
+    it("sets the attribution as GA user properties on the landing itself", () => {
+      enableGa();
+      setReferrer("https://gemini.google.com/app");
+
+      render(<AiReferrerTracker />);
+
+      expect(mockSendGAEvent).toHaveBeenCalledWith("set", "user_properties", {
+        ai_source: "gemini",
+        ai_source_medium: "referral",
+        ai_first_touch_at: expect.any(String),
+      });
+    });
+
+    it("re-applies the stored attribution for a returning visitor without re-firing the landing", () => {
+      enableGa();
+      const existing: AiFirstTouch = {
+        source: "claude",
+        medium: "referral",
+        landingPath: "/project/my-project",
+        firstSeenAt: "2026-07-31T10:00:00.000Z",
+      };
+      window.localStorage.setItem(AI_FIRST_TOUCH_STORAGE_KEY, JSON.stringify(existing));
+      setReferrer("");
+
+      render(<AiReferrerTracker />);
+
+      expect(mockSendGAEvent).toHaveBeenCalledTimes(1);
+      expect(mockSendGAEvent).toHaveBeenCalledWith("set", "user_properties", {
+        ai_source: "claude",
+        ai_source_medium: "referral",
+        ai_first_touch_at: "2026-07-31T10:00:00.000Z",
+      });
+      expect(mockMixpanelEvent).not.toHaveBeenCalled();
+    });
+
+    it("sets nothing for a visitor with no AI first touch", () => {
+      enableGa();
+      setReferrer("https://twitter.com/karmahq");
+
+      render(<AiReferrerTracker />);
+
+      expect(mockSendGAEvent).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/__tests__/unit/hooks/useMixpanel.test.ts
+++ b/__tests__/unit/hooks/useMixpanel.test.ts
@@ -6,6 +6,10 @@
 import { renderHook, waitFor } from "@testing-library/react";
 import mp from "mixpanel-browser";
 import { useMixpanel } from "@/hooks/useMixpanel";
+import {
+  __resetAiFirstTouchCacheForTests,
+  AI_FIRST_TOUCH_STORAGE_KEY,
+} from "@/utilities/aiReferrer";
 
 // Mock mixpanel-browser
 vi.mock("mixpanel-browser");
@@ -19,6 +23,7 @@ describe("useMixpanel", () => {
     vi.clearAllMocks();
     // Reset environment variables
     process.env = { ...originalEnv };
+    __resetAiFirstTouchCacheForTests();
   });
 
   afterEach(() => {
@@ -336,6 +341,83 @@ describe("useMixpanel", () => {
 
       expect(mockMixpanel.track).toHaveBeenCalledWith("prefix1:event1", {}, expect.any(Function));
       expect(mockMixpanel.track).toHaveBeenCalledWith("prefix2:event2", {}, expect.any(Function));
+    });
+  });
+
+  describe("AI First-Touch Attribution", () => {
+    const storeFirstTouch = () => {
+      window.localStorage.setItem(
+        AI_FIRST_TOUCH_STORAGE_KEY,
+        JSON.stringify({
+          source: "chatgpt",
+          medium: "utm",
+          landingPath: "/programs",
+          firstSeenAt: "2026-07-31T10:00:00.000Z",
+        })
+      );
+    };
+
+    afterEach(() => {
+      window.localStorage.clear();
+    });
+
+    it("should merge the stored AI first touch into reported events", async () => {
+      process.env.NEXT_PUBLIC_MIXPANEL_KEY = "test-key";
+      process.env.NEXT_PUBLIC_ENV = "production";
+      storeFirstTouch();
+
+      mockMixpanel.track = vi.fn((_event, _props, callback) => {
+        if (typeof callback === "function") {
+          callback(1);
+        }
+      });
+
+      const { result } = renderHook(() => useMixpanel());
+
+      await waitFor(() => {
+        expect(mockMixpanel.init).toHaveBeenCalled();
+      });
+
+      await result.current.mixpanel.reportEvent({
+        event: "donation_completed",
+        properties: { amount: 100 },
+      });
+
+      expect(mockMixpanel.track).toHaveBeenCalledWith(
+        "gap:donation_completed",
+        {
+          amount: 100,
+          ai_source: "chatgpt",
+          ai_source_medium: "utm",
+          ai_first_touch_at: "2026-07-31T10:00:00.000Z",
+        },
+        expect.any(Function)
+      );
+    });
+
+    it("should let an explicit event property win over the first-touch value", async () => {
+      process.env.NEXT_PUBLIC_MIXPANEL_KEY = "test-key";
+      process.env.NEXT_PUBLIC_ENV = "production";
+      storeFirstTouch();
+
+      mockMixpanel.track = vi.fn((_event, _props, callback) => {
+        if (typeof callback === "function") {
+          callback(1);
+        }
+      });
+
+      const { result } = renderHook(() => useMixpanel());
+
+      await waitFor(() => {
+        expect(mockMixpanel.init).toHaveBeenCalled();
+      });
+
+      await result.current.mixpanel.reportEvent({
+        event: "override_event",
+        properties: { ai_source: "perplexity" },
+      });
+
+      expect(mockMixpanel.track.mock.calls[0][1]).toMatchObject({ ai_source: "perplexity" });
     });
   });
 });

--- a/__tests__/unit/utilities/aiReferrer.test.ts
+++ b/__tests__/unit/utilities/aiReferrer.test.ts
@@ -1,0 +1,419 @@
+/**
+ * @file Tests for AI-referrer classification and first-touch attribution
+ */
+
+import {
+  __resetAiFirstTouchCacheForTests,
+  AI_FIRST_TOUCH_STORAGE_KEY,
+  type AiFirstTouch,
+  type AiReferrerClassification,
+  type AiReferrerInput,
+  type AiReferrerMedium,
+  type AiSource,
+  type CaptureAiFirstTouchResult,
+  captureAiFirstTouch,
+  classifyAiReferrer,
+  getAiFirstTouchProps,
+  readAiFirstTouch,
+} from "@/utilities/aiReferrer";
+
+const SITE = "https://gap.karmahq.xyz";
+const LANDING = `${SITE}/project/my-project`;
+
+const readStoredRaw = (): string | null => window.localStorage.getItem(AI_FIRST_TOUCH_STORAGE_KEY);
+
+/** Typed expectation so a table row can't name a source or medium that doesn't exist. */
+const expectClassification = (
+  input: AiReferrerInput,
+  source: AiSource,
+  medium: AiReferrerMedium
+) => {
+  const expected: AiReferrerClassification = { source, medium };
+  expect(classifyAiReferrer(input)).toEqual(expected);
+};
+
+describe("classifyAiReferrer", () => {
+  describe("referrer host", () => {
+    it.each<[string, AiSource]>([
+      ["https://chat.openai.com/", "chatgpt"],
+      ["https://chatgpt.com/c/abc123", "chatgpt"],
+      ["https://claude.ai/chat/abc", "claude"],
+      ["https://www.anthropic.com/", "claude"],
+      ["https://www.perplexity.ai/search?q=karma", "perplexity"],
+      ["https://pplx.ai/x", "perplexity"],
+      ["https://gemini.google.com/app", "gemini"],
+      ["https://bard.google.com/", "gemini"],
+      ["https://copilot.microsoft.com/chats/1", "copilot"],
+      ["https://edgeservices.bing.com/edgesvc", "copilot"],
+      ["https://poe.com/chat/1", "ai-generic"],
+      ["https://www.phind.com/search", "ai-generic"],
+      ["https://chat.deepseek.com/", "ai-generic"],
+    ])("classifies %s as %s via referral", (referrer, expected) => {
+      expectClassification({ referrer, url: LANDING }, expected, "referral");
+    });
+  });
+
+  describe("bing.com — only the answer-engine surfaces, never organic search", () => {
+    it.each([
+      "https://www.bing.com/chat?q=karma",
+      "https://www.bing.com/chat/",
+      "https://bing.com/copilotsearch?q=karma",
+      "https://www.bing.com/search?q=karma&showconv=1",
+    ])("classifies %s as copilot", (referrer) => {
+      expectClassification({ referrer, url: LANDING }, "copilot", "referral");
+    });
+
+    it.each(["https://www.bing.com/search?q=karma", "https://www.bing.com/", "https://bing.com"])(
+      "leaves %s unclassified",
+      (referrer) => {
+        expect(classifyAiReferrer({ referrer, url: LANDING })).toBeNull();
+      }
+    );
+  });
+
+  describe("utm parameters (assistants that strip the referrer)", () => {
+    it.each<[string, AiSource]>([
+      ["utm_source=chatgpt.com", "chatgpt"],
+      ["utm_source=openai", "chatgpt"],
+      ["utm_source=perplexity", "perplexity"],
+      ["utm_source=Claude", "claude"],
+      ["utm_source=gemini", "gemini"],
+      ["utm_source=bing-chat", "copilot"],
+    ])("classifies %s as %s via utm with no referrer at all", (query, expected) => {
+      expectClassification({ referrer: "", url: `${LANDING}?${query}` }, expected, "utm");
+    });
+
+    it("falls back to ai-generic when only utm_medium marks the visit as AI", () => {
+      expectClassification(
+        { referrer: "", url: `${LANDING}?utm_source=some-new-assistant&utm_medium=ai` },
+        "ai-generic",
+        "utm"
+      );
+    });
+
+    it("prefers the utm tag over a conflicting referrer host", () => {
+      expectClassification(
+        {
+          referrer: "https://www.perplexity.ai/search",
+          url: `${LANDING}?utm_source=chatgpt.com`,
+        },
+        "chatgpt",
+        "utm"
+      );
+    });
+  });
+
+  describe("non-AI traffic", () => {
+    it("returns null when there is no referrer and no utm tag", () => {
+      expect(classifyAiReferrer({ referrer: "", url: LANDING })).toBeNull();
+    });
+
+    it("does not classify bare google.com as gemini", () => {
+      expect(classifyAiReferrer({ referrer: "https://www.google.com/", url: LANDING })).toBeNull();
+    });
+
+    it("returns null for a same-origin (internal navigation) referrer", () => {
+      expect(classifyAiReferrer({ referrer: `${SITE}/projects`, url: LANDING })).toBeNull();
+    });
+
+    it("returns null for a non-AI external referrer", () => {
+      expect(
+        classifyAiReferrer({ referrer: "https://twitter.com/karmahq", url: LANDING })
+      ).toBeNull();
+    });
+
+    it.each([
+      "https://notchatgpt.com/",
+      "https://chatgpt.com.evil.io/c/abc",
+      "https://www.perplexity.ai.phishing.example/search",
+      "https://fake-claude.ai/chat",
+    ])("does not classify the lookalike host %s", (referrer) => {
+      expect(classifyAiReferrer({ referrer, url: LANDING })).toBeNull();
+    });
+
+    it("matches an AI host case-insensitively", () => {
+      expectClassification(
+        { referrer: "https://CHATGPT.COM/c/abc", url: LANDING },
+        "chatgpt",
+        "referral"
+      );
+    });
+
+    it("ignores a non-AI utm campaign", () => {
+      expect(
+        classifyAiReferrer({
+          referrer: "",
+          url: `${LANDING}?utm_source=newsletter&utm_medium=email`,
+        })
+      ).toBeNull();
+    });
+  });
+
+  describe("malformed input", () => {
+    it("returns null for a malformed referrer instead of throwing", () => {
+      expect(() => classifyAiReferrer({ referrer: "not-a-url", url: LANDING })).not.toThrow();
+      expect(classifyAiReferrer({ referrer: "not-a-url", url: LANDING })).toBeNull();
+    });
+
+    it.each(["", "://", "javascript:void(0)", "android-app://com.example"])(
+      "returns null for referrer %j",
+      (referrer) => {
+        expect(classifyAiReferrer({ referrer, url: LANDING })).toBeNull();
+      }
+    );
+
+    it("classifies a protocol-relative referrer, which is a valid URL reference", () => {
+      expectClassification(
+        { referrer: "//chatgpt.com/c/abc", url: LANDING },
+        "chatgpt",
+        "referral"
+      );
+    });
+
+    it("still classifies via utm when the referrer is malformed", () => {
+      expectClassification(
+        { referrer: "not-a-url", url: `${LANDING}?utm_source=perplexity` },
+        "perplexity",
+        "utm"
+      );
+    });
+
+    it("returns null when the current url itself is malformed and the referrer is not AI", () => {
+      expect(classifyAiReferrer({ referrer: "", url: "not-a-url" })).toBeNull();
+    });
+
+    it("still classifies by referrer when the current url is malformed", () => {
+      expect(classifyAiReferrer({ referrer: "https://claude.ai/chat", url: "" })).toEqual({
+        source: "claude",
+        medium: "referral",
+      });
+    });
+  });
+});
+
+describe("captureAiFirstTouch", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    __resetAiFirstTouchCacheForTests();
+  });
+
+  it("persists source, medium, landing path and timestamp on an AI landing", () => {
+    const result = captureAiFirstTouch({
+      referrer: "https://www.perplexity.ai/search",
+      url: `${LANDING}?ref=abc`,
+    });
+
+    expect(result.isNew).toBe(true);
+    expect(result.firstTouch).toEqual({
+      source: "perplexity",
+      medium: "referral",
+      landingPath: "/project/my-project",
+      firstSeenAt: expect.any(String),
+    });
+    expect(readAiFirstTouch()).toEqual(result.firstTouch);
+  });
+
+  it("stores the pathname only — never the query string or any identifier", () => {
+    captureAiFirstTouch({
+      referrer: "",
+      url: `${LANDING}?utm_source=chatgpt.com&email=someone%40example.com&userId=0xabc`,
+    });
+
+    const raw = readStoredRaw() ?? "";
+    expect(raw).not.toContain("?");
+    expect(raw).not.toContain("example.com");
+    expect(raw).not.toContain("0xabc");
+    expect(Object.keys(JSON.parse(raw)).sort()).toEqual([
+      "firstSeenAt",
+      "landingPath",
+      "medium",
+      "source",
+    ]);
+  });
+
+  it("does not write anything when the visit is not AI-originated", () => {
+    const result = captureAiFirstTouch({ referrer: "https://www.google.com/", url: LANDING });
+
+    expect(result).toEqual({ firstTouch: null, isNew: false });
+    expect(readStoredRaw()).toBeNull();
+  });
+
+  it("survives simulated internal navigation without being overwritten or cleared", () => {
+    const landing = captureAiFirstTouch({
+      referrer: "https://chatgpt.com/c/abc",
+      url: `${SITE}/project/my-project`,
+    });
+    expect(landing.isNew).toBe(true);
+
+    // Three same-origin hops, each re-running capture the way a hard
+    // navigation would.
+    const hops: AiReferrerInput[] = [
+      { referrer: `${SITE}/project/my-project`, url: `${SITE}/project/my-project/grants` },
+      { referrer: `${SITE}/project/my-project/grants`, url: `${SITE}/project/my-project/impact` },
+      { referrer: `${SITE}/project/my-project/impact`, url: `${SITE}/funding-map` },
+    ];
+    for (const hopInput of hops) {
+      const hop: CaptureAiFirstTouchResult = captureAiFirstTouch(hopInput);
+      expect(hop.isNew).toBe(false);
+      expect(hop.firstTouch).toEqual(landing.firstTouch);
+    }
+
+    expect(readAiFirstTouch()).toEqual(landing.firstTouch);
+    expect(getAiFirstTouchProps()).toEqual({
+      ai_source: "chatgpt",
+      ai_source_medium: "referral",
+      ai_first_touch_at: landing.firstTouch?.firstSeenAt,
+    });
+  });
+
+  it("keeps the original source when a later visit comes from a different answer engine", () => {
+    const first = captureAiFirstTouch({ referrer: "https://claude.ai/chat/1", url: LANDING });
+    const second = captureAiFirstTouch({
+      referrer: "https://www.perplexity.ai/search",
+      url: `${SITE}/funding-map`,
+    });
+
+    expect(second.isNew).toBe(false);
+    expect(second.firstTouch).toEqual(first.firstTouch);
+    expect(second.firstTouch?.source).toBe("claude");
+  });
+
+  it("treats a corrupted stored value as absent and re-captures without throwing", () => {
+    window.localStorage.setItem(AI_FIRST_TOUCH_STORAGE_KEY, "{not-json");
+
+    expect(readAiFirstTouch()).toBeNull();
+    const result = captureAiFirstTouch({ referrer: "https://chatgpt.com/c/abc", url: LANDING });
+
+    expect(result.isNew).toBe(true);
+    expect(result.firstTouch?.source).toBe("chatgpt");
+  });
+
+  it("treats a structurally invalid stored value as absent", () => {
+    window.localStorage.setItem(
+      AI_FIRST_TOUCH_STORAGE_KEY,
+      JSON.stringify({ source: "not-a-source", medium: "referral" })
+    );
+
+    expect(readAiFirstTouch()).toBeNull();
+    expect(getAiFirstTouchProps()).toEqual({});
+  });
+
+  it("falls back to document.referrer and window.location when no input is given", () => {
+    const referrerSpy = vi
+      .spyOn(document, "referrer", "get")
+      .mockReturnValue("https://poe.com/chat");
+
+    const result = captureAiFirstTouch();
+
+    expect(result.firstTouch?.source).toBe("ai-generic");
+    expect(result.firstTouch?.landingPath).toBe(window.location.pathname);
+    referrerSpy.mockRestore();
+  });
+
+  it("degrades to a session-only classification when localStorage writes are blocked", () => {
+    const setItemSpy = vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+      throw new DOMException("QuotaExceededError");
+    });
+
+    const result = captureAiFirstTouch({ referrer: "https://claude.ai/chat/1", url: LANDING });
+
+    expect(result.firstTouch?.source).toBe("claude");
+    expect(result.isNew).toBe(true);
+    // Nothing reached storage, but later events in the same page load must
+    // still be attributed — otherwise a Safari-private-mode visitor loses the
+    // AI origin on every event after the landing.
+    expect(readStoredRaw()).toBeNull();
+    expect(getAiFirstTouchProps()).toEqual({
+      ai_source: "claude",
+      ai_source_medium: "referral",
+      ai_first_touch_at: result.firstTouch?.firstSeenAt,
+    });
+    setItemSpy.mockRestore();
+  });
+});
+
+describe("first-touch capture ordering", () => {
+  let referrerSpy: ReturnType<typeof vi.spyOn> | undefined;
+
+  beforeEach(() => {
+    window.localStorage.clear();
+    __resetAiFirstTouchCacheForTests();
+  });
+
+  afterEach(() => {
+    referrerSpy?.mockRestore();
+    referrerSpy = undefined;
+  });
+
+  it("captures on the first property read, so an event that beats the tracker is attributed", () => {
+    referrerSpy = vi
+      .spyOn(document, "referrer", "get")
+      .mockReturnValue("https://www.perplexity.ai/search?q=karma");
+
+    // Simulates a page's own view event firing before the deferred
+    // AiReferrerTracker chunk has loaded.
+    expect(getAiFirstTouchProps()).toMatchObject({
+      ai_source: "perplexity",
+      ai_source_medium: "referral",
+    });
+    expect(readAiFirstTouch()?.source).toBe("perplexity");
+  });
+
+  it("still reports the landing exactly once when a property read captured first", () => {
+    referrerSpy = vi
+      .spyOn(document, "referrer", "get")
+      .mockReturnValue("https://www.perplexity.ai/search?q=karma");
+
+    getAiFirstTouchProps();
+
+    const first = captureAiFirstTouch();
+    const second = captureAiFirstTouch();
+
+    expect(first.isNew).toBe(true);
+    expect(second.isNew).toBe(false);
+    expect(first.firstTouch?.source).toBe("perplexity");
+  });
+
+  it("does not report a landing for a visitor whose record predates this page load", () => {
+    window.localStorage.setItem(
+      AI_FIRST_TOUCH_STORAGE_KEY,
+      JSON.stringify({
+        source: "gemini",
+        medium: "utm",
+        landingPath: "/programs",
+        firstSeenAt: "2026-07-31T10:00:00.000Z",
+      } satisfies AiFirstTouch)
+    );
+
+    getAiFirstTouchProps();
+
+    expect(captureAiFirstTouch().isNew).toBe(false);
+  });
+});
+
+describe("getAiFirstTouchProps", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    __resetAiFirstTouchCacheForTests();
+  });
+
+  it("returns an empty object when there is no stored first touch", () => {
+    expect(getAiFirstTouchProps()).toEqual({});
+  });
+
+  it("returns the normalized analytics properties when a first touch is stored", () => {
+    const stored: AiFirstTouch = {
+      source: "gemini",
+      medium: "utm",
+      landingPath: "/programs",
+      firstSeenAt: "2026-07-31T10:00:00.000Z",
+    };
+    window.localStorage.setItem(AI_FIRST_TOUCH_STORAGE_KEY, JSON.stringify(stored));
+
+    expect(getAiFirstTouchProps()).toEqual({
+      ai_source: "gemini",
+      ai_source_medium: "utm",
+      ai_first_touch_at: "2026-07-31T10:00:00.000Z",
+    });
+  });
+});

--- a/__tests__/unit/utilities/mixpanelEvent-ai-first-touch.test.ts
+++ b/__tests__/unit/utilities/mixpanelEvent-ai-first-touch.test.ts
@@ -1,0 +1,135 @@
+/**
+ * @file Tests that AI first-touch attribution is merged into every Mixpanel
+ * event fired through the `mixpanelEvent` helper — this is what lets a
+ * conversion that happens long after the landing still report its AI origin.
+ */
+
+import mp from "mixpanel-browser";
+import {
+  __resetAiFirstTouchCacheForTests,
+  AI_FIRST_TOUCH_STORAGE_KEY,
+  type AiFirstTouch,
+} from "@/utilities/aiReferrer";
+import { mixpanelEvent } from "@/utilities/mixpanelEvent";
+
+vi.mock("mixpanel-browser");
+
+const mockMixpanel = mp as vi.Mocked<typeof mp>;
+
+const STORED_FIRST_TOUCH: AiFirstTouch = {
+  source: "perplexity",
+  medium: "referral",
+  landingPath: "/project/my-project",
+  firstSeenAt: "2026-07-31T10:00:00.000Z",
+};
+
+const trackedProperties = (): Record<string, unknown> =>
+  mockMixpanel.track.mock.calls[0][1] as Record<string, unknown>;
+
+describe("mixpanelEvent AI first-touch attribution", () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env = { ...originalEnv };
+    window.localStorage.clear();
+    __resetAiFirstTouchCacheForTests();
+    mockMixpanel.track = vi.fn((_event, _props, callback) => {
+      if (typeof callback === "function") {
+        callback(1);
+      }
+    });
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  const enableProduction = () => {
+    process.env.NEXT_PUBLIC_MIXPANEL_KEY = "test-key";
+    process.env.NEXT_PUBLIC_ENV = "production";
+  };
+
+  const storeFirstTouch = (firstTouch: AiFirstTouch = STORED_FIRST_TOUCH) => {
+    window.localStorage.setItem(AI_FIRST_TOUCH_STORAGE_KEY, JSON.stringify(firstTouch));
+  };
+
+  it("merges the stored first touch into a later conversion event", async () => {
+    enableProduction();
+    storeFirstTouch();
+
+    await mixpanelEvent({ event: "donation-completed", properties: { amount: 100 } });
+
+    expect(mockMixpanel.track).toHaveBeenCalledWith(
+      "gap:donation-completed",
+      {
+        amount: 100,
+        ai_source: "perplexity",
+        ai_source_medium: "referral",
+        ai_first_touch_at: "2026-07-31T10:00:00.000Z",
+      },
+      expect.any(Function)
+    );
+  });
+
+  it("attaches the first touch to events that carry no properties of their own", async () => {
+    enableProduction();
+    storeFirstTouch();
+
+    await mixpanelEvent({ event: "propertyless-event" });
+
+    expect(trackedProperties()).toEqual({
+      ai_source: "perplexity",
+      ai_source_medium: "referral",
+      ai_first_touch_at: "2026-07-31T10:00:00.000Z",
+    });
+  });
+
+  it("lets an explicit event property win over the first-touch value", async () => {
+    enableProduction();
+    storeFirstTouch();
+
+    await mixpanelEvent({
+      event: "ai-referral-landing",
+      properties: { ai_source: "chatgpt" },
+    });
+
+    expect(trackedProperties().ai_source).toBe("chatgpt");
+  });
+
+  it("leaves properties untouched when the visitor has no AI first touch", async () => {
+    enableProduction();
+
+    await mixpanelEvent({ event: "organic-event", properties: { amount: 100 } });
+
+    expect(trackedProperties()).toEqual({ amount: 100 });
+  });
+
+  it("ignores a corrupted stored value rather than polluting the event", async () => {
+    enableProduction();
+    window.localStorage.setItem(AI_FIRST_TOUCH_STORAGE_KEY, "{not-json");
+
+    await mixpanelEvent({ event: "organic-event" });
+
+    expect(trackedProperties()).toEqual({});
+  });
+
+  it("stays a no-op outside production even with a stored first touch", () => {
+    process.env.NEXT_PUBLIC_MIXPANEL_KEY = "test-key";
+    process.env.NEXT_PUBLIC_ENV = "development";
+    storeFirstTouch();
+
+    expect(mixpanelEvent({ event: "dev-event" })).toBeUndefined();
+    expect(mockMixpanel.init).not.toHaveBeenCalled();
+    expect(mockMixpanel.track).not.toHaveBeenCalled();
+  });
+
+  it("stays a no-op when no Mixpanel key is configured", () => {
+    delete process.env.NEXT_PUBLIC_MIXPANEL_KEY;
+    process.env.NEXT_PUBLIC_ENV = "production";
+    storeFirstTouch();
+
+    expect(mixpanelEvent({ event: "keyless-event" })).toBeUndefined();
+    expect(mockMixpanel.track).not.toHaveBeenCalled();
+  });
+});

--- a/artifacts/aeo-measurement/README.md
+++ b/artifacts/aeo-measurement/README.md
@@ -1,0 +1,23 @@
+# AEO measurement — release annotation log
+
+`releases.csv` ties AEO site changes to the dates they reached `main`, so a change in
+AI-referral traffic (see the `ai_source` / `ai_source_medium` / `ai_first_touch_at`
+properties on every Mixpanel event) can be read against the release that plausibly
+caused it.
+
+## Columns
+
+| Column | Meaning |
+|---|---|
+| `date` | `YYYY-MM-DD` the change reached `main`, taken from git history — never estimated |
+| `route_cohort` | The routes or surfaces the change affects, as the cohort you would filter analytics by |
+| `issue` | `AEO-NN (DEV-NNN)` — the AEO work item and its Linear issue |
+| `commit` | Short SHA on `main`. Normally the merge commit; for work that rode another PR's branch, the feature commit, called out in `notes` |
+| `expected_metric` | What the change is expected to move, in one phrase |
+| `notes` | What shipped, and any caveat needed to read the row correctly |
+
+## Appending a row
+
+Add one row per shipped AEO change, newest last. Take the date from
+`git log -1 --format=%cd --date=short <commit>` on `main` — do not fill it in from memory.
+Rows are append-only; correct a mistake in place rather than deleting history.

--- a/artifacts/aeo-measurement/releases.csv
+++ b/artifacts/aeo-measurement/releases.csv
@@ -1,0 +1,7 @@
+date,route_cohort,issue,commit,expected_metric,notes
+2026-07-30,"/community/[communityId], /community/[communityId]/projects",AEO-01 (DEV-584),6d9226303,AI crawler citation of project entities,"Server-rendered entity list plus crawlable pagination; merged via PR #1957"
+2026-07-30,/programs/[programId],AEO-02 (DEV-585),df70aff91,Program pages citable without JS,"SSR with React Query hydration; merged via PR #1956"
+2026-07-30,site-wide (/robots.txt),AEO-07 (DEV-590),d3c76d879,AI search and user-fetch crawler access,"SearchUser crawler rules plus robots tests; merged via PR #1953"
+2026-07-30,/knowledge/*,AEO-08 (DEV-591),65c4b44da,Truthful Article JSON-LD dates,"Per-article date model replacing build-time dates; merged via PR #1954"
+2026-07-31,/llms.txt,AEO-10 (DEV-593),8a06d27cd,Populated LLM URL index,"Sitemap-index resolution plus empty-section abort; merged via PR #1955"
+2026-07-31,"/agents.md, /llms.txt, Organization JSON-LD",AEO-15 (DEV-609),3acd44c0b,Consistent three-audience self-description,"Rode the AEO-10 branch, so it reached main in the same merge (8a06d27cd); commit cited is the feature commit, not a separate merge"

--- a/components/DeferredLayoutComponents.tsx
+++ b/components/DeferredLayoutComponents.tsx
@@ -50,6 +50,11 @@ const HotjarAnalytics = dynamic(() => import("@/components/Utilities/HotjarAnaly
   ssr: false,
 });
 
+const AiReferrerTracker = dynamic(
+  () => import("@/components/Utilities/AiReferrerTracker").then((mod) => mod.AiReferrerTracker),
+  { ssr: false }
+);
+
 interface DeferredLayoutComponentsProps {
   toasterConfig: {
     position: "top-right";
@@ -78,6 +83,7 @@ export function DeferredLayoutComponents({ toasterConfig }: DeferredLayoutCompon
       <Analytics />
       <SpeedInsights />
       <HotjarAnalytics />
+      <AiReferrerTracker />
       <ContributorProfileDialog />
       <ApiKeyManagementModal />
       <OnboardingDialog />

--- a/components/Utilities/AiReferrerTracker.tsx
+++ b/components/Utilities/AiReferrerTracker.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import { sendGAEvent } from "@next/third-parties/google";
+import { useEffect, useRef } from "react";
+import { captureAiFirstTouch, getAiFirstTouchProps } from "@/utilities/aiReferrer";
+import { mixpanelEvent } from "@/utilities/mixpanelEvent";
+
+const MIXPANEL_LANDING_EVENT = "ai-referral-landing";
+const GA_LANDING_EVENT = "ai_referral_landing";
+
+/**
+ * Mirrors the gating in app/layout.tsx — gtag only exists on the page when
+ * <GoogleAnalytics> was rendered, so calling it elsewhere would be a no-op at
+ * best and a console warning at worst.
+ */
+const isGoogleAnalyticsActive = (): boolean =>
+  Boolean(process.env.NEXT_PUBLIC_GA_TRACKING_ID) && process.env.NEXT_PUBLIC_ENV === "production";
+
+/**
+ * Records the first-touch answer-engine attribution for this visitor, applies
+ * it to Google Analytics for the whole page load, and emits one landing event
+ * per capture. Renders nothing.
+ *
+ * Mounted once from `DeferredLayoutComponents` (root layout), so App Router
+ * client navigations never re-run the capture — and `captureAiFirstTouch` is
+ * write-once anyway, so a hard navigation cannot overwrite the original source.
+ *
+ * Uses the `mixpanelEvent` helper rather than the `useMixpanel` hook for the
+ * same reason as `scanner-view-tracker`: the hook sets its Mixpanel instance in
+ * an effect that races a one-shot mount effect, so the first event would no-op.
+ * Both helpers are already no-ops outside production.
+ */
+export function AiReferrerTracker() {
+  const capturedRef = useRef(false);
+
+  useEffect(() => {
+    if (capturedRef.current) return;
+    capturedRef.current = true;
+
+    const { firstTouch, isNew } = captureAiFirstTouch();
+    if (!firstTouch) return;
+
+    const googleAnalyticsActive = isGoogleAnalyticsActive();
+
+    if (googleAnalyticsActive) {
+      // GA4 user properties are user-scoped and attach to every subsequent
+      // event of the page load, including the pageviews of client navigations.
+      // Mixpanel gets the same attribution per-event via `getAiFirstTouchProps`
+      // inside the event helpers; without this `set`, GA would only ever see it
+      // on the landing event below and a returning visitor's conversion could
+      // not be traced back to the answer engine.
+      sendGAEvent("set", "user_properties", getAiFirstTouchProps());
+    }
+
+    // Everything below reports the landing itself, which happens exactly once
+    // per visitor — a returning visitor keeps the attribution above but must
+    // not re-emit the landing.
+    if (!isNew) return;
+
+    const properties = {
+      ai_source: firstTouch.source,
+      ai_source_medium: firstTouch.medium,
+      ai_landing_path: firstTouch.landingPath,
+    };
+
+    void mixpanelEvent({ event: MIXPANEL_LANDING_EVENT, properties })?.catch(() => {
+      // SUPPRESSED: a dropped analytics beacon must never surface to the user
+      // or to Sentry. Mixpanel already retries its own queue.
+    });
+
+    if (googleAnalyticsActive) {
+      sendGAEvent("event", GA_LANDING_EVENT, properties);
+    }
+  }, []);
+
+  return null;
+}

--- a/hooks/useMixpanel.ts
+++ b/hooks/useMixpanel.ts
@@ -1,6 +1,7 @@
 "use client";
 import mp, { type Mixpanel } from "mixpanel-browser";
 import { useEffect, useState } from "react";
+import { getAiFirstTouchProps } from "@/utilities/aiReferrer";
 
 export interface IMixpanelEvent {
   event: string;
@@ -25,8 +26,11 @@ export const useMixpanel = (prefix = "gap"): IUseMixpanel => {
   }, []);
 
   const reportEvent = (data: IMixpanelEvent): Promise<void> =>
+    // First-touch AI attribution rides along on every event; event-level
+    // properties win on key collision. Mirrors utilities/mixpanelEvent.ts.
     new Promise((resolve, reject) => {
-      mixpanel?.track(`${prefix}:${data.event}`, data.properties || {}, (err) => {
+      const properties = { ...getAiFirstTouchProps(), ...(data.properties || {}) };
+      mixpanel?.track(`${prefix}:${data.event}`, properties, (err) => {
         if (err && err !== 1) {
           reject(err);
         } else {

--- a/utilities/aiReferrer.ts
+++ b/utilities/aiReferrer.ts
@@ -1,0 +1,384 @@
+/**
+ * AI-referrer (answer engine) classification and first-touch attribution.
+ *
+ * Answer engines send traffic in three shapes, and all three have to be handled:
+ *   1. a normal `Referer` header (chat.openai.com, perplexity.ai, ...)
+ *   2. no referrer at all, but a tagged landing URL (ChatGPT appends
+ *      `utm_source=chatgpt.com`)
+ *   3. no referrer and no tags — indistinguishable from direct traffic, so it
+ *      is deliberately NOT attributed rather than guessed at.
+ *
+ * The resulting label is merged into every Mixpanel event (see
+ * `utilities/mixpanelEvent.ts` / `hooks/useMixpanel.ts`) and set as GA4 user
+ * properties (see `components/Utilities/AiReferrerTracker.tsx`), so a
+ * conversion several navigations after the landing still carries its AI origin
+ * in both tools.
+ */
+
+export type AiSource = "chatgpt" | "claude" | "perplexity" | "gemini" | "copilot" | "ai-generic";
+
+export type AiReferrerMedium = "referral" | "utm";
+
+export interface AiReferrerClassification {
+  source: AiSource;
+  medium: AiReferrerMedium;
+}
+
+export interface AiFirstTouch extends AiReferrerClassification {
+  /** Pathname only — never the query string, so no identifiers are persisted. */
+  landingPath: string;
+  firstSeenAt: string;
+}
+
+export interface AiReferrerInput {
+  referrer: string;
+  url: string;
+}
+
+export interface CaptureAiFirstTouchResult {
+  firstTouch: AiFirstTouch | null;
+  /** True only for the visit that actually wrote the record. */
+  isNew: boolean;
+}
+
+export const AI_FIRST_TOUCH_STORAGE_KEY = "karma-ai-first-touch";
+
+const AI_SOURCES: readonly AiSource[] = [
+  "chatgpt",
+  "claude",
+  "perplexity",
+  "gemini",
+  "copilot",
+  "ai-generic",
+];
+
+const AI_MEDIUMS: readonly AiReferrerMedium[] = ["referral", "utm"];
+
+/**
+ * `utm_source` values, normalized to lowercase. Assistants are inconsistent:
+ * ChatGPT tags `chatgpt.com`, hand-built campaigns tag `chatgpt`.
+ */
+const UTM_SOURCE_TO_AI_SOURCE: Readonly<Record<string, AiSource>> = {
+  chatgpt: "chatgpt",
+  "chatgpt.com": "chatgpt",
+  "chat.openai.com": "chatgpt",
+  openai: "chatgpt",
+  "openai.com": "chatgpt",
+  claude: "claude",
+  "claude.ai": "claude",
+  "claude.com": "claude",
+  anthropic: "claude",
+  "anthropic.com": "claude",
+  perplexity: "perplexity",
+  "perplexity.ai": "perplexity",
+  pplx: "perplexity",
+  "pplx.ai": "perplexity",
+  gemini: "gemini",
+  "gemini.google.com": "gemini",
+  bard: "gemini",
+  "bard.google.com": "gemini",
+  copilot: "copilot",
+  "copilot.microsoft.com": "copilot",
+  "bing-chat": "copilot",
+  bingchat: "copilot",
+  "microsoft-copilot": "copilot",
+  ai: "ai-generic",
+  llm: "ai-generic",
+  llms: "ai-generic",
+  "ai-assistant": "ai-generic",
+  "answer-engine": "ai-generic",
+};
+
+/** `utm_medium` values that mark a visit as AI-originated on their own. */
+const AI_UTM_MEDIUMS: ReadonlySet<string> = new Set([
+  "ai",
+  "llm",
+  "chatbot",
+  "ai-referral",
+  "answer-engine",
+]);
+
+/**
+ * Referrer hostnames. Matching is exact or on a dot-suffix, so
+ * `chat.openai.com` matches via `openai.com`.
+ *
+ * Deliberately absent: bare `bing.com` and bare `google.com`. Copilot and
+ * Gemini answers sometimes arrive under the parent search domain, where they
+ * are indistinguishable from organic search — classifying them would pollute
+ * the AI cohort with organic traffic. Where the *path* disambiguates, the
+ * host is picked up by PATH_SCOPED_REFERRER_RULES below instead.
+ */
+const REFERRER_HOST_TO_AI_SOURCE: Readonly<Record<string, AiSource>> = {
+  "openai.com": "chatgpt",
+  "chatgpt.com": "chatgpt",
+  "claude.ai": "claude",
+  "claude.com": "claude",
+  "anthropic.com": "claude",
+  "perplexity.ai": "perplexity",
+  "pplx.ai": "perplexity",
+  "gemini.google.com": "gemini",
+  "bard.google.com": "gemini",
+  "copilot.microsoft.com": "copilot",
+  "copilot.cloud.microsoft": "copilot",
+  "edgeservices.bing.com": "copilot",
+  "poe.com": "ai-generic",
+  "you.com": "ai-generic",
+  "phind.com": "ai-generic",
+  "meta.ai": "ai-generic",
+  "duck.ai": "ai-generic",
+  "grok.com": "ai-generic",
+  "x.ai": "ai-generic",
+  "chat.mistral.ai": "ai-generic",
+  "chat.deepseek.com": "ai-generic",
+};
+
+interface PathScopedReferrerRule {
+  /** Matched exactly or on a dot-suffix, like REFERRER_HOST_TO_AI_SOURCE. */
+  host: string;
+  /** Path prefixes that identify the assistant surface on a shared host. */
+  pathPrefixes: readonly string[];
+  /** Query parameters whose mere presence identifies the assistant surface. */
+  markerParams: readonly string[];
+  source: AiSource;
+}
+
+/**
+ * Hosts that serve both organic search and an answer engine, where the path or
+ * a marker query parameter tells the two apart. `www.bing.com/search` stays
+ * unclassified, but `www.bing.com/chat` and the `showconv=1` conversation mode
+ * are unambiguously Bing Chat / Copilot.
+ */
+const PATH_SCOPED_REFERRER_RULES: readonly PathScopedReferrerRule[] = [
+  {
+    host: "bing.com",
+    pathPrefixes: ["/chat", "/copilotsearch"],
+    markerParams: ["showconv"],
+    source: "copilot",
+  },
+];
+
+const parseUrl = (value: string): URL | null => {
+  if (!value) return null;
+  // A protocol-relative reference ("//chatgpt.com/c/abc") is a valid URL
+  // reference but not a valid absolute URL, so `new URL` rejects it. Browsers
+  // never serialize `document.referrer` that way, but callers can.
+  const candidate = value.startsWith("//") ? `https:${value}` : value;
+  try {
+    return new URL(candidate);
+  } catch {
+    // SUPPRESSED: a malformed referrer or location is expected input here
+    // (browsers pass through whatever the previous page set) and is treated
+    // exactly like an absent one. Nothing actionable to report.
+    return null;
+  }
+};
+
+const normalizeHost = (host: string): string => host.toLowerCase().replace(/^www\./, "");
+
+const hostMatches = (normalizedHost: string, candidate: string): boolean =>
+  normalizedHost === candidate || normalizedHost.endsWith(`.${candidate}`);
+
+const matchReferrerUrl = (referrerUrl: URL): AiSource | null => {
+  const normalized = normalizeHost(referrerUrl.hostname);
+  for (const [candidate, source] of Object.entries(REFERRER_HOST_TO_AI_SOURCE)) {
+    if (hostMatches(normalized, candidate)) {
+      return source;
+    }
+  }
+  const path = referrerUrl.pathname.toLowerCase();
+  for (const rule of PATH_SCOPED_REFERRER_RULES) {
+    if (!hostMatches(normalized, rule.host)) continue;
+    if (rule.pathPrefixes.some((prefix) => path === prefix || path.startsWith(`${prefix}/`))) {
+      return rule.source;
+    }
+    if (rule.markerParams.some((param) => referrerUrl.searchParams.has(param))) {
+      return rule.source;
+    }
+  }
+  return null;
+};
+
+const classifyByUtm = (url: URL | null): AiReferrerClassification | null => {
+  if (!url) return null;
+  const utmSource = (url.searchParams.get("utm_source") ?? "").trim().toLowerCase();
+  const utmMedium = (url.searchParams.get("utm_medium") ?? "").trim().toLowerCase();
+
+  const mappedSource = UTM_SOURCE_TO_AI_SOURCE[utmSource];
+  if (mappedSource) {
+    return { source: mappedSource, medium: "utm" };
+  }
+  if (AI_UTM_MEDIUMS.has(utmMedium)) {
+    return { source: "ai-generic", medium: "utm" };
+  }
+  return null;
+};
+
+const classifyByReferrer = (
+  referrerUrl: URL | null,
+  currentUrl: URL | null
+): AiReferrerClassification | null => {
+  if (!referrerUrl) return null;
+  // Internal navigation: the referrer is our own origin, which must never be
+  // read as a new acquisition source.
+  if (currentUrl && normalizeHost(referrerUrl.hostname) === normalizeHost(currentUrl.hostname)) {
+    return null;
+  }
+  const source = matchReferrerUrl(referrerUrl);
+  return source ? { source, medium: "referral" } : null;
+};
+
+/**
+ * Classifies a landing as coming from an answer engine, or returns `null` when
+ * there is no evidence of one. UTM tags win over the referrer header: an
+ * assistant that both strips the referrer and tags the URL is the common case,
+ * and an explicitly tagged campaign is the more specific signal.
+ */
+export const classifyAiReferrer = (input: AiReferrerInput): AiReferrerClassification | null => {
+  const currentUrl = parseUrl(input.url);
+  const utmClassification = classifyByUtm(currentUrl);
+  if (utmClassification) return utmClassification;
+  return classifyByReferrer(parseUrl(input.referrer), currentUrl);
+};
+
+const isAiFirstTouch = (value: unknown): value is AiFirstTouch => {
+  if (typeof value !== "object" || value === null) return false;
+  const candidate = value as Record<string, unknown>;
+  return (
+    AI_SOURCES.includes(candidate.source as AiSource) &&
+    AI_MEDIUMS.includes(candidate.medium as AiReferrerMedium) &&
+    typeof candidate.landingPath === "string" &&
+    typeof candidate.firstSeenAt === "string"
+  );
+};
+
+/**
+ * Reads the persisted first touch. Anything unreadable or malformed (blocked
+ * storage, hand-edited value, older shape) is treated as absent.
+ */
+export const readAiFirstTouch = (): AiFirstTouch | null => {
+  if (typeof window === "undefined") return null;
+  try {
+    const raw = window.localStorage.getItem(AI_FIRST_TOUCH_STORAGE_KEY);
+    if (!raw) return null;
+    const parsed: unknown = JSON.parse(raw);
+    return isAiFirstTouch(parsed) ? parsed : null;
+  } catch {
+    // SUPPRESSED: localStorage can throw when storage is disabled (Safari
+    // private mode, blocked third-party contexts) and JSON.parse throws on a
+    // corrupted value. Attribution is best-effort telemetry — degrading to
+    // "no first touch" is the correct behavior, and reporting it would be noise.
+    return null;
+  }
+};
+
+const writeAiFirstTouch = (firstTouch: AiFirstTouch): void => {
+  try {
+    // Not gated on the analytics env. localStorage is origin-scoped and every
+    // environment (localhost, preview, staging, production) is its own origin,
+    // so a record written outside production can never be inherited by
+    // production events — and gating would make the feature unverifiable in
+    // exactly the preview deploys where it has to be QA'd.
+    window.localStorage.setItem(AI_FIRST_TOUCH_STORAGE_KEY, JSON.stringify(firstTouch));
+  } catch {
+    // SUPPRESSED: same blocked-storage case as readAiFirstTouch. The in-memory
+    // memo below still carries the classification for the rest of this page
+    // load, so only the cross-page-load memory is lost.
+  }
+};
+
+/**
+ * Resolved-once-per-page-load memo. `{ value }` means resolved (possibly to
+ * `null`); `null` means not resolved yet. It keeps attribution alive when
+ * localStorage writes are blocked, and spares every tracked event a repeated
+ * read-and-JSON.parse.
+ */
+let resolvedFirstTouch: { value: AiFirstTouch | null } | null = null;
+
+/** Set when this page load created the record; consumed by the first reader. */
+let landingReportPending = false;
+
+/**
+ * Resolves the visitor's first touch, capturing it from the current referrer
+ * and URL if this page load is the landing itself.
+ *
+ * Resolution is lazy rather than driven solely by `AiReferrerTracker` on
+ * purpose: the tracker is behind a deferred `ssr:false` chunk, so a page that
+ * reports a view event from its own mount effect would otherwise beat it and
+ * emit an unattributed event. Whichever caller runs first performs the capture.
+ */
+const resolveAiFirstTouch = (input?: AiReferrerInput): AiFirstTouch | null => {
+  if (resolvedFirstTouch) return resolvedFirstTouch.value;
+  if (typeof window === "undefined") return null;
+
+  const existing = readAiFirstTouch();
+  if (existing) {
+    resolvedFirstTouch = { value: existing };
+    return existing;
+  }
+
+  const resolved: AiReferrerInput = input ?? {
+    referrer: window.document.referrer,
+    url: window.location.href,
+  };
+
+  const classification = classifyAiReferrer(resolved);
+  if (!classification) {
+    resolvedFirstTouch = { value: null };
+    return null;
+  }
+
+  const firstTouch: AiFirstTouch = {
+    source: classification.source,
+    medium: classification.medium,
+    landingPath: parseUrl(resolved.url)?.pathname ?? "/",
+    firstSeenAt: new Date().toISOString(),
+  };
+
+  writeAiFirstTouch(firstTouch);
+  resolvedFirstTouch = { value: firstTouch };
+  landingReportPending = true;
+  return firstTouch;
+};
+
+/**
+ * Write-once first-touch capture.
+ *
+ * An existing record is NEVER overwritten. That is what makes the attribution
+ * survive everything that happens after the landing: internal hard navigations
+ * (whose referrer is our own origin), later direct visits, and even a later
+ * visit from a *different* answer engine all keep the original source.
+ *
+ * `isNew` is true exactly once per captured record, for whichever caller
+ * reports the landing — it stays true even if `getAiFirstTouchProps` happened
+ * to perform the capture first.
+ */
+export const captureAiFirstTouch = (input?: AiReferrerInput): CaptureAiFirstTouchResult => {
+  if (typeof window === "undefined") return { firstTouch: null, isNew: false };
+
+  const firstTouch = resolveAiFirstTouch(input);
+  if (!firstTouch) return { firstTouch: null, isNew: false };
+
+  const isNew = landingReportPending;
+  landingReportPending = false;
+  return { firstTouch, isNew };
+};
+
+/**
+ * Analytics properties describing the AI origin of the current visitor, merged
+ * into every tracked event. Empty when the visit has no AI first touch.
+ */
+export const getAiFirstTouchProps = (): Record<string, unknown> => {
+  const firstTouch = resolveAiFirstTouch();
+  if (!firstTouch) return {};
+  return {
+    ai_source: firstTouch.source,
+    ai_source_medium: firstTouch.medium,
+    ai_first_touch_at: firstTouch.firstSeenAt,
+  };
+};
+
+/** Test-only reset of the per-page-load memo between test cases. */
+export const __resetAiFirstTouchCacheForTests = (): void => {
+  resolvedFirstTouch = null;
+  landingReportPending = false;
+};

--- a/utilities/mixpanelEvent.ts
+++ b/utilities/mixpanelEvent.ts
@@ -1,4 +1,5 @@
 import mp from "mixpanel-browser";
+import { getAiFirstTouchProps } from "@/utilities/aiReferrer";
 
 export interface IMixpanelEvent {
   event: string;
@@ -14,8 +15,12 @@ export const mixpanelEvent = (data: IMixpanelEvent) => {
   }
   mp.init(process.env.NEXT_PUBLIC_MIXPANEL_KEY);
   const mixpanel = mp;
+  // First-touch AI attribution rides along on every event, so a conversion
+  // several navigations after the landing still knows it started at an answer
+  // engine. Event-level properties win on key collision.
+  const properties = { ...getAiFirstTouchProps(), ...(data.properties || {}) };
   return new Promise<void>((resolve, reject) => {
-    mixpanel?.track(`gap:${data.event}`, data.properties || {}, (err) => {
+    mixpanel?.track(`gap:${data.event}`, properties, (err) => {
       if (err && err !== 1) {
         reject(err);
       } else {


### PR DESCRIPTION
## Overview

AEO-09 (DEV-592), part of DEV-583.

Two things, both in service of one question — *is answer-engine visibility actually
sending us traffic, and which of our changes moved it?*

1. Normalized answer-engine referrer classification wired into the analytics flow we
   already have, with write-once first-touch attribution.
2. A release annotation log at `artifacts/aeo-measurement/releases.csv` tying each
   shipped AEO change to the date it reached `main`.

## Problem

We ship AEO work — server-rendered entities, crawler rules, `/llms.txt`, JSON-LD — and
have no way to tell whether any of it produced a visit. Answer-engine traffic currently
lands in the same undifferentiated bucket as everything else, for three reasons:

- **Referrer shapes vary.** Some engines send a normal `Referer`. Some strip it entirely
  and tag the landing URL instead (`utm_source=chatgpt.com`). Some send nothing at all.
  Handling only the first case misses most of the cohort.
- **The landing is not the conversion.** A visit arrives from an answer engine, browses
  four pages, then donates. Without persisted attribution the donation looks like direct
  traffic and the answer engine gets no credit.
- **No release timeline.** Even with the traffic data, a movement in the graph cannot be
  attributed to a release without a record of what shipped when.

## Solution

### Classification (`utilities/aiReferrer.ts`)

Maps ChatGPT/OpenAI, Claude/Anthropic, Perplexity, Gemini, Copilot/Bing Chat and a set of
generic assistants to stable source labels, via either the referrer host or `utm` tags.
UTM tags win over the referrer header — an engine that both strips the referrer and tags
the URL is the common case, and an explicit tag is the more specific signal.

Two deliberate accuracy decisions:

- **Host matching is exact or dot-suffix.** `chat.openai.com` resolves via `openai.com`;
  `notchatgpt.com` and `chatgpt.com.evil.io` do not resolve at all. Matching is
  case-insensitive and `www.`-insensitive.
- **Bare `bing.com` and `google.com` are excluded.** An answer served under the parent
  search domain is indistinguishable from organic search, and classifying it would
  pollute the cohort with organic traffic. Where the path or a marker parameter
  disambiguates — `/chat`, `/copilotsearch`, `showconv=1` — a path-scoped rule picks the
  host up as `copilot`.

Where there is genuinely no evidence, the visit is left unattributed rather than guessed
at. A quiet false negative beats a cohort you cannot trust.

### First-touch persistence

One `localStorage` record, written once, never overwritten. That is what makes it survive
internal hard navigations (whose referrer is our own origin), later direct visits, and
even a later visit from a *different* engine — the original source wins.

Only the landing **pathname** is stored, never the query string, so no identifiers are
persisted. The stored value is validated on read; anything malformed, hand-edited, or
from an older shape is treated as absent.

### Analytics wiring

Reuses the existing Mixpanel + GA4 flow. No new tracker, no new vendor.

- **Mixpanel** — both entry points (`utilities/mixpanelEvent.ts` and the `useMixpanel`
  hook) merge `ai_source` / `ai_source_medium` / `ai_first_touch_at` into every event.
  Event-level properties win on key collision, so no existing call site changes behaviour.
- **GA4** — `AiReferrerTracker` sets the attribution as user properties on every page
  load, so it attaches to subsequent events including client-navigation pageviews. It
  also emits one `ai_referral_landing` event per captured visitor.

Both helpers are already no-ops outside production; the GA calls additionally mirror the
`app/layout.tsx` gating so `gtag` is never called when it does not exist on the page.

### Release log

`artifacts/aeo-measurement/releases.csv`, with a README documenting the columns and the
append procedure. Seeded with AEO-01, 02, 07, 08, 10 and 15. Every date came from
`git log` on the actual commit — none estimated, all verifiable.

## Testing steps

```bash
pnpm vitest run --project unit \
  __tests__/unit/utilities/aiReferrer.test.ts \
  __tests__/unit/utilities/mixpanelEvent-ai-first-touch.test.ts \
  __tests__/unit/components/AiReferrerTracker.test.tsx \
  __tests__/unit/hooks/useMixpanel.test.ts --reporter=dot
```

96 tests, all green. `pnpm typecheck` clean. Biome and the anti-pattern checker clean on
every changed file.

Coverage maps to the acceptance criteria:

- Every listed source classified via referrer host, plus the utm path for each.
- No-referrer, empty-string, malformed (`not-a-url`, `://`, `javascript:`,
  `android-app://`) and protocol-relative referrers.
- Lookalike hosts, uppercase hosts, bare `google.com`, bare `bing.com`.
- First touch surviving simulated internal navigation, a later different-engine visit, a
  corrupted stored value, and blocked `localStorage`.
- Ordering: an event that beats the tracker's mount still gets attributed, and the
  landing still reports exactly once.

Manual check on a preview deploy: land on any page with `?utm_source=chatgpt.com`,
confirm `karma-ai-first-touch` in `localStorage`, navigate internally, confirm the record
is unchanged and that subsequent Mixpanel events carry `ai_source`.

## Risk/scope notes

- **Additive only.** No existing analytics call site changes shape; the new properties are
  merged in and lose to any event-level key of the same name.
- **`localStorage` is not gated on the analytics env**, on purpose. It is origin-scoped
  and every environment is its own origin, so a record written on a preview can never be
  inherited by production. Gating it would make the feature unverifiable in exactly the
  preview deploys where it has to be QA'd. Event *transmission* remains gated as before.
- **No PII.** Pathname, source label, medium and timestamp — nothing else.
- **SSR-safe.** Every `window` touch is guarded; the tracker is behind an `ssr:false`
  dynamic import and renders nothing, so it cannot cause a hydration mismatch.
- **Classification is intentionally conservative.** Expect the cohort to under-count
  rather than over-count. If the numbers look low, that is the design; loosening the
  `bing.com` / `google.com` rules is the lever, and it trades precision for volume.

## Review notes

Two independent reviews ran against this branch. Findings and resolutions:

**GA attribution only reached the landing event (high).** The stored first touch was
merged into Mixpanel events but GA saw it only once, so a returning visitor's conversion
could not be traced back in GA. Resolved by setting it as GA4 user properties on every
page load, not just on the capture, and separating "apply attribution" from "report the
landing" so a returning visitor gets the former without re-firing the latter.

**Deferred capture could lose the first event (medium).** The tracker sits behind an
`ssr:false` chunk, so a page reporting a view event from its own mount effect could beat
it and emit an unattributed event. Resolved by making capture lazy inside the utility —
whichever caller runs first performs it — with the landing-report flag surviving so the
landing is still reported exactly once regardless of who captured.

**Bing Chat was unclassifiable (medium).** Excluding all of `bing.com` to avoid organic
search also excluded Bing Chat, which the ticket names explicitly. Resolved with
path-scoped rules so `/chat`, `/copilotsearch` and `showconv=1` classify as `copilot`
while `/search` stays out.

**Attribution written outside the analytics gate (medium).** Reviewed and kept as-is,
with the reasoning documented at the write site: `localStorage` is origin-scoped, so
cross-environment leakage is not possible, and gating would block preview QA. Only event
transmission needs gating, and it has it.

**Attribution lost when `localStorage` writes are blocked (low).** The classification was
returned once and then dropped, so later events in the same page load lost it. Resolved
with a per-page-load memo, which also spares every event a repeated read-and-parse.

**Protocol-relative referrers rejected (low).** `//chatgpt.com/c/abc` is a valid URL
reference but not a valid absolute URL, so `new URL` threw and the visit went
unattributed. Resolved by normalizing the scheme before parsing.

Two additions on top of the review findings: an explicit lookalike-host test
(`notchatgpt.com`, `chatgpt.com.evil.io`) and a case-insensitivity test, since spoofable
hostnames were called out as a risk and the behaviour — correct already — was untested.
