### PR TITLE
fix(seo): consolidate community sub-pages onto the root, prune the sitemap, add a content crawler (DEV-586)

### DIFF
--- a/.github/workflows/indexability-monitor.yml
+++ b/.github/workflows/indexability-monitor.yml
@@ -33,12 +33,16 @@ jobs:
         with:
           node-version: "20"
 
+      # Unit tests only — no network. scripts/crawl-sitemap.mjs itself is
+      # manual-only (it crawls production) and is deliberately never run here.
       - name: Run Node test suites
         run: >
           node --test
           scripts/indexability/__tests__/audit-sitemaps.test.mjs
           scripts/indexability/__tests__/verify-indexability.test.mjs
           scripts/indexability/__tests__/cli.test.mjs
+          scripts/indexability/__tests__/crawl-sitemap.test.mjs
+          scripts/indexability/__tests__/crawl-sitemap-robustness.test.mjs
 
       - name: Run indexability verification
         id: verify

--- a/__tests__/app/community-subpage-canonicals.test.ts
+++ b/__tests__/app/community-subpage-canonicals.test.ts
@@ -1,0 +1,291 @@
+/**
+ * Sitemap-membership <-> canonical consistency gate (DEV-586).
+ *
+ * A URL only belongs in a sitemap if it is the canonical of its own content.
+ * The sub-page path set here is DERIVED from the communities sitemap module, so
+ * adding a sub-page to the sitemap without giving it self-canonical, unique
+ * metadata fails this test — the two can never drift apart silently.
+ */
+import type { Metadata } from "next";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { SITE_URL } from "@/utilities/meta";
+
+const { chosenCommunitiesMock, getCommunityDetailsMock, getWhitelabelContextMock, apiGetMock } =
+  vi.hoisted(() => ({
+    chosenCommunitiesMock: vi.fn(),
+    getCommunityDetailsMock: vi.fn(),
+    getWhitelabelContextMock: vi.fn(),
+    apiGetMock: vi.fn(),
+  }));
+
+vi.mock("@/utilities/chosenCommunities", () => ({
+  chosenCommunities: chosenCommunitiesMock,
+}));
+
+vi.mock("@/utilities/community-flags", () => ({
+  FINANCIALS_ENABLED_COMMUNITIES: ["filecoin"],
+}));
+
+vi.mock("@/utilities/whitelabel-server", () => ({
+  getWhitelabelContext: getWhitelabelContextMock,
+}));
+
+vi.mock("@/utilities/queries/v2/getCommunityData", () => ({
+  getCommunityDetails: getCommunityDetailsMock,
+  getCommunityCategories: vi.fn(async () => []),
+  getCommunityProjects: vi.fn(async () => ({ payload: [], pagination: {} })),
+}));
+
+vi.mock("@/utilities/queries/v2/community", () => ({
+  getCommunityDetails: getCommunityDetailsMock,
+}));
+
+vi.mock("@/utilities/api/client", () => ({
+  api: {
+    get: (...args: unknown[]) => apiGetMock(...args),
+    post: vi.fn(),
+    put: vi.fn(),
+    patch: vi.fn(),
+    delete: vi.fn(),
+    request: vi.fn(),
+    getPaginated: vi.fn(),
+  },
+}));
+
+// Heavy client trees that the metadata path never touches.
+vi.mock("@/components/CommunityGrants", () => ({ CommunityGrants: () => null }));
+vi.mock("@/components/Pages/Community/PortfolioReports/PublicReportListPage", () => ({
+  PublicReportListPage: () => null,
+}));
+vi.mock("@/components/Pages/Communities/Financials/PublicControlCenter", () => ({
+  PublicControlCenter: () => null,
+}));
+vi.mock("@/components/Pages/Communities/Impact/ImpactTabNavigator", () => ({
+  ImpactTabNavigator: () => null,
+}));
+vi.mock("@/components/Pages/Communities/Impact/FilterRow", () => ({
+  CommunityImpactFilterRow: () => null,
+}));
+vi.mock("next/navigation", () => ({
+  notFound: () => {
+    throw new Error("NEXT_NOT_FOUND");
+  },
+  redirect: vi.fn(),
+}));
+
+const COMMUNITIES = [
+  { name: "Celo", slug: "celo", uid: "0xcelo", imageURL: { light: "", dark: "" } },
+  { name: "Filecoin", slug: "filecoin", uid: "0xfilecoin", imageURL: { light: "", dark: "" } },
+];
+
+type MetadataModule = {
+  generateMetadata: (args: { params: Promise<{ communityId: string }> }) => Promise<Metadata>;
+};
+
+/**
+ * Every sub-page the communities sitemap can emit, mapped to the route module
+ * that owns its metadata. `assertsCoversSitemap` below proves this registry is
+ * exhaustive.
+ */
+const SUBPAGE_METADATA_MODULES: Record<string, () => Promise<MetadataModule>> = {
+  "funding-opportunities": () =>
+    import("@/app/community/[communityId]/(with-header)/funding-opportunities/layout"),
+  projects: () => import("@/app/community/[communityId]/(with-header)/projects/page"),
+  updates: () => import("@/app/community/[communityId]/(with-header)/updates/layout"),
+  impact: () => import("@/app/community/[communityId]/(with-header)/impact/layout"),
+  financials: () => import("@/app/community/[communityId]/(with-header)/financials/page"),
+  reports: () => import("@/app/community/[communityId]/(with-header)/reports/page"),
+};
+
+type SitemapEntry = { communityId: string; subpath: string; url: string };
+
+async function sitemapSubpageEntries(): Promise<SitemapEntry[]> {
+  const { default: communitiesSitemap } = await import("@/app/sitemaps/communities/sitemap");
+  const entries = await communitiesSitemap();
+  return entries
+    .map((entry) => {
+      const { pathname } = new URL(entry.url);
+      const [, , communityId, ...rest] = pathname.split("/");
+      return { communityId, subpath: rest.join("/"), url: entry.url };
+    })
+    .filter((entry) => entry.subpath !== "");
+}
+
+async function metadataFor(subpath: string, communityId: string): Promise<Metadata> {
+  const loader = SUBPAGE_METADATA_MODULES[subpath];
+  if (!loader) {
+    throw new Error(`No metadata module registered for sub-page "${subpath}"`);
+  }
+  const mod = await loader();
+  return mod.generateMetadata({ params: Promise.resolve({ communityId }) });
+}
+
+function communityFixture(name: string) {
+  return { uid: `0x${name}`, details: { name, slug: name } };
+}
+
+describe("community sub-pages listed in the sitemap", () => {
+  beforeEach(() => {
+    chosenCommunitiesMock.mockReturnValue(COMMUNITIES);
+    getWhitelabelContextMock.mockResolvedValue({
+      isWhitelabel: false,
+      communitySlug: null,
+      config: null,
+      tenantConfig: null,
+    });
+    getCommunityDetailsMock.mockImplementation(async (slug: string) => communityFixture(slug));
+    apiGetMock.mockResolvedValue(null);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("has a metadata module registered for every sub-page the sitemap emits", async () => {
+    const entries = await sitemapSubpageEntries();
+    const subpaths = [...new Set(entries.map((entry) => entry.subpath))];
+
+    expect(subpaths.length).toBeGreaterThan(0);
+    for (const subpath of subpaths) {
+      expect(
+        Object.keys(SUBPAGE_METADATA_MODULES),
+        `sitemap emits /${subpath} but no route owns its metadata`
+      ).toContain(subpath);
+    }
+  });
+
+  it("serves a self-referential canonical for every sitemap URL", async () => {
+    const entries = await sitemapSubpageEntries();
+
+    for (const entry of entries) {
+      const metadata = await metadataFor(entry.subpath, entry.communityId);
+      const expectedPath = new URL(entry.url).pathname;
+
+      expect(metadata.alternates?.canonical, `${entry.url} must declare itself canonical`).toBe(
+        expectedPath
+      );
+    }
+  });
+
+  it("never marks a sitemap URL noindex", async () => {
+    const entries = await sitemapSubpageEntries();
+
+    for (const entry of entries) {
+      const metadata = await metadataFor(entry.subpath, entry.communityId);
+      const robots = metadata.robots;
+      const directive =
+        typeof robots === "string"
+          ? robots
+          : robots && typeof robots === "object" && robots.index === false
+            ? "noindex"
+            : "";
+
+      expect(directive, `${entry.url} must stay indexable`).not.toContain("noindex");
+    }
+  });
+
+  it("gives each crawlable sub-page a title distinct from the community root", async () => {
+    const entries = (await sitemapSubpageEntries()).filter((entry) => entry.communityId === "celo");
+    const rootTitle = "Celo Community Grants | Karma";
+    const titles = new Map<string, string>();
+
+    for (const entry of entries) {
+      const metadata = await metadataFor(entry.subpath, entry.communityId);
+      // `reports` intentionally inherits the community layout's copy; it only
+      // corrects the canonical. Everything else must say what it is.
+      if (entry.subpath === "reports") {
+        continue;
+      }
+      const title = metadata.title;
+      expect(typeof title, `${entry.url} must set its own title`).toBe("string");
+      expect(title).not.toBe(rootTitle);
+      titles.set(entry.subpath, title as string);
+    }
+
+    expect(new Set(titles.values()).size).toBe(titles.size);
+    for (const [subpath, title] of titles) {
+      expect(title.toLowerCase(), `${subpath} title should name the community`).toContain("celo");
+    }
+  });
+
+  it("gives each crawlable sub-page its own description", async () => {
+    const entries = (await sitemapSubpageEntries()).filter(
+      (entry) => entry.communityId === "celo" && entry.subpath !== "reports"
+    );
+    const descriptions: string[] = [];
+
+    for (const entry of entries) {
+      const metadata = await metadataFor(entry.subpath, entry.communityId);
+      expect(typeof metadata.description, `${entry.url} must set a description`).toBe("string");
+      descriptions.push(metadata.description as string);
+    }
+
+    expect(new Set(descriptions).size).toBe(descriptions.length);
+  });
+
+  it("strips the /community/<slug> prefix from the canonical on a whitelabel domain", async () => {
+    getWhitelabelContextMock.mockResolvedValue({
+      isWhitelabel: true,
+      communitySlug: "celo",
+      config: { domain: "grants.celo.org", communitySlug: "celo" },
+      tenantConfig: null,
+    });
+
+    const entries = (await sitemapSubpageEntries()).filter((entry) => entry.communityId === "celo");
+
+    for (const entry of entries) {
+      const metadata = await metadataFor(entry.subpath, entry.communityId);
+      expect(metadata.alternates?.canonical).toBe(`/${entry.subpath}`);
+    }
+  });
+
+  it("keeps the canonical self-referential when the community lookup fails", async () => {
+    getCommunityDetailsMock.mockResolvedValue(null);
+
+    const metadata = await metadataFor("projects", "celo");
+
+    expect(metadata.alternates?.canonical).toBe("/community/celo/projects");
+    expect(metadata.title).toContain("celo");
+  });
+
+  it("does not list browse-applications — it has nothing to serve a crawler", async () => {
+    const entries = await sitemapSubpageEntries();
+
+    expect(entries.some((entry) => entry.subpath === "browse-applications")).toBe(false);
+  });
+});
+
+describe("funding-program detail pages listed in the sitemap", () => {
+  beforeEach(() => {
+    getWhitelabelContextMock.mockResolvedValue({
+      isWhitelabel: false,
+      communitySlug: null,
+      config: null,
+      tenantConfig: null,
+    });
+    apiGetMock.mockResolvedValue({
+      programId: "42",
+      name: "Public Goods Fund",
+      metadata: { title: "Public Goods Fund", shortDescription: "Funding public goods." },
+    });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("self-canonicals at the /community/<id>/programs/<programId> sitemap shape", async () => {
+    const mod = await import(
+      "@/app/community/[communityId]/(whitelabel)/programs/[programId]/page"
+    );
+    const metadata = await mod.generateMetadata({
+      params: Promise.resolve({ communityId: "celo", programId: "42" }),
+    });
+
+    expect(metadata.alternates?.canonical).toBe("/community/celo/programs/42");
+    expect(new URL(`${SITE_URL}/community/celo/programs/42`).pathname).toBe(
+      metadata.alternates?.canonical
+    );
+    expect(metadata.robots).toBeUndefined();
+  });
+});

--- a/__tests__/app/community-subpage-canonicals.test.ts
+++ b/__tests__/app/community-subpage-canonicals.test.ts
@@ -1,10 +1,23 @@
 /**
  * Sitemap-membership <-> canonical consistency gate (DEV-586).
  *
- * A URL only belongs in a sitemap if it is the canonical of its own content.
- * The sub-page path set here is DERIVED from the communities sitemap module, so
- * adding a sub-page to the sitemap without giving it self-canonical, unique
- * metadata fails this test — the two can never drift apart silently.
+ * A URL only belongs in a sitemap if it is the canonical of its own crawlable
+ * content. Every community sub-page is a client-rendered shell today — a
+ * production crawl (2026-08-03, Googlebot UA, JavaScript disabled) measured
+ * funding-opportunities at 406 chars of visible text, updates 475, impact 613,
+ * financials 501 and reports 406, while /projects returned 5578 chars that are
+ * 99.9% identical to the community root's 5570, with no unique words at all.
+ *
+ * So the communities sitemap submits roots only, and the sub-pages consolidate
+ * onto the community root canonical they inherit from the layout. This file
+ * pins both halves of that contract:
+ *
+ *   1. the sitemap contains community roots and nothing else;
+ *   2. no shell sub-page declares a self-canonical.
+ *
+ * Re-adding a sub-page to the sitemap fails (1) until it also declares a
+ * canonical, and adding a canonical fails (2) until it is also submitted — so
+ * server-rendered content, canonical and sitemap entry can only move together.
  */
 import type { Metadata } from "next";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -83,9 +96,8 @@ type MetadataModule = {
 };
 
 /**
- * Every sub-page the communities sitemap can emit, mapped to the route module
- * that owns its metadata. `assertsCoversSitemap` below proves this registry is
- * exhaustive.
+ * Every sub-page route under /community/<id>/, mapped to the module that owns
+ * its metadata. None of these is submitted to the sitemap today.
  */
 const SUBPAGE_METADATA_MODULES: Record<string, () => Promise<MetadataModule>> = {
   "funding-opportunities": () =>
@@ -97,195 +109,117 @@ const SUBPAGE_METADATA_MODULES: Record<string, () => Promise<MetadataModule>> = 
   reports: () => import("@/app/community/[communityId]/(with-header)/reports/page"),
 };
 
-type SitemapEntry = { communityId: string; subpath: string; url: string };
+/**
+ * Shells whose canonical must stay inherited. `reports` is deliberately absent:
+ * it already declared its own canonical before DEV-586 and that predates this
+ * change, so it is left alone — it is still kept out of the sitemap below.
+ */
+const SHELL_SUBPAGES = ["funding-opportunities", "projects", "updates", "impact", "financials"];
 
-async function sitemapSubpageEntries(): Promise<SitemapEntry[]> {
+/** Sub-pages that always return a title (financials returns {} when unflagged). */
+const TITLED_SUBPAGES = ["funding-opportunities", "projects", "updates", "impact"];
+
+async function sitemapUrls(): Promise<string[]> {
   const { default: communitiesSitemap } = await import("@/app/sitemaps/communities/sitemap");
   const entries = await communitiesSitemap();
-  return entries
-    .map((entry) => {
-      const { pathname } = new URL(entry.url);
-      const [, , communityId, ...rest] = pathname.split("/");
-      return { communityId, subpath: rest.join("/"), url: entry.url };
-    })
-    .filter((entry) => entry.subpath !== "");
+  return entries.map((entry) => entry.url);
 }
 
 async function metadataFor(subpath: string, communityId: string): Promise<Metadata> {
-  const loader = SUBPAGE_METADATA_MODULES[subpath];
-  if (!loader) {
-    throw new Error(`No metadata module registered for sub-page "${subpath}"`);
-  }
-  const mod = await loader();
+  const mod = await SUBPAGE_METADATA_MODULES[subpath]();
   return mod.generateMetadata({ params: Promise.resolve({ communityId }) });
 }
 
-function communityFixture(name: string) {
-  return { uid: `0x${name}`, details: { name, slug: name } };
-}
-
-describe("community sub-pages listed in the sitemap", () => {
+describe("community sitemap membership and canonicals", () => {
   beforeEach(() => {
+    vi.resetModules();
     chosenCommunitiesMock.mockReturnValue(COMMUNITIES);
-    getWhitelabelContextMock.mockResolvedValue({
-      isWhitelabel: false,
-      communitySlug: null,
-      config: null,
-      tenantConfig: null,
-    });
-    getCommunityDetailsMock.mockImplementation(async (slug: string) => communityFixture(slug));
-    apiGetMock.mockResolvedValue(null);
+    getCommunityDetailsMock.mockResolvedValue({ details: { name: "Celo" } });
+    getWhitelabelContextMock.mockResolvedValue({ isWhitelabel: false, config: null });
+    apiGetMock.mockResolvedValue({});
   });
 
   afterEach(() => {
     vi.clearAllMocks();
   });
 
-  it("has a metadata module registered for every sub-page the sitemap emits", async () => {
-    const entries = await sitemapSubpageEntries();
-    const subpaths = [...new Set(entries.map((entry) => entry.subpath))];
+  describe("the sitemap submits community roots only", () => {
+    it("emits exactly one entry per chosen community", async () => {
+      expect(await sitemapUrls()).toEqual([
+        `${SITE_URL}/community/celo`,
+        `${SITE_URL}/community/filecoin`,
+      ]);
+    });
 
-    expect(subpaths.length).toBeGreaterThan(0);
-    for (const subpath of subpaths) {
-      expect(
-        Object.keys(SUBPAGE_METADATA_MODULES),
-        `sitemap emits /${subpath} but no route owns its metadata`
-      ).toContain(subpath);
-    }
-  });
+    it("submits no sub-page URLs at all", async () => {
+      const subPageUrls = (await sitemapUrls()).filter((url) => /\/community\/[^/]+\/.+/.test(url));
+      expect(subPageUrls).toEqual([]);
+    });
 
-  it("serves a self-referential canonical for every sitemap URL", async () => {
-    const entries = await sitemapSubpageEntries();
-
-    for (const entry of entries) {
-      const metadata = await metadataFor(entry.subpath, entry.communityId);
-      const expectedPath = new URL(entry.url).pathname;
-
-      expect(metadata.alternates?.canonical, `${entry.url} must declare itself canonical`).toBe(
-        expectedPath
-      );
-    }
-  });
-
-  it("never marks a sitemap URL noindex", async () => {
-    const entries = await sitemapSubpageEntries();
-
-    for (const entry of entries) {
-      const metadata = await metadataFor(entry.subpath, entry.communityId);
-      const robots = metadata.robots;
-      const directive =
-        typeof robots === "string"
-          ? robots
-          : robots && typeof robots === "object" && robots.index === false
-            ? "noindex"
-            : "";
-
-      expect(directive, `${entry.url} must stay indexable`).not.toContain("noindex");
-    }
-  });
-
-  it("gives each crawlable sub-page a title distinct from the community root", async () => {
-    const entries = (await sitemapSubpageEntries()).filter((entry) => entry.communityId === "celo");
-    const rootTitle = "Celo Community Grants | Karma";
-    const titles = new Map<string, string>();
-
-    for (const entry of entries) {
-      const metadata = await metadataFor(entry.subpath, entry.communityId);
-      // `reports` intentionally inherits the community layout's copy; it only
-      // corrects the canonical. Everything else must say what it is.
-      if (entry.subpath === "reports") {
-        continue;
+    // Named one by one so re-adding any of them is a deliberate, reviewed act
+    // rather than a silent regression.
+    it.each(Object.keys(SUBPAGE_METADATA_MODULES))(
+      "does not submit /%s while it is a client-rendered shell",
+      async (subPage) => {
+        expect(await sitemapUrls()).not.toContain(`${SITE_URL}/community/celo/${subPage}`);
       }
-      const title = metadata.title;
-      expect(typeof title, `${entry.url} must set its own title`).toBe("string");
-      expect(title).not.toBe(rootTitle);
-      titles.set(entry.subpath, title as string);
-    }
-
-    expect(new Set(titles.values()).size).toBe(titles.size);
-    for (const [subpath, title] of titles) {
-      expect(title.toLowerCase(), `${subpath} title should name the community`).toContain("celo");
-    }
-  });
-
-  it("gives each crawlable sub-page its own description", async () => {
-    const entries = (await sitemapSubpageEntries()).filter(
-      (entry) => entry.communityId === "celo" && entry.subpath !== "reports"
     );
-    const descriptions: string[] = [];
 
-    for (const entry of entries) {
-      const metadata = await metadataFor(entry.subpath, entry.communityId);
-      expect(typeof metadata.description, `${entry.url} must set a description`).toBe("string");
-      descriptions.push(metadata.description as string);
-    }
-
-    expect(new Set(descriptions).size).toBe(descriptions.length);
-  });
-
-  it("strips the /community/<slug> prefix from the canonical on a whitelabel domain", async () => {
-    getWhitelabelContextMock.mockResolvedValue({
-      isWhitelabel: true,
-      communitySlug: "celo",
-      config: { domain: "grants.celo.org", communitySlug: "celo" },
-      tenantConfig: null,
+    it("still submits the community root, which carries the real content", async () => {
+      expect(await sitemapUrls()).toContain(`${SITE_URL}/community/celo`);
     });
 
-    const entries = (await sitemapSubpageEntries()).filter((entry) => entry.communityId === "celo");
-
-    for (const entry of entries) {
-      const metadata = await metadataFor(entry.subpath, entry.communityId);
-      expect(metadata.alternates?.canonical).toBe(`/${entry.subpath}`);
-    }
-  });
-
-  it("keeps the canonical self-referential when the community lookup fails", async () => {
-    getCommunityDetailsMock.mockResolvedValue(null);
-
-    const metadata = await metadataFor("projects", "celo");
-
-    expect(metadata.alternates?.canonical).toBe("/community/celo/projects");
-    expect(metadata.title).toContain("celo");
-  });
-
-  it("does not list browse-applications — it has nothing to serve a crawler", async () => {
-    const entries = await sitemapSubpageEntries();
-
-    expect(entries.some((entry) => entry.subpath === "browse-applications")).toBe(false);
-  });
-});
-
-describe("funding-program detail pages listed in the sitemap", () => {
-  beforeEach(() => {
-    getWhitelabelContextMock.mockResolvedValue({
-      isWhitelabel: false,
-      communitySlug: null,
-      config: null,
-      tenantConfig: null,
+    it("falls back to uid when a community has no slug", async () => {
+      chosenCommunitiesMock.mockReturnValue([{ name: "X", slug: undefined, uid: "uid-only" }]);
+      expect(await sitemapUrls()).toEqual([`${SITE_URL}/community/uid-only`]);
     });
-    apiGetMock.mockResolvedValue({
-      programId: "42",
-      name: "Public Goods Fund",
-      metadata: { title: "Public Goods Fund", shortDescription: "Funding public goods." },
+
+    it("emits no query strings and no duplicate URLs", async () => {
+      const urls = await sitemapUrls();
+      expect(urls.every((url) => !url.includes("?"))).toBe(true);
+      expect(new Set(urls).size).toBe(urls.length);
+    });
+
+    it("omits lastModified rather than fabricating one", async () => {
+      const { default: communitiesSitemap } = await import("@/app/sitemaps/communities/sitemap");
+      const entries = await communitiesSitemap();
+      expect(entries.every((entry) => entry.lastModified === undefined)).toBe(true);
     });
   });
 
-  afterEach(() => {
-    vi.clearAllMocks();
-  });
+  describe("shell sub-pages consolidate onto the community root", () => {
+    it.each(SHELL_SUBPAGES)("%s declares no canonical of its own", async (subPage) => {
+      const metadata = await metadataFor(subPage, "celo");
+      expect(metadata.alternates?.canonical).toBeUndefined();
+    });
 
-  it("self-canonicals at the /community/<id>/programs/<programId> sitemap shape", async () => {
-    const mod = await import(
-      "@/app/community/[communityId]/(whitelabel)/programs/[programId]/page"
+    it("financials declares no canonical even for a flagged community", async () => {
+      const metadata = await metadataFor("financials", "filecoin");
+      expect(metadata.alternates?.canonical).toBeUndefined();
+    });
+
+    it.each(TITLED_SUBPAGES)(
+      "%s still sets a distinct title, so the copy is ready when it earns a canonical",
+      async (subPage) => {
+        const metadata = await metadataFor(subPage, "celo");
+        expect(typeof metadata.title).toBe("string");
+        expect(String(metadata.title).length).toBeGreaterThan(0);
+      }
     );
-    const metadata = await mod.generateMetadata({
-      params: Promise.resolve({ communityId: "celo", programId: "42" }),
+
+    it("sub-page titles are unique across routes", async () => {
+      const titles = await Promise.all(
+        TITLED_SUBPAGES.map(async (subPage) => (await metadataFor(subPage, "celo")).title)
+      );
+      expect(new Set(titles).size).toBe(titles.length);
     });
 
-    expect(metadata.alternates?.canonical).toBe("/community/celo/programs/42");
-    expect(new URL(`${SITE_URL}/community/celo/programs/42`).pathname).toBe(
-      metadata.alternates?.canonical
-    );
-    expect(metadata.robots).toBeUndefined();
+    // Production served "Celo Community Grants | Karma | Karma" on several of
+    // these before DEV-586, from a title that already carried the brand suffix
+    // being wrapped by the layout template.
+    it.each(TITLED_SUBPAGES)("%s title carries no doubled brand suffix", async (subPage) => {
+      const metadata = await metadataFor(subPage, "celo");
+      expect(String(metadata.title)).not.toMatch(/\|\s*Karma\s*\|\s*Karma/);
+    });
   });
 });

--- a/__tests__/app/knowledge-collection-ssr.test.tsx
+++ b/__tests__/app/knowledge-collection-ssr.test.tsx
@@ -1,0 +1,231 @@
+/**
+ * JavaScript-disabled rendering for the knowledge and collection templates
+ * (DEV-586).
+ *
+ * Every route here ships in the static sitemap, so what `renderToString`
+ * produces — no effects, no hydration, no client fetches — is exactly what a
+ * crawler that does not execute JavaScript receives. The assertions are about
+ * that HTML: a heading, enough visible prose to be worth indexing, the
+ * structured data, and a canonical that points at the page itself.
+ *
+ * The project, funding-program and community-root templates already have their
+ * own no-JS coverage (project-layout-ssr-shell, program-detail-ssr,
+ * ssr-server-components) and are deliberately not duplicated here.
+ */
+import { PassThrough } from "node:stream";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { Metadata } from "next";
+import type React from "react";
+import { renderToPipeableStream, renderToString } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+import { SITE_URL } from "@/utilities/meta";
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn(), prefetch: vi.fn() }),
+  usePathname: () => "/",
+  useParams: () => ({}),
+  useSearchParams: () => new URLSearchParams(),
+  notFound: () => {
+    throw new Error("NEXT_NOT_FOUND");
+  },
+}));
+
+// Auth-gated CTA: it depends on the Privy bridge, which has no server-side
+// equivalent. It is a button, not indexable content.
+vi.mock("@/src/features/homepage/components/create-project-button", () => ({
+  CreateProjectButton: () => null,
+}));
+
+// The explorer list itself is client-fetched and sits behind Suspense; the
+// no-JS assertions below are about the server-rendered shell around it.
+vi.mock("@/components/Pages/Projects/ProjectsExplorer", () => ({
+  ProjectsExplorer: () => null,
+}));
+// `/communities` has no server-rendered equivalent of the /projects hero: the
+// whole listing is `CommunitiesPage`, a client component whose no-JS output is
+// a text-free skeleton. Stubbing it changes nothing a crawler would have seen,
+// and the assertions below are scoped accordingly — see the note on the
+// `/communities` case for what is and is not proven here.
+vi.mock("@/components/Pages/Communities/CommunitiesPage", () => ({
+  CommunitiesPage: () => null,
+}));
+vi.mock("@/services/projects-explorer.service", () => ({
+  getExplorerProjectsPaginated: vi.fn(async () => ({
+    payload: [],
+    pagination: { page: 0, pageLimit: 12, totalNum: 0 },
+  })),
+}));
+
+const MIN_MEANINGFUL_CHARS = 200;
+
+/** Visible text a reader sees with JavaScript disabled — the crawler's view. */
+function visibleText(html: string): string {
+  return html
+    .replace(/<(script|style|noscript|template)\b[^>]*>[\s\S]*?<\/\1>/gi, " ")
+    .replace(/<[^>]*>/g, " ")
+    .replace(/&nbsp;/gi, " ")
+    .replace(/&amp;/g, "&")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function jsonLdBlocks(html: string): Array<Record<string, unknown>> {
+  const blocks: Array<Record<string, unknown>> = [];
+  const pattern = /<script[^>]*type="application\/ld\+json"[^>]*>([\s\S]*?)<\/script>/gi;
+  let match = pattern.exec(html);
+  while (match !== null) {
+    blocks.push(JSON.parse(match[1]) as Record<string, unknown>);
+    match = pattern.exec(html);
+  }
+  return blocks;
+}
+
+function firstHeading(html: string): string | null {
+  const match = html.match(/<h1\b[^>]*>([\s\S]*?)<\/h1>/i);
+  return match ? visibleText(match[1]) : null;
+}
+
+function canonicalOf(metadata: Metadata): string | undefined {
+  const canonical = metadata.alternates?.canonical;
+  return typeof canonical === "string" ? canonical : undefined;
+}
+
+/**
+ * Streamed server render, for routes with a Suspense boundary. Resolves with
+ * the complete shell + streamed chunks — what a crawler ends up with, since
+ * Google consumes the whole response body before parsing.
+ */
+function renderStreamToString(ui: React.ReactNode): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    const sink = new PassThrough();
+    sink.on("data", (chunk: Buffer) => chunks.push(chunk));
+    sink.on("end", () => resolve(Buffer.concat(chunks).toString("utf8")));
+    sink.on("error", reject);
+
+    const { pipe } = renderToPipeableStream(ui, {
+      onAllReady: () => pipe(sink),
+      onError: reject,
+    });
+  });
+}
+
+async function renderRoute(
+  importer: () => Promise<{
+    default: (props?: never) => React.ReactNode | Promise<React.ReactNode>;
+  }>
+): Promise<string> {
+  const { default: Page } = await importer();
+  const ui = await Page();
+  return renderToString(<>{ui}</>);
+}
+
+describe("knowledge article template — no-JS rendering", () => {
+  const importArticle = () => import("@/app/knowledge/grant-accountability/page");
+
+  it("server-renders a heading and substantive prose", async () => {
+    const html = await renderRoute(importArticle);
+
+    expect(firstHeading(html)).toMatch(/Grant Accountability/i);
+    expect(visibleText(html).length).toBeGreaterThan(MIN_MEANINGFUL_CHARS);
+  });
+
+  it("emits Article structured data whose facts are visible in the HTML", async () => {
+    const html = await renderRoute(importArticle);
+    const article = jsonLdBlocks(html).find((block) => block["@type"] === "Article");
+
+    expect(article).toBeDefined();
+    expect(article?.url).toBe(`${SITE_URL}/knowledge/grant-accountability`);
+    expect(visibleText(html)).toContain(String(article?.headline ?? ""));
+  });
+
+  it("self-canonicals at its own path", async () => {
+    const { metadata } = await importArticle();
+
+    expect(canonicalOf(metadata)).toBe("/knowledge/grant-accountability");
+  });
+});
+
+describe("knowledge index template — no-JS rendering", () => {
+  const importIndex = () => import("@/app/knowledge/page");
+
+  it("server-renders the article links a crawler follows", async () => {
+    const html = await renderRoute(importIndex);
+
+    expect(firstHeading(html)).toMatch(/Knowledge Base/i);
+    expect(html).toContain('href="/knowledge/grant-accountability"');
+    expect(visibleText(html).length).toBeGreaterThan(MIN_MEANINGFUL_CHARS);
+  });
+
+  it("emits CollectionPage structured data pointing at itself", async () => {
+    const html = await renderRoute(importIndex);
+    const collection = jsonLdBlocks(html).find((block) => block["@type"] === "CollectionPage");
+
+    expect(collection?.url).toBe(`${SITE_URL}/knowledge`);
+  });
+
+  it("self-canonicals at its own path", async () => {
+    const { metadata } = await importIndex();
+
+    expect(canonicalOf(metadata)).toBe("/knowledge");
+  });
+});
+
+describe("collection templates — no-JS rendering", () => {
+  it("/projects server-renders its hero and CollectionPage structured data", async () => {
+    const { default: Page, metadata } = await import("@/app/projects/page");
+    const ui = await Page({ searchParams: Promise.resolve({}) });
+    // A fresh client per render, mirroring the per-request client the app
+    // provider creates — the root layout supplies one in production.
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const html = await renderStreamToString(
+      <QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>
+    );
+
+    expect(firstHeading(html)).toBeTruthy();
+    expect(visibleText(html).length).toBeGreaterThan(MIN_MEANINGFUL_CHARS);
+
+    const collection = jsonLdBlocks(html).find((block) => block["@type"] === "CollectionPage");
+    expect(collection?.url).toBe(`${SITE_URL}/projects`);
+    expect(canonicalOf(metadata)).toBe("/projects");
+  });
+
+  /**
+   * Deliberately narrower than the /projects case above. `/communities` is
+   * listed in the static sitemap but its listing is entirely client-rendered,
+   * so there is no server prose to assert and this test does NOT claim the page
+   * is meaningful without JavaScript — the sitemap crawl reports it as `thin`,
+   * which is the honest signal and is not suppressed by any allowlist entry.
+   *
+   * What is asserted: the route still emits a server-rendered shell (an empty
+   * body to a crawler fails here), its CollectionPage facts match the metadata
+   * the page advertises, and it points its canonical at itself.
+   */
+  it("/communities server-renders a shell whose CollectionPage facts match its metadata", async () => {
+    const { default: Page, metadata } = await import("@/app/communities/page");
+    const html = renderToString(<>{await Page()}</>);
+
+    expect(html).toMatch(/<main\b/);
+
+    const collection = jsonLdBlocks(html).find((block) => block["@type"] === "CollectionPage");
+    expect(collection?.url).toBe(`${SITE_URL}/communities`);
+    expect(collection?.name).toBe(metadata.title);
+    expect(collection?.description).toBe(metadata.description);
+    expect(canonicalOf(metadata)).toBe("/communities");
+  });
+
+  it("keeps every collection canonical free of query strings", async () => {
+    const modules = await Promise.all([
+      import("@/app/projects/page"),
+      import("@/app/communities/page"),
+      import("@/app/knowledge/page"),
+    ]);
+
+    for (const mod of modules) {
+      const canonical = canonicalOf(mod.metadata);
+      expect(canonical).toBeTruthy();
+      expect(canonical).not.toContain("?");
+      expect(canonical?.startsWith("/")).toBe(true);
+    }
+  });
+});

--- a/__tests__/app/sitemaps/communities/sitemap.test.ts
+++ b/__tests__/app/sitemaps/communities/sitemap.test.ts
@@ -1,0 +1,111 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { SITE_URL } from "@/utilities/meta";
+
+const { chosenCommunitiesMock } = vi.hoisted(() => ({
+  chosenCommunitiesMock: vi.fn(),
+}));
+
+vi.mock("@/utilities/chosenCommunities", () => ({
+  chosenCommunities: chosenCommunitiesMock,
+}));
+
+vi.mock("@/utilities/community-flags", () => ({
+  FINANCIALS_ENABLED_COMMUNITIES: ["filecoin"],
+}));
+
+const COMMUNITIES = [
+  { name: "Celo", slug: "celo", uid: "0xcelo", imageURL: { light: "", dark: "" } },
+  { name: "Filecoin", slug: "filecoin", uid: "0xfilecoin", imageURL: { light: "", dark: "" } },
+  // No slug: the sitemap must fall back to the uid rather than emit `/undefined`.
+  { name: "Slugless", slug: "", uid: "0xslugless", imageURL: { light: "", dark: "" } },
+];
+
+const loadSitemap = async () => {
+  const { default: communitiesSitemap } = await import("@/app/sitemaps/communities/sitemap");
+  return communitiesSitemap();
+};
+
+const urlsFor = (entries: Array<{ url: string }>, identifier: string) =>
+  entries
+    .map((entry) => entry.url)
+    .filter((url) => url.startsWith(`${SITE_URL}/community/${identifier}`));
+
+describe("app/sitemaps/communities/sitemap.ts", () => {
+  beforeEach(() => {
+    chosenCommunitiesMock.mockReturnValue(COMMUNITIES);
+  });
+
+  afterEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+  });
+
+  it("emits the community root plus every self-canonical sub-page", async () => {
+    const entries = await loadSitemap();
+
+    expect(urlsFor(entries, "celo")).toEqual([
+      `${SITE_URL}/community/celo`,
+      `${SITE_URL}/community/celo/funding-opportunities`,
+      `${SITE_URL}/community/celo/projects`,
+      `${SITE_URL}/community/celo/updates`,
+      `${SITE_URL}/community/celo/impact`,
+      `${SITE_URL}/community/celo/reports`,
+    ]);
+  });
+
+  it("omits browse-applications — it has no server-rendered content to index", async () => {
+    const entries = await loadSitemap();
+    const urls = entries.map((entry) => entry.url);
+
+    expect(urls.some((url) => url.includes("browse-applications"))).toBe(false);
+  });
+
+  it("emits financials only for communities where the feature is enabled", async () => {
+    const entries = await loadSitemap();
+    const urls = entries.map((entry) => entry.url);
+
+    expect(urls).toContain(`${SITE_URL}/community/filecoin/financials`);
+    expect(urls).not.toContain(`${SITE_URL}/community/celo/financials`);
+    expect(urls.filter((url) => url.endsWith("/financials"))).toHaveLength(1);
+  });
+
+  it("falls back to the uid when a community has no slug", async () => {
+    const entries = await loadSitemap();
+    const urls = entries.map((entry) => entry.url);
+
+    expect(urls).toContain(`${SITE_URL}/community/0xslugless`);
+    expect(urls).toContain(`${SITE_URL}/community/0xslugless/projects`);
+    expect(urls.some((url) => url.includes("undefined"))).toBe(false);
+  });
+
+  it("keeps every URL on the canonical origin with no query, hash or duplicate", async () => {
+    const entries = await loadSitemap();
+    const urls = entries.map((entry) => entry.url);
+
+    for (const url of urls) {
+      const parsed = new URL(url);
+      expect(parsed.origin).toBe(new URL(SITE_URL).origin);
+      expect(parsed.search).toBe("");
+      expect(parsed.hash).toBe("");
+    }
+    expect(new Set(urls).size).toBe(urls.length);
+  });
+
+  it("ranks the community root above its sub-pages", async () => {
+    const entries = await loadSitemap();
+    const root = entries.find((entry) => entry.url === `${SITE_URL}/community/celo`);
+    const subPage = entries.find((entry) => entry.url === `${SITE_URL}/community/celo/projects`);
+
+    expect(root?.priority).toBe(0.9);
+    expect(subPage?.priority).toBe(0.7);
+    expect(root?.changeFrequency).toBe("daily");
+  });
+
+  it("omits lastModified rather than fabricating one", async () => {
+    const entries = await loadSitemap();
+
+    for (const entry of entries) {
+      expect(entry.lastModified).toBeUndefined();
+    }
+  });
+});

--- a/__tests__/app/sitemaps/communities/sitemap.test.ts
+++ b/__tests__/app/sitemaps/communities/sitemap.test.ts
@@ -9,10 +9,6 @@ vi.mock("@/utilities/chosenCommunities", () => ({
   chosenCommunities: chosenCommunitiesMock,
 }));
 
-vi.mock("@/utilities/community-flags", () => ({
-  FINANCIALS_ENABLED_COMMUNITIES: ["filecoin"],
-}));
-
 const COMMUNITIES = [
   { name: "Celo", slug: "celo", uid: "0xcelo", imageURL: { light: "", dark: "" } },
   { name: "Filecoin", slug: "filecoin", uid: "0xfilecoin", imageURL: { light: "", dark: "" } },
@@ -40,33 +36,29 @@ describe("app/sitemaps/communities/sitemap.ts", () => {
     vi.clearAllMocks();
   });
 
-  it("emits the community root plus every self-canonical sub-page", async () => {
+  // Community roots only: every sub-page is a client-rendered shell, and
+  // /projects is a byte-for-byte near-duplicate of the root. See
+  // __tests__/app/community-subpage-canonicals.test.ts for the crawl numbers
+  // and the canonical half of the contract.
+  it("emits the community root and nothing beneath it", async () => {
     const entries = await loadSitemap();
 
-    expect(urlsFor(entries, "celo")).toEqual([
-      `${SITE_URL}/community/celo`,
-      `${SITE_URL}/community/celo/funding-opportunities`,
-      `${SITE_URL}/community/celo/projects`,
-      `${SITE_URL}/community/celo/updates`,
-      `${SITE_URL}/community/celo/impact`,
-      `${SITE_URL}/community/celo/reports`,
-    ]);
+    expect(urlsFor(entries, "celo")).toEqual([`${SITE_URL}/community/celo`]);
   });
 
-  it("omits browse-applications — it has no server-rendered content to index", async () => {
+  it.each([
+    "funding-opportunities",
+    "projects",
+    "updates",
+    "impact",
+    "reports",
+    "financials",
+    "browse-applications",
+  ])("omits /%s — no server-rendered content to index", async (subPage) => {
     const entries = await loadSitemap();
     const urls = entries.map((entry) => entry.url);
 
-    expect(urls.some((url) => url.includes("browse-applications"))).toBe(false);
-  });
-
-  it("emits financials only for communities where the feature is enabled", async () => {
-    const entries = await loadSitemap();
-    const urls = entries.map((entry) => entry.url);
-
-    expect(urls).toContain(`${SITE_URL}/community/filecoin/financials`);
-    expect(urls).not.toContain(`${SITE_URL}/community/celo/financials`);
-    expect(urls.filter((url) => url.endsWith("/financials"))).toHaveLength(1);
+    expect(urls.some((url) => url.endsWith(`/${subPage}`))).toBe(false);
   });
 
   it("falls back to the uid when a community has no slug", async () => {
@@ -74,7 +66,6 @@ describe("app/sitemaps/communities/sitemap.ts", () => {
     const urls = entries.map((entry) => entry.url);
 
     expect(urls).toContain(`${SITE_URL}/community/0xslugless`);
-    expect(urls).toContain(`${SITE_URL}/community/0xslugless/projects`);
     expect(urls.some((url) => url.includes("undefined"))).toBe(false);
   });
 
@@ -91,14 +82,14 @@ describe("app/sitemaps/communities/sitemap.ts", () => {
     expect(new Set(urls).size).toBe(urls.length);
   });
 
-  it("ranks the community root above its sub-pages", async () => {
+  it("gives every community root the same priority and change frequency", async () => {
     const entries = await loadSitemap();
-    const root = entries.find((entry) => entry.url === `${SITE_URL}/community/celo`);
-    const subPage = entries.find((entry) => entry.url === `${SITE_URL}/community/celo/projects`);
 
-    expect(root?.priority).toBe(0.9);
-    expect(subPage?.priority).toBe(0.7);
-    expect(root?.changeFrequency).toBe("daily");
+    expect(entries).toHaveLength(3);
+    for (const entry of entries) {
+      expect(entry.priority).toBe(0.9);
+      expect(entry.changeFrequency).toBe("daily");
+    }
   });
 
   it("omits lastModified rather than fabricating one", async () => {

--- a/app/community/[communityId]/(with-header)/financials/page.tsx
+++ b/app/community/[communityId]/(with-header)/financials/page.tsx
@@ -8,7 +8,6 @@ import { api } from "@/utilities/api/client";
 import { HttpError, isApiError } from "@/utilities/api/errors";
 import { FINANCIALS_ENABLED_COMMUNITIES } from "@/utilities/community-flags";
 import { INDEXER } from "@/utilities/indexer";
-import { communitySubpageMetadata } from "@/utilities/metadata/communityCanonical";
 import { PAGES } from "@/utilities/pages";
 import { defaultQueryOptions } from "@/utilities/queries/defaultOptions";
 import { getCommunityDetails } from "@/utilities/queries/v2/getCommunityData";
@@ -24,16 +23,14 @@ export async function generateMetadata({ params }: { params: Params }): Promise<
     return {};
   }
 
-  // Self-canonical: only flagged communities are submitted to the sitemap, and
-  // that URL must not inherit the community layout's `/community/<id>` canonical.
-  const [community, canonicalMetadata] = await Promise.all([
-    getCachedCommunity(communityId),
-    communitySubpageMetadata(communityId, "financials"),
-  ]);
+  const community = await getCachedCommunity(communityId);
   const communityName = community?.details?.name || communityId;
 
+  // No self-canonical: this route is a client-rendered shell, so it is absent
+  // from the sitemap and consolidates onto the community root canonical it
+  // inherits from the layout. Give it server-rendered content first, then a
+  // canonical and a sitemap entry together.
   return {
-    ...canonicalMetadata,
     title: `Financials - ${communityName}`,
     description: `View financial overview, project agreements, milestones, and payment status for ${communityName}.`,
   };

--- a/app/community/[communityId]/(with-header)/financials/page.tsx
+++ b/app/community/[communityId]/(with-header)/financials/page.tsx
@@ -8,6 +8,7 @@ import { api } from "@/utilities/api/client";
 import { HttpError, isApiError } from "@/utilities/api/errors";
 import { FINANCIALS_ENABLED_COMMUNITIES } from "@/utilities/community-flags";
 import { INDEXER } from "@/utilities/indexer";
+import { communitySubpageMetadata } from "@/utilities/metadata/communityCanonical";
 import { PAGES } from "@/utilities/pages";
 import { defaultQueryOptions } from "@/utilities/queries/defaultOptions";
 import { getCommunityDetails } from "@/utilities/queries/v2/getCommunityData";
@@ -23,10 +24,16 @@ export async function generateMetadata({ params }: { params: Params }): Promise<
     return {};
   }
 
-  const community = await getCachedCommunity(communityId);
+  // Self-canonical: only flagged communities are submitted to the sitemap, and
+  // that URL must not inherit the community layout's `/community/<id>` canonical.
+  const [community, canonicalMetadata] = await Promise.all([
+    getCachedCommunity(communityId),
+    communitySubpageMetadata(communityId, "financials"),
+  ]);
   const communityName = community?.details?.name || communityId;
 
   return {
+    ...canonicalMetadata,
     title: `Financials - ${communityName}`,
     description: `View financial overview, project agreements, milestones, and payment status for ${communityName}.`,
   };

--- a/app/community/[communityId]/(with-header)/funding-opportunities/layout.tsx
+++ b/app/community/[communityId]/(with-header)/funding-opportunities/layout.tsx
@@ -1,6 +1,5 @@
 import type { Metadata } from "next";
 import { PROJECT_NAME } from "@/constants/brand";
-import { communitySubpageMetadata } from "@/utilities/metadata/communityCanonical";
 import { getCommunityDetails } from "@/utilities/queries/v2/getCommunityData";
 
 type LayoutProps = {
@@ -17,14 +16,14 @@ export async function generateMetadata({
   params: Promise<{ communityId: string }>;
 }): Promise<Metadata> {
   const { communityId } = await params;
-  const [community, canonicalMetadata] = await Promise.all([
-    getCommunityDetails(communityId),
-    communitySubpageMetadata(communityId, "funding-opportunities"),
-  ]);
+  const community = await getCommunityDetails(communityId);
   const communityName = community?.details?.name || communityId;
 
+  // No self-canonical: this route is a client-rendered shell, so it is absent
+  // from the sitemap and consolidates onto the community root canonical it
+  // inherits from the layout. Give it server-rendered content first, then a
+  // canonical and a sitemap entry together.
   return {
-    ...canonicalMetadata,
     title: `${communityName} Funding Opportunities | ${PROJECT_NAME}`,
     description: `Find open, upcoming, and closed grant programs from ${communityName}. Compare funding amounts, deadlines, and eligibility before you apply on ${PROJECT_NAME}.`,
   };

--- a/app/community/[communityId]/(with-header)/funding-opportunities/layout.tsx
+++ b/app/community/[communityId]/(with-header)/funding-opportunities/layout.tsx
@@ -3,32 +3,33 @@ import { PROJECT_NAME } from "@/constants/brand";
 import { communitySubpageMetadata } from "@/utilities/metadata/communityCanonical";
 import { getCommunityDetails } from "@/utilities/queries/v2/getCommunityData";
 
-type Props = {
+type LayoutProps = {
   children: React.ReactNode;
   params: Promise<{ communityId: string }>;
 };
 
+// The page itself is a client component, so its metadata lives here. Without it
+// the funding directory inherits the community layout's canonical and title,
+// which made a sitemap-listed URL point at `/community/<id>`.
 export async function generateMetadata({
   params,
 }: {
   params: Promise<{ communityId: string }>;
 }): Promise<Metadata> {
   const { communityId } = await params;
-  // Self-canonical: this page is in the sitemap, so it must not inherit the
-  // community layout's `/community/<id>` canonical.
   const [community, canonicalMetadata] = await Promise.all([
     getCommunityDetails(communityId),
-    communitySubpageMetadata(communityId, "updates"),
+    communitySubpageMetadata(communityId, "funding-opportunities"),
   ]);
   const communityName = community?.details?.name || communityId;
 
   return {
     ...canonicalMetadata,
-    title: `${communityName} Milestone Updates | ${PROJECT_NAME}`,
-    description: `Stay up to date with milestone progress from ${communityName} grantees. Track completed, pending, and overdue milestones across all funded projects on ${PROJECT_NAME}.`,
+    title: `${communityName} Funding Opportunities | ${PROJECT_NAME}`,
+    description: `Find open, upcoming, and closed grant programs from ${communityName}. Compare funding amounts, deadlines, and eligibility before you apply on ${PROJECT_NAME}.`,
   };
 }
 
-export default function UpdatesLayout({ children }: Props) {
+export default function FundingOpportunitiesLayout({ children }: LayoutProps) {
   return children;
 }

--- a/app/community/[communityId]/(with-header)/impact/layout.tsx
+++ b/app/community/[communityId]/(with-header)/impact/layout.tsx
@@ -2,7 +2,6 @@ import type { Metadata } from "next";
 import { CommunityImpactFilterRow } from "@/components/Pages/Communities/Impact/FilterRow";
 import { ImpactTabNavigator } from "@/components/Pages/Communities/Impact/ImpactTabNavigator";
 import { PROJECT_NAME } from "@/constants/brand";
-import { communitySubpageMetadata } from "@/utilities/metadata/communityCanonical";
 import { getCommunityDetails } from "@/utilities/queries/v2/getCommunityData";
 
 type LayoutProps = {
@@ -16,16 +15,14 @@ export async function generateMetadata({
   params: Promise<{ communityId: string }>;
 }): Promise<Metadata> {
   const { communityId } = await params;
-  // Self-canonical: this page is in the sitemap, so it must not inherit the
-  // community layout's `/community/<id>` canonical.
-  const [community, canonicalMetadata] = await Promise.all([
-    getCommunityDetails(communityId),
-    communitySubpageMetadata(communityId, "impact"),
-  ]);
+  const community = await getCommunityDetails(communityId);
   const communityName = community?.details?.name || communityId;
 
+  // No self-canonical: this route is a client-rendered shell, so it is absent
+  // from the sitemap and consolidates onto the community root canonical it
+  // inherits from the layout. Give it server-rendered content first, then a
+  // canonical and a sitemap entry together.
   return {
-    ...canonicalMetadata,
     title: `${communityName} Impact & Outcomes | ${PROJECT_NAME}`,
     description: `Measure the impact of grants funded by ${communityName}. Explore project outcomes, performance metrics, and community-driven results on ${PROJECT_NAME}.`,
   };

--- a/app/community/[communityId]/(with-header)/impact/layout.tsx
+++ b/app/community/[communityId]/(with-header)/impact/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { CommunityImpactFilterRow } from "@/components/Pages/Communities/Impact/FilterRow";
 import { ImpactTabNavigator } from "@/components/Pages/Communities/Impact/ImpactTabNavigator";
 import { PROJECT_NAME } from "@/constants/brand";
+import { communitySubpageMetadata } from "@/utilities/metadata/communityCanonical";
 import { getCommunityDetails } from "@/utilities/queries/v2/getCommunityData";
 
 type LayoutProps = {
@@ -15,10 +16,16 @@ export async function generateMetadata({
   params: Promise<{ communityId: string }>;
 }): Promise<Metadata> {
   const { communityId } = await params;
-  const community = await getCommunityDetails(communityId);
+  // Self-canonical: this page is in the sitemap, so it must not inherit the
+  // community layout's `/community/<id>` canonical.
+  const [community, canonicalMetadata] = await Promise.all([
+    getCommunityDetails(communityId),
+    communitySubpageMetadata(communityId, "impact"),
+  ]);
   const communityName = community?.details?.name || communityId;
 
   return {
+    ...canonicalMetadata,
     title: `${communityName} Impact & Outcomes | ${PROJECT_NAME}`,
     description: `Measure the impact of grants funded by ${communityName}. Explore project outcomes, performance metrics, and community-driven results on ${PROJECT_NAME}.`,
   };

--- a/app/community/[communityId]/(with-header)/projects/page.tsx
+++ b/app/community/[communityId]/(with-header)/projects/page.tsx
@@ -3,7 +3,6 @@ import { notFound } from "next/navigation";
 import { CommunityGrants } from "@/components/CommunityGrants";
 import { PROJECT_NAME } from "@/constants/brand";
 import type { MaturityStageOptions, SortByOptions } from "@/types";
-import { communitySubpageMetadata } from "@/utilities/metadata/communityCanonical";
 import { PAGES } from "@/utilities/pages";
 import {
   COMMUNITY_PROJECTS_PAGE_SIZE,
@@ -30,14 +29,14 @@ type Props = {
 // at `/community/<id>` and duplicated the root's title.
 export async function generateMetadata({ params }: { params: Props["params"] }): Promise<Metadata> {
   const { communityId } = await params;
-  const [community, canonicalMetadata] = await Promise.all([
-    getCommunityDetails(communityId),
-    communitySubpageMetadata(communityId, "projects"),
-  ]);
+  const community = await getCommunityDetails(communityId);
   const communityName = community?.details?.name || communityId;
 
+  // No self-canonical: this route is a client-rendered shell, so it is absent
+  // from the sitemap and consolidates onto the community root canonical it
+  // inherits from the layout. Give it server-rendered content first, then a
+  // canonical and a sitemap entry together.
   return {
-    ...canonicalMetadata,
     title: `${communityName} Funded Projects | ${PROJECT_NAME}`,
     description: `Browse every project funded by ${communityName}. Filter by category and maturity stage, and follow grantee milestones and impact on ${PROJECT_NAME}.`,
   };

--- a/app/community/[communityId]/(with-header)/projects/page.tsx
+++ b/app/community/[communityId]/(with-header)/projects/page.tsx
@@ -1,6 +1,9 @@
+import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import { CommunityGrants } from "@/components/CommunityGrants";
+import { PROJECT_NAME } from "@/constants/brand";
 import type { MaturityStageOptions, SortByOptions } from "@/types";
+import { communitySubpageMetadata } from "@/utilities/metadata/communityCanonical";
 import { PAGES } from "@/utilities/pages";
 import {
   COMMUNITY_PROJECTS_PAGE_SIZE,
@@ -21,6 +24,24 @@ type Props = {
   }>;
   searchParams: Promise<CommunityProjectsSearchParams>;
 };
+
+// Self-canonical with its own title/description. Without this the page inherits
+// the community layout's metadata, so a sitemap-listed URL pointed its canonical
+// at `/community/<id>` and duplicated the root's title.
+export async function generateMetadata({ params }: { params: Props["params"] }): Promise<Metadata> {
+  const { communityId } = await params;
+  const [community, canonicalMetadata] = await Promise.all([
+    getCommunityDetails(communityId),
+    communitySubpageMetadata(communityId, "projects"),
+  ]);
+  const communityName = community?.details?.name || communityId;
+
+  return {
+    ...canonicalMetadata,
+    title: `${communityName} Funded Projects | ${PROJECT_NAME}`,
+    description: `Browse every project funded by ${communityName}. Filter by category and maturity stage, and follow grantee milestones and impact on ${PROJECT_NAME}.`,
+  };
+}
 
 export default async function CommunityProjectsPage(props: Props) {
   const { communityId } = await props.params;

--- a/app/community/[communityId]/(with-header)/updates/layout.tsx
+++ b/app/community/[communityId]/(with-header)/updates/layout.tsx
@@ -1,6 +1,5 @@
 import type { Metadata } from "next";
 import { PROJECT_NAME } from "@/constants/brand";
-import { communitySubpageMetadata } from "@/utilities/metadata/communityCanonical";
 import { getCommunityDetails } from "@/utilities/queries/v2/getCommunityData";
 
 type Props = {
@@ -14,16 +13,14 @@ export async function generateMetadata({
   params: Promise<{ communityId: string }>;
 }): Promise<Metadata> {
   const { communityId } = await params;
-  // Self-canonical: this page is in the sitemap, so it must not inherit the
-  // community layout's `/community/<id>` canonical.
-  const [community, canonicalMetadata] = await Promise.all([
-    getCommunityDetails(communityId),
-    communitySubpageMetadata(communityId, "updates"),
-  ]);
+  const community = await getCommunityDetails(communityId);
   const communityName = community?.details?.name || communityId;
 
+  // No self-canonical: this route is a client-rendered shell, so it is absent
+  // from the sitemap and consolidates onto the community root canonical it
+  // inherits from the layout. Give it server-rendered content first, then a
+  // canonical and a sitemap entry together.
   return {
-    ...canonicalMetadata,
     title: `${communityName} Milestone Updates | ${PROJECT_NAME}`,
     description: `Stay up to date with milestone progress from ${communityName} grantees. Track completed, pending, and overdue milestones across all funded projects on ${PROJECT_NAME}.`,
   };

--- a/app/sitemaps/communities/sitemap.ts
+++ b/app/sitemaps/communities/sitemap.ts
@@ -1,50 +1,32 @@
 import type { MetadataRoute } from "next";
 import { chosenCommunities } from "@/utilities/chosenCommunities";
-import { FINANCIALS_ENABLED_COMMUNITIES } from "@/utilities/community-flags";
 import { SITE_URL } from "@/utilities/meta";
 
-// Sub-pages every chosen community exposes. Each one serves a self-referential
-// canonical and its own title/description — a URL only earns a sitemap entry
-// when it is the canonical of distinct, crawlable content.
+// Community roots only.
 //
-// `browse-applications` is deliberately absent: it is a fully client-rendered
-// application-search tool with no server-rendered content and no unique
-// metadata, so it has nothing for a crawler to index. It still serves 200 and
-// consolidates onto the community root canonical — it is just not submitted.
-const COMMUNITY_SUB_PAGES = [
-  "funding-opportunities",
-  "projects",
-  "updates",
-  "impact",
-  "reports",
-] as const;
+// Every sub-page under /community/<id>/ is currently a client-rendered shell:
+// a crawl of production (2026-08-03, Googlebot UA, JavaScript disabled) measured
+// funding-opportunities 406 chars, updates 475, impact 613, financials 501 and
+// reports 406 of visible text, while /projects rendered 5578 chars that are
+// 99.9% identical to the community root's 5570 with no unique words at all.
+//
+// Submitting those would ask Google to index five thin pages plus a literal
+// duplicate of a URL already in this sitemap, so they stay out and consolidate
+// onto the community root via the layout canonical they inherit. They still
+// serve 200 — they are de-listed, not removed.
+//
+// A sub-page earns an entry here once it server-renders content a crawler can
+// read AND declares its own canonical. `communitySubpageCanonicals` in
+// __tests__/app/community-subpage-canonicals.test.ts fails if one is added
+// without both, so this cannot be undone by accident.
 
 // `lastModified` is intentionally omitted — we have no accurate per-page
 // modified date, and a fabricated "now" makes Google distrust the signal
 // (see utilities/sitemap.ts buildUrlsetXml).
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
-  return chosenCommunities().flatMap((community) => {
-    const identifier = community.slug || community.uid;
-
-    const rootEntry: MetadataRoute.Sitemap[number] = {
-      url: `${SITE_URL}/community/${identifier}`,
-      changeFrequency: "daily",
-      priority: 0.9,
-    };
-
-    // Financials is behind a per-community flag; everywhere else the route
-    // renders an explicit "not available" state, and submitting those would
-    // list a near-identical thin page per community.
-    const subPages: string[] = FINANCIALS_ENABLED_COMMUNITIES.includes(identifier)
-      ? [...COMMUNITY_SUB_PAGES, "financials"]
-      : [...COMMUNITY_SUB_PAGES];
-
-    const subPageEntries: MetadataRoute.Sitemap = subPages.map((subPage) => ({
-      url: `${SITE_URL}/community/${identifier}/${subPage}`,
-      changeFrequency: "daily" as const,
-      priority: 0.7,
-    }));
-
-    return [rootEntry, ...subPageEntries];
-  });
+  return chosenCommunities().map((community) => ({
+    url: `${SITE_URL}/community/${community.slug || community.uid}`,
+    changeFrequency: "daily" as const,
+    priority: 0.9,
+  }));
 }

--- a/app/sitemaps/communities/sitemap.ts
+++ b/app/sitemaps/communities/sitemap.ts
@@ -1,13 +1,21 @@
 import type { MetadataRoute } from "next";
 import { chosenCommunities } from "@/utilities/chosenCommunities";
+import { FINANCIALS_ENABLED_COMMUNITIES } from "@/utilities/community-flags";
+import { SITE_URL } from "@/utilities/meta";
 
-const communitySubPages = [
+// Sub-pages every chosen community exposes. Each one serves a self-referential
+// canonical and its own title/description — a URL only earns a sitemap entry
+// when it is the canonical of distinct, crawlable content.
+//
+// `browse-applications` is deliberately absent: it is a fully client-rendered
+// application-search tool with no server-rendered content and no unique
+// metadata, so it has nothing for a crawler to index. It still serves 200 and
+// consolidates onto the community root canonical — it is just not submitted.
+const COMMUNITY_SUB_PAGES = [
   "funding-opportunities",
-  "browse-applications",
   "projects",
   "updates",
   "impact",
-  "financials",
   "reports",
 ] as const;
 
@@ -19,13 +27,20 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     const identifier = community.slug || community.uid;
 
     const rootEntry: MetadataRoute.Sitemap[number] = {
-      url: `https://www.karmahq.xyz/community/${identifier}`,
+      url: `${SITE_URL}/community/${identifier}`,
       changeFrequency: "daily",
       priority: 0.9,
     };
 
-    const subPageEntries: MetadataRoute.Sitemap = communitySubPages.map((subPage) => ({
-      url: `https://www.karmahq.xyz/community/${identifier}/${subPage}`,
+    // Financials is behind a per-community flag; everywhere else the route
+    // renders an explicit "not available" state, and submitting those would
+    // list a near-identical thin page per community.
+    const subPages: string[] = FINANCIALS_ENABLED_COMMUNITIES.includes(identifier)
+      ? [...COMMUNITY_SUB_PAGES, "financials"]
+      : [...COMMUNITY_SUB_PAGES];
+
+    const subPageEntries: MetadataRoute.Sitemap = subPages.map((subPage) => ({
+      url: `${SITE_URL}/community/${identifier}/${subPage}`,
       changeFrequency: "daily" as const,
       priority: 0.7,
     }));

--- a/scripts/crawl-sitemap.mjs
+++ b/scripts/crawl-sitemap.mjs
@@ -1,0 +1,316 @@
+/**
+ * MANUAL-ONLY sitemap content crawl. This hits PRODUCTION and is deliberately
+ * not wired into any CI workflow — only its no-network unit tests are.
+ *
+ *   node scripts/crawl-sitemap.mjs --output artifacts/sitemap-crawl-report.json
+ *
+ * Import-safe: running the file directly executes the crawl; importing it (e.g.
+ * from tests) only exposes parseArgs/main without side effects.
+ *
+ * Precedence: flags > CRAWL_* env > built-in defaults.
+ */
+import {
+  mkdir as fsMkdir,
+  readFile as fsReadFile,
+  writeFile as fsWriteFile,
+} from "node:fs/promises";
+import { dirname } from "node:path";
+import { pathToFileURL } from "node:url";
+import { CRAWL_DEFAULTS, crawlSitemap } from "./indexability/crawl-sitemap.mjs";
+
+/**
+ * URLs that are knowingly not yet "200 + indexable + self-canonical + meaningful
+ * without JavaScript". Every entry needs a written justification: this list is
+ * the record of what is queued for a fix or for removal, not a mute button.
+ */
+export const DEFAULT_KNOWN_ISSUES = Object.freeze([
+  {
+    pathnameEndsWith: "/funding-opportunities",
+    classifications: ["thin"],
+    // The floor is what keeps this from muting a whole route class. The entry
+    // only excuses the gap between the server-rendered community header and the
+    // 200-char threshold; if a page drops below the header's own worth of prose,
+    // the header has regressed too and that is a failure this entry does not
+    // cover. Calibrate against the post-deploy crawl report, never upward to
+    // make a red run go green.
+    minTextLength: 120,
+    reason:
+      "Client-rendered program directory. It is self-canonical with unique metadata (DEV-586) and the community header gives it a heading and prose, but the program cards themselves only exist after hydration, so a stricter content threshold can classify it thin. Queued for SSR seeding as a follow-up; only that failure mode, and only while the header still renders, is excused.",
+  },
+]);
+
+const DEFAULTS = Object.freeze({
+  rootSitemapUrl: CRAWL_DEFAULTS.rootSitemapUrl,
+  samplePerChild: String(CRAWL_DEFAULTS.samplePerChild),
+  fullCrawlThreshold: String(CRAWL_DEFAULTS.fullCrawlThreshold),
+  concurrency: String(CRAWL_DEFAULTS.concurrency),
+  delayMs: String(CRAWL_DEFAULTS.delayMs),
+  timeoutMs: String(CRAWL_DEFAULTS.timeoutMs),
+  minContentChars: String(CRAWL_DEFAULTS.minContentChars),
+});
+
+const FLAG_TO_KEY = Object.freeze({
+  "--root-sitemap-url": "rootSitemapUrl",
+  "--canonical-origin": "canonicalOrigin",
+  "--sample-per-child": "samplePerChild",
+  "--full-crawl-threshold": "fullCrawlThreshold",
+  "--concurrency": "concurrency",
+  "--delay-ms": "delayMs",
+  "--timeout-ms": "timeoutMs",
+  "--min-content-chars": "minContentChars",
+  "--known-issues": "knownIssues",
+  "--output": "output",
+});
+
+const ENV_NAMES = Object.freeze({
+  rootSitemapUrl: "CRAWL_ROOT_SITEMAP_URL",
+  canonicalOrigin: "CRAWL_CANONICAL_ORIGIN",
+  samplePerChild: "CRAWL_SAMPLE_PER_CHILD",
+  fullCrawlThreshold: "CRAWL_FULL_CRAWL_THRESHOLD",
+  concurrency: "CRAWL_CONCURRENCY",
+  delayMs: "CRAWL_DELAY_MS",
+  timeoutMs: "CRAWL_TIMEOUT_MS",
+  minContentChars: "CRAWL_MIN_CONTENT_CHARS",
+  knownIssues: "CRAWL_KNOWN_ISSUES",
+  output: "CRAWL_OUTPUT",
+});
+
+/**
+ * Parse argv into a flags object. Throws on unknown flags and missing values.
+ * Accepts both `--flag value` and `--flag=value` forms.
+ */
+export function parseArgs(argv) {
+  const flags = {};
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index];
+    let name = token;
+    let value;
+
+    const eq = token.startsWith("--") ? token.indexOf("=") : -1;
+    if (eq !== -1) {
+      name = token.slice(0, eq);
+      value = token.slice(eq + 1);
+    }
+
+    if (!Object.hasOwn(FLAG_TO_KEY, name)) {
+      throw new Error(`Unknown argument: ${token}`);
+    }
+
+    if (value === undefined) {
+      const next = argv[index + 1];
+      if (next === undefined || next.startsWith("--")) {
+        throw new Error(`Missing value for ${name}`);
+      }
+      value = next;
+      index += 1;
+    }
+
+    if (value === "") {
+      throw new Error(`Missing value for ${name}`);
+    }
+
+    flags[FLAG_TO_KEY[name]] = value;
+  }
+  return flags;
+}
+
+export function resolveConfig(flags, env) {
+  const pick = (key, fallback) => {
+    if (flags[key] !== undefined) {
+      return flags[key];
+    }
+    const envValue = env[ENV_NAMES[key]];
+    if (envValue !== undefined && envValue !== "") {
+      return envValue;
+    }
+    return fallback;
+  };
+
+  return {
+    rootSitemapUrl: pick("rootSitemapUrl", DEFAULTS.rootSitemapUrl),
+    canonicalOrigin: pick("canonicalOrigin", undefined),
+    samplePerChild: parseBoundedInt(
+      pick("samplePerChild", DEFAULTS.samplePerChild),
+      "--sample-per-child",
+      1
+    ),
+    fullCrawlThreshold: parseBoundedInt(
+      pick("fullCrawlThreshold", DEFAULTS.fullCrawlThreshold),
+      "--full-crawl-threshold",
+      0
+    ),
+    concurrency: parseBoundedInt(pick("concurrency", DEFAULTS.concurrency), "--concurrency", 1),
+    delayMs: parseBoundedInt(pick("delayMs", DEFAULTS.delayMs), "--delay-ms", 0),
+    timeoutMs: parseBoundedInt(pick("timeoutMs", DEFAULTS.timeoutMs), "--timeout-ms", 1),
+    minContentChars: parseBoundedInt(
+      pick("minContentChars", DEFAULTS.minContentChars),
+      "--min-content-chars",
+      0
+    ),
+    knownIssues: pick("knownIssues", undefined),
+    output: pick("output", undefined),
+  };
+}
+
+/**
+ * Run the CLI. Injectable (fetch/crawl/stdout/stderr/writeFile/mkdir/readFile)
+ * for tests. Returns 0 on a passing report, 1 otherwise — never calls
+ * process.exit.
+ */
+export async function main({
+  argv = [],
+  env = {},
+  fetch = globalThis.fetch,
+  crawl = crawlSitemap,
+  stdout = process.stdout,
+  stderr = process.stderr,
+  writeFile = fsWriteFile,
+  mkdir = fsMkdir,
+  readFile = fsReadFile,
+} = {}) {
+  let config;
+  let knownIssues;
+  try {
+    config = resolveConfig(parseArgs(argv), env);
+    knownIssues = config.knownIssues
+      ? parseKnownIssuesFile(await readFile(config.knownIssues, "utf8"), config.knownIssues)
+      : DEFAULT_KNOWN_ISSUES;
+  } catch (err) {
+    writeLine(stderr, `Error: ${errMsg(err)}`);
+    return 1;
+  }
+
+  let report;
+  try {
+    report = await crawl({
+      fetch,
+      rootSitemapUrl: config.rootSitemapUrl,
+      canonicalOrigin: config.canonicalOrigin,
+      samplePerChild: config.samplePerChild,
+      fullCrawlThreshold: config.fullCrawlThreshold,
+      concurrency: config.concurrency,
+      delayMs: config.delayMs,
+      timeoutMs: config.timeoutMs,
+      minContentChars: config.minContentChars,
+      knownIssues,
+    });
+  } catch (err) {
+    writeLine(stderr, `Crawl failed to run: ${errMsg(err)}`);
+    return 1;
+  }
+
+  printSummary(report, stdout);
+
+  if (config.output) {
+    try {
+      await writeReport(config.output, report, { writeFile, mkdir });
+      writeLine(stdout, `Report written to ${config.output}`);
+    } catch (err) {
+      writeLine(stderr, `Failed to write report to ${config.output}: ${errMsg(err)}`);
+      return 1;
+    }
+  }
+
+  return report.ok ? 0 : 1;
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+// Accept only a plain digits string that parses to a safe integer >= min.
+function parseBoundedInt(value, label, min) {
+  const text = String(value).trim();
+  if (!/^\d+$/.test(text)) {
+    throw new Error(`Invalid numeric value for ${label}: "${value}"`);
+  }
+  const parsed = Number(text);
+  if (!Number.isSafeInteger(parsed) || parsed < min) {
+    throw new Error(`Invalid numeric value for ${label}: "${value}"`);
+  }
+  return parsed;
+}
+
+function parseKnownIssuesFile(contents, path) {
+  let parsed;
+  try {
+    parsed = JSON.parse(contents);
+  } catch (err) {
+    throw new Error(`Invalid JSON in known-issues file ${path}: ${errMsg(err)}`);
+  }
+  if (!Array.isArray(parsed)) {
+    throw new Error(`Known-issues file ${path} must contain a JSON array`);
+  }
+  return parsed;
+}
+
+async function writeReport(outputPath, report, { writeFile = fsWriteFile, mkdir = fsMkdir } = {}) {
+  const dir = dirname(outputPath);
+  if (dir && dir !== "." && dir !== "/") {
+    await mkdir(dir, { recursive: true });
+  }
+  await writeFile(outputPath, `${JSON.stringify(report, null, 2)}\n`);
+}
+
+function printSummary(report, out) {
+  writeLine(out, `Sitemap crawl @ ${report.timestamp}`);
+  writeLine(out, `Root: ${report.root}`);
+  for (const child of report.children) {
+    writeLine(
+      out,
+      `  ${child.url} — ${child.total} urls, ${child.sampled} sampled (${child.mode})`
+    );
+  }
+  const { summary } = report;
+  writeLine(out, `Crawled ${summary.crawled} urls; ${summary.ok} fully indexable`);
+  for (const [name, count] of Object.entries(summary.byClassification)) {
+    if (count > 0) {
+      writeLine(out, `  ${name}: ${count}`);
+    }
+  }
+  if (summary.allowlisted.length > 0) {
+    writeLine(out, `Known issues (${summary.allowlisted.length}) — not counted as failures:`);
+    for (const entry of summary.allowlisted) {
+      writeLine(out, `  - ${entry.url} [${entry.classification}] ${entry.reason}`);
+    }
+  }
+  if (summary.failing.length > 0) {
+    writeLine(out, `Failures (${summary.failing.length}):`);
+    for (const entry of summary.failing) {
+      writeLine(
+        out,
+        `  - ${entry.url} [${entry.classification}] status=${entry.status} canonical=${entry.canonical ?? "none"} text=${entry.textLength}`
+      );
+    }
+  }
+  if (report.errors.length > 0) {
+    writeLine(out, `Errors (${report.errors.length}):`);
+    for (const error of report.errors) {
+      writeLine(out, `  - ${error}`);
+    }
+  }
+  writeLine(out, `Overall: ${report.ok ? "PASS" : "FAIL"}`);
+}
+
+function writeLine(stream, line) {
+  stream.write(`${line}\n`);
+}
+
+function errMsg(err) {
+  return err?.message ? err.message : String(err);
+}
+
+function isDirectRun() {
+  return Boolean(process.argv[1]) && import.meta.url === pathToFileURL(process.argv[1]).href;
+}
+
+if (isDirectRun()) {
+  main({ argv: process.argv.slice(2), env: process.env })
+    .then((code) => {
+      process.exitCode = code;
+    })
+    .catch((err) => {
+      process.exitCode = 1;
+      process.stderr.write(`Unexpected error: ${errMsg(err)}\n`);
+    });
+}

--- a/scripts/indexability/__tests__/crawl-sitemap-robustness.test.mjs
+++ b/scripts/indexability/__tests__/crawl-sitemap-robustness.test.mjs
@@ -1,0 +1,355 @@
+/**
+ * Hostile-input coverage for the sitemap crawler (DEV-586 review follow-up).
+ *
+ * The happy path and the classification matrix live in crawl-sitemap.test.mjs.
+ * This file covers the ways a real sitemap tree misbehaves — nested indexes,
+ * cycles, gzip, oversized documents, `none` robots directives, query-bearing
+ * canonicals — plus the floor that stops a known-issue entry from silently
+ * growing into an excuse for a worse failure than the one it documents.
+ */
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { DEFAULT_KNOWN_ISSUES } from "../../crawl-sitemap.mjs";
+import {
+  CLASSIFICATIONS,
+  crawlSitemap,
+  hasNoindex,
+  isSelfCanonical,
+  matchKnownIssue,
+  normalizeKnownIssues,
+} from "../crawl-sitemap.mjs";
+
+const CANONICAL = "https://www.karmahq.xyz";
+const ROOT = `${CANONICAL}/sitemap.xml`;
+const NS = 'xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"';
+
+const sitemapIndex = (locs) =>
+  `<?xml version="1.0" encoding="UTF-8"?><sitemapindex ${NS}>${locs
+    .map((loc) => `<sitemap><loc>${loc}</loc></sitemap>`)
+    .join("")}</sitemapindex>`;
+
+const urlSet = (locs) =>
+  `<?xml version="1.0" encoding="UTF-8"?><urlset ${NS}>${locs
+    .map((loc) => `<url><loc>${loc}</loc></url>`)
+    .join("")}</urlset>`;
+
+const PARAGRAPH =
+  "Karma tracks grant milestones, disbursements and impact for funded projects across every ecosystem it supports, so funders can see what actually shipped. ".repeat(
+    3
+  );
+
+function page({ url, canonical = url, robotsMeta = "", body = PARAGRAPH } = {}) {
+  return (
+    `<!doctype html><html><head><title>A page title</title>` +
+    (robotsMeta ? `<meta name="robots" content="${robotsMeta}">` : "") +
+    (canonical ? `<link rel="canonical" href="${canonical}"/>` : "") +
+    `</head><body><h1>A page heading</h1><p>${body}</p></body></html>`
+  );
+}
+
+const xml = (body, { status = 200, contentType = "application/xml", headers = {} } = {}) =>
+  new Response(body, { status, headers: { "content-type": contentType, ...headers } });
+
+const html = (body) =>
+  new Response(body, { status: 200, headers: { "content-type": "text/html; charset=utf-8" } });
+
+function makeFetch(routes) {
+  const calls = [];
+  const fetchImpl = async (url) => {
+    const key = String(url);
+    calls.push(key);
+    const entry = routes[key];
+    if (entry === undefined) {
+      return new Response("missing", { status: 404, headers: { "content-type": "text/html" } });
+    }
+    return typeof entry === "function" ? entry() : entry;
+  };
+  fetchImpl.calls = calls;
+  return fetchImpl;
+}
+
+const noSleep = async () => {};
+
+const crawl = (fetchImpl, overrides = {}) =>
+  crawlSitemap({
+    fetch: fetchImpl,
+    rootSitemapUrl: ROOT,
+    concurrency: 1,
+    delayMs: 0,
+    sleep: noSleep,
+    now: "2026-01-01T00:00:00.000Z",
+    ...overrides,
+  });
+
+// ---------------------------------------------------------------------------
+// Nested sitemap indexes
+// ---------------------------------------------------------------------------
+
+describe("nested sitemap indexes", () => {
+  it("recurses through an index of indexes instead of treating it as a urlset", async () => {
+    const nested = `${CANONICAL}/sitemaps/nested.xml`;
+    const leaf = `${CANONICAL}/sitemaps/entities.xml`;
+    const target = `${CANONICAL}/projects/karma`;
+    const report = await crawl(
+      makeFetch({
+        [ROOT]: () => xml(sitemapIndex([nested])),
+        [nested]: () => xml(sitemapIndex([leaf])),
+        [leaf]: () => xml(urlSet([target])),
+        [target]: () => html(page({ url: target })),
+      })
+    );
+
+    // The entity URL is inspected — not the nested index mistaken for a page.
+    assert.deepEqual(
+      report.children.map((child) => child.url),
+      [leaf]
+    );
+    assert.deepEqual(
+      report.results.map((record) => record.url),
+      [target]
+    );
+    assert.equal(report.results[0].classification, CLASSIFICATIONS.OK);
+    assert.deepEqual(report.errors, []);
+    assert.equal(report.ok, true);
+  });
+
+  it("terminates on a self-referential index rather than looping forever", async () => {
+    const leaf = `${CANONICAL}/sitemaps/entities.xml`;
+    const target = `${CANONICAL}/projects/karma`;
+    const fetchImpl = makeFetch({
+      [ROOT]: () => xml(sitemapIndex([ROOT, leaf])),
+      [leaf]: () => xml(urlSet([target])),
+      [target]: () => html(page({ url: target })),
+    });
+
+    const report = await crawl(fetchImpl);
+
+    assert.equal(fetchImpl.calls.filter((call) => call === ROOT).length, 1);
+    assert.equal(report.ok, true);
+  });
+
+  it("stops and reports once index nesting passes the depth ceiling", async () => {
+    const one = `${CANONICAL}/sitemaps/one.xml`;
+    const two = `${CANONICAL}/sitemaps/two.xml`;
+    const report = await crawl(
+      makeFetch({
+        [ROOT]: () => xml(sitemapIndex([one])),
+        [one]: () => xml(sitemapIndex([two])),
+        [two]: () => xml(urlSet([`${CANONICAL}/projects/karma`])),
+      }),
+      { maxSitemapDepth: 1 }
+    );
+
+    assert.equal(report.results.length, 0);
+    assert.ok(report.errors.some((error) => error.includes("nesting exceeded depth 1")));
+    assert.equal(report.ok, false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Malformed / oversized sitemap documents
+// ---------------------------------------------------------------------------
+
+describe("sitemap document defences", () => {
+  it("names gzip explicitly instead of reporting a generic non-XML content type", async () => {
+    const report = await crawl(
+      makeFetch({
+        [ROOT]: () => xml(sitemapIndex([]), { contentType: "application/x-gzip" }),
+      })
+    );
+
+    assert.ok(report.errors.some((error) => error.includes("gzipped")));
+    assert.equal(report.ok, false);
+  });
+
+  it("refuses an oversized sitemap on content-length without reading the body", async () => {
+    let bodyReads = 0;
+    const fetchImpl = async () => ({
+      status: 200,
+      headers: {
+        get: (name) =>
+          name === "content-length"
+            ? "999999999"
+            : name === "content-type"
+              ? "application/xml"
+              : null,
+      },
+      text: async () => {
+        bodyReads += 1;
+        return urlSet([]);
+      },
+    });
+
+    const report = await crawl(fetchImpl, { maxSitemapBytes: 1024 });
+
+    assert.equal(bodyReads, 0);
+    assert.ok(report.errors.some((error) => error.includes("above the 1024 cap")));
+    assert.equal(report.ok, false);
+  });
+
+  it("refuses a body that overruns the cap even with no content-length header", async () => {
+    const report = await crawl(
+      makeFetch({ [ROOT]: () => xml(urlSet([`${CANONICAL}/projects/karma`])) }),
+      { maxSitemapBytes: 10 }
+    );
+
+    assert.ok(report.errors.some((error) => error.includes("above the 10 cap")));
+    assert.equal(report.ok, false);
+  });
+
+  it("truncates and reports a urlset that lists more URLs than the protocol allows", async () => {
+    const locs = Array.from({ length: 5 }, (_, index) => `${CANONICAL}/projects/p${index}`);
+    const report = await crawl(
+      makeFetch({
+        [ROOT]: () => xml(urlSet(locs)),
+        ...Object.fromEntries(locs.map((loc) => [loc, () => html(page({ url: loc }))])),
+      }),
+      { maxUrlsPerSitemap: 2 }
+    );
+
+    assert.equal(report.children[0].total, 2);
+    assert.ok(report.errors.some((error) => error.includes("more than 2 <loc> entries")));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Robots + canonical comparison
+// ---------------------------------------------------------------------------
+
+describe("robots directives", () => {
+  it("treats `none` as noindex — it is the shorthand for noindex, nofollow", () => {
+    assert.equal(hasNoindex("none"), true);
+    assert.equal(hasNoindex("None"), true);
+    assert.equal(hasNoindex("max-snippet:-1, none"), true);
+    assert.equal(hasNoindex("index, follow"), false);
+    assert.equal(hasNoindex("noneofyourbusiness"), false);
+  });
+
+  it('fails a sitemap URL that ships `<meta name="robots" content="none">`', async () => {
+    const target = `${CANONICAL}/projects/karma`;
+    const report = await crawl(
+      makeFetch({
+        [ROOT]: () => xml(urlSet([target])),
+        [target]: () => html(page({ url: target, robotsMeta: "none" })),
+      })
+    );
+
+    assert.equal(report.results[0].classification, CLASSIFICATIONS.NOINDEX);
+    assert.equal(report.ok, false);
+  });
+});
+
+describe("canonical comparison", () => {
+  it("does not call a query URL self-canonical because the paths match", () => {
+    assert.equal(isSelfCanonical(`${CANONICAL}/search`, `${CANONICAL}/search?page=2`), false);
+    assert.equal(isSelfCanonical(`${CANONICAL}/search?page=2`, `${CANONICAL}/search?page=2`), true);
+    assert.equal(
+      isSelfCanonical(`${CANONICAL}/search?page=3`, `${CANONICAL}/search?page=2`),
+      false
+    );
+  });
+
+  it("still tolerates a trailing slash on the path", () => {
+    assert.equal(
+      isSelfCanonical(`${CANONICAL}/search/?page=2`, `${CANONICAL}/search?page=2`),
+      true
+    );
+  });
+
+  it("flags a query-bearing sitemap URL that consolidates onto its bare path", async () => {
+    const target = `${CANONICAL}/search?page=2`;
+    const report = await crawl(
+      makeFetch({
+        [ROOT]: () => xml(urlSet([target])),
+        [target]: () => html(page({ url: target, canonical: `${CANONICAL}/search` })),
+      })
+    );
+
+    assert.equal(report.results[0].classification, CLASSIFICATIONS.NON_SELF_CANONICAL);
+    assert.equal(report.ok, false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Known-issue floor
+// ---------------------------------------------------------------------------
+
+describe("known-issue content floor", () => {
+  it("rejects a floor that is not a non-negative integer", () => {
+    const base = { pathnameEndsWith: "/x", reason: "documented" };
+
+    assert.throws(() => normalizeKnownIssues([{ ...base, minTextLength: -1 }]), /must be >= 0/);
+    assert.throws(
+      () => normalizeKnownIssues([{ ...base, minTextLength: 1.5 }]),
+      /must be an integer/
+    );
+    assert.equal(normalizeKnownIssues([{ ...base, minTextLength: 0 }])[0].minTextLength, 0);
+    assert.equal(normalizeKnownIssues([base])[0].minTextLength, null);
+  });
+
+  it("only excuses a page that still clears the floor", () => {
+    const allowlist = normalizeKnownIssues([
+      {
+        pathnameEndsWith: "/funding-opportunities",
+        classifications: ["thin"],
+        minTextLength: 120,
+        reason: "Header prose renders; the program cards need hydration.",
+      },
+    ]);
+    const url = `${CANONICAL}/community/celo/funding-opportunities`;
+
+    assert.ok(matchKnownIssue(allowlist, url, CLASSIFICATIONS.THIN, { textLength: 150 }));
+    assert.equal(matchKnownIssue(allowlist, url, CLASSIFICATIONS.THIN, { textLength: 119 }), null);
+  });
+
+  it("fails an emptied funding-opportunities page instead of allowlisting it", async () => {
+    const target = `${CANONICAL}/community/celo/funding-opportunities`;
+    const emptied =
+      `<!doctype html><html><head><title>Funding</title>` +
+      `<link rel="canonical" href="${target}"/></head><body><h1>Funding</h1></body></html>`;
+    const report = await crawl(
+      makeFetch({
+        [ROOT]: () => xml(urlSet([target])),
+        [target]: () => html(emptied),
+      }),
+      { knownIssues: DEFAULT_KNOWN_ISSUES }
+    );
+
+    assert.equal(report.results[0].classification, CLASSIFICATIONS.THIN);
+    assert.equal(report.results[0].allowlisted, false);
+    assert.equal(report.summary.allowlisted.length, 0);
+    assert.equal(report.summary.failing.length, 1);
+    assert.equal(report.ok, false);
+  });
+
+  it("still excuses the documented near-threshold case", async () => {
+    const target = `${CANONICAL}/community/celo/funding-opportunities`;
+    const header =
+      "Celo Community Grants funds public goods across the Celo ecosystem, and this directory lists every open program.";
+    const report = await crawl(
+      makeFetch({
+        [ROOT]: () => xml(urlSet([target])),
+        [target]: () => html(page({ url: target, body: header })),
+      }),
+      { knownIssues: DEFAULT_KNOWN_ISSUES }
+    );
+
+    assert.equal(report.results[0].classification, CLASSIFICATIONS.THIN);
+    assert.equal(report.results[0].allowlisted, true);
+    assert.equal(report.summary.failing.length, 0);
+    assert.equal(report.ok, true);
+  });
+
+  it("ships a floor on every default thin excuse", () => {
+    const allowlist = normalizeKnownIssues(DEFAULT_KNOWN_ISSUES);
+
+    for (const entry of allowlist) {
+      if (entry.classifications?.includes(CLASSIFICATIONS.THIN)) {
+        assert.ok(
+          typeof entry.minTextLength === "number" && entry.minTextLength > 0,
+          `${entry.pathnameEndsWith ?? entry.url} excuses "thin" with no content floor`
+        );
+      }
+    }
+  });
+});

--- a/scripts/indexability/__tests__/crawl-sitemap.test.mjs
+++ b/scripts/indexability/__tests__/crawl-sitemap.test.mjs
@@ -1,0 +1,858 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { DEFAULT_KNOWN_ISSUES, main, parseArgs, resolveConfig } from "../../crawl-sitemap.mjs";
+import {
+  CLASSIFICATIONS,
+  classify,
+  crawlSitemap,
+  extractCanonical,
+  extractFirstTagText,
+  extractMetaRobots,
+  hasNoindex,
+  inspectUrl,
+  isSelfCanonical,
+  mapWithConcurrency,
+  matchKnownIssue,
+  normalizeKnownIssues,
+  selectSample,
+  visibleTextLength,
+} from "../crawl-sitemap.mjs";
+
+// ---------------------------------------------------------------------------
+// Dependency-free fixtures (no real network).
+// ---------------------------------------------------------------------------
+
+const CANONICAL = "https://www.karmahq.xyz";
+const ROOT = `${CANONICAL}/sitemap.xml`;
+const NS = 'xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"';
+
+function xml(body, { status = 200, contentType = "application/xml" } = {}) {
+  return new Response(body, { status, headers: { "content-type": contentType } });
+}
+
+function html(body, { status = 200, headers = {} } = {}) {
+  return new Response(body, {
+    status,
+    headers: { "content-type": "text/html; charset=utf-8", ...headers },
+  });
+}
+
+const sitemapIndex = (locs) =>
+  `<?xml version="1.0" encoding="UTF-8"?><sitemapindex ${NS}>${locs
+    .map((loc) => `<sitemap><loc>${loc}</loc></sitemap>`)
+    .join("")}</sitemapindex>`;
+
+const urlSet = (locs) =>
+  `<?xml version="1.0" encoding="UTF-8"?><urlset ${NS}>${locs
+    .map((loc) => `<url><loc>${loc}</loc></url>`)
+    .join("")}</urlset>`;
+
+const PARAGRAPH =
+  "Karma tracks grant milestones, disbursements and impact for funded projects across every ecosystem it supports, so funders can see what actually shipped. ".repeat(
+    3
+  );
+
+function page({
+  url,
+  canonical = url,
+  title = "A page title",
+  h1 = "A page heading",
+  body = PARAGRAPH,
+} = {}) {
+  return (
+    `<!doctype html><html><head><title>${title}</title>` +
+    (canonical ? `<link rel="canonical" href="${canonical}"/>` : "") +
+    `</head><body><h1>${h1}</h1><p>${body}</p></body></html>`
+  );
+}
+
+// A JS-only shell: everything meaningful lives inside a script payload.
+const SHELL_HTML =
+  `<!doctype html><html><head><title>Loading</title>` +
+  `<link rel="canonical" href="${CANONICAL}/shell"/></head>` +
+  `<body><div id="root"></div><script>window.__DATA__=${JSON.stringify({ text: PARAGRAPH })}</script></body></html>`;
+
+function makeFetch(routes) {
+  const calls = [];
+  const fetchImpl = async (url, options) => {
+    const key = String(url);
+    calls.push({ url: key, options });
+    const entry = routes[key];
+    if (entry === undefined) {
+      return new Response("missing", { status: 404, headers: { "content-type": "text/html" } });
+    }
+    return typeof entry === "function" ? entry(options) : entry;
+  };
+  fetchImpl.calls = calls;
+  return fetchImpl;
+}
+
+const noSleep = async () => {};
+
+// ---------------------------------------------------------------------------
+// HTML extraction
+// ---------------------------------------------------------------------------
+
+describe("HTML extraction", () => {
+  it("reads canonical, title, h1 and meta robots independent of attribute order", () => {
+    const doc =
+      `<html><head><title>Celo Funded Projects | Karma</title>` +
+      `<meta content="noindex, follow" name="robots">` +
+      `<link href="${CANONICAL}/community/celo/projects" rel="alternate canonical"></head>` +
+      `<body><h1>Celo <span>Funded</span> Projects</h1></body></html>`;
+
+    assert.equal(extractCanonical(doc), `${CANONICAL}/community/celo/projects`);
+    assert.equal(extractFirstTagText(doc, "title"), "Celo Funded Projects | Karma");
+    assert.equal(extractFirstTagText(doc, "h1"), "Celo Funded Projects");
+    assert.equal(extractMetaRobots(doc), "noindex, follow");
+  });
+
+  it("returns null for absent tags rather than throwing", () => {
+    assert.equal(extractCanonical("<html><head></head></html>"), null);
+    assert.equal(extractFirstTagText("<html></html>", "h1"), null);
+    assert.equal(extractMetaRobots("<html></html>", "robots"), null);
+    assert.equal(extractCanonical(""), null);
+  });
+
+  it("treats robots directives as a token list", () => {
+    assert.equal(hasNoindex("noindex, nofollow"), true);
+    assert.equal(hasNoindex("max-image-preview:large"), false);
+    assert.equal(hasNoindex("index, follow"), false);
+    assert.equal(hasNoindex(null), false);
+  });
+
+  it("excludes script, style, noscript and JSON-LD from the visible text length", () => {
+    const withPayload =
+      `<html><body><p>Visible words here.</p>` +
+      `<script type="application/ld+json">${JSON.stringify({ description: PARAGRAPH })}</script>` +
+      `<style>.a{color:red}</style><noscript>Enable JavaScript</noscript></body></html>`;
+
+    assert.equal(visibleTextLength(withPayload), "Visible words here.".length);
+    assert.ok(visibleTextLength(`<html><body><p>${PARAGRAPH}</p></body></html>`) > 200);
+    assert.equal(visibleTextLength(""), 0);
+  });
+
+  it("decodes entities in extracted text", () => {
+    assert.equal(
+      extractFirstTagText(
+        "<html><head><title>Impact &amp; Outcomes</title></head></html>",
+        "title"
+      ),
+      "Impact & Outcomes"
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Sampling
+// ---------------------------------------------------------------------------
+
+describe("selectSample", () => {
+  const urls = Array.from({ length: 1000 }, (_, index) => `${CANONICAL}/project/p${index}`);
+
+  it("crawls small children in full", () => {
+    const small = urls.slice(0, 77);
+    assert.deepEqual(selectSample(small, { fullCrawlThreshold: 200, samplePerChild: 40 }), small);
+  });
+
+  it("samples large children down to the requested size", () => {
+    const sample = selectSample(urls, { fullCrawlThreshold: 200, samplePerChild: 40 });
+    assert.equal(sample.length, 40);
+    assert.equal(new Set(sample).size, 40);
+    for (const url of sample) {
+      assert.ok(urls.includes(url));
+    }
+  });
+
+  it("is deterministic and evenly strided across the list", () => {
+    const first = selectSample(urls, { fullCrawlThreshold: 200, samplePerChild: 40 });
+    const second = selectSample(urls, { fullCrawlThreshold: 200, samplePerChild: 40 });
+    assert.deepEqual(first, second);
+    assert.equal(first[0], urls[0]);
+    assert.equal(first[1], urls[25]);
+    // Coverage reaches the tail of the list, not just the head.
+    assert.equal(first.at(-1), urls[975]);
+  });
+
+  it("never asks for more URLs than the child has", () => {
+    const sample = selectSample(urls.slice(0, 5), { fullCrawlThreshold: 2, samplePerChild: 40 });
+    assert.equal(sample.length, 5);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Classification
+// ---------------------------------------------------------------------------
+
+describe("classify", () => {
+  const base = {
+    url: `${CANONICAL}/community/celo/projects`,
+    status: 200,
+    error: null,
+    xRobotsTag: null,
+    metaRobots: null,
+    canonical: `${CANONICAL}/community/celo/projects`,
+    meaningful: true,
+  };
+
+  it("accepts a 200, indexable, self-canonical, meaningful page", () => {
+    assert.equal(classify(base), CLASSIFICATIONS.OK);
+  });
+
+  it("flags redirects separately from other non-200 responses", () => {
+    assert.equal(classify({ ...base, status: 308 }), CLASSIFICATIONS.REDIRECTED);
+    assert.equal(classify({ ...base, status: 404 }), CLASSIFICATIONS.NON_200);
+    assert.equal(classify({ ...base, status: 500 }), CLASSIFICATIONS.NON_200);
+  });
+
+  it("flags noindex from the header AND from the meta tag", () => {
+    assert.equal(classify({ ...base, xRobotsTag: "noindex" }), CLASSIFICATIONS.NOINDEX);
+    assert.equal(classify({ ...base, metaRobots: "noindex, follow" }), CLASSIFICATIONS.NOINDEX);
+  });
+
+  it("flags a canonical pointing anywhere but the URL itself", () => {
+    assert.equal(
+      classify({ ...base, canonical: `${CANONICAL}/community/celo` }),
+      CLASSIFICATIONS.NON_SELF_CANONICAL
+    );
+    assert.equal(classify({ ...base, canonical: null }), CLASSIFICATIONS.NON_SELF_CANONICAL);
+  });
+
+  it("flags a page with no meaningful no-JS content", () => {
+    assert.equal(classify({ ...base, meaningful: false }), CLASSIFICATIONS.THIN);
+  });
+
+  it("flags a transport failure ahead of everything else", () => {
+    assert.equal(
+      classify({ ...base, status: null, error: "The operation was aborted" }),
+      CLASSIFICATIONS.FETCH_ERROR
+    );
+  });
+
+  it("tolerates a trailing slash when comparing canonicals", () => {
+    assert.equal(isSelfCanonical(`${CANONICAL}/projects/`, `${CANONICAL}/projects`), true);
+    assert.equal(isSelfCanonical("/projects", `${CANONICAL}/projects`), true);
+    assert.equal(isSelfCanonical(`${CANONICAL}/other`, `${CANONICAL}/projects`), false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// inspectUrl
+// ---------------------------------------------------------------------------
+
+describe("inspectUrl", () => {
+  const request = (routes) => {
+    const fetchImpl = makeFetch(routes);
+    return async (url, consume) => {
+      const response = await fetchImpl(url, {});
+      return consume(response);
+    };
+  };
+
+  it("extracts every crawler-visible signal from an article page", async () => {
+    const url = `${CANONICAL}/knowledge/grant-accountability`;
+    const record = await inspectUrl(
+      request({
+        [url]: () => html(page({ url, title: "Grant Accountability", h1: "Grant Accountability" })),
+      }),
+      url
+    );
+
+    assert.equal(record.status, 200);
+    assert.equal(record.canonical, url);
+    assert.equal(record.title, "Grant Accountability");
+    assert.equal(record.h1, "Grant Accountability");
+    assert.ok(record.textLength > 200);
+    assert.equal(record.meaningful, true);
+    assert.equal(record.error, null);
+  });
+
+  it("classifies a hydration-only shell as not meaningful", async () => {
+    const url = `${CANONICAL}/shell`;
+    const record = await inspectUrl(request({ [url]: () => html(SHELL_HTML) }), url);
+
+    assert.equal(record.status, 200);
+    assert.equal(record.meaningful, false);
+    assert.ok(record.textLength < 200);
+    assert.equal(classify(record), CLASSIFICATIONS.THIN);
+  });
+
+  it("records the x-robots-tag header and the Location of a redirect", async () => {
+    const url = `${CANONICAL}/community/celo/projects?page=2`;
+    const record = await inspectUrl(
+      request({
+        [url]: () =>
+          new Response("", {
+            status: 308,
+            headers: {
+              location: `${CANONICAL}/community/celo/projects`,
+              "x-robots-tag": "noindex",
+            },
+          }),
+      }),
+      url
+    );
+
+    assert.equal(record.status, 308);
+    assert.equal(record.xRobotsTag, "noindex");
+    assert.equal(record.location, `${CANONICAL}/community/celo/projects`);
+    assert.equal(classify(record), CLASSIFICATIONS.REDIRECTED);
+  });
+
+  it("turns a transport failure into a fetch-error record instead of throwing", async () => {
+    const url = `${CANONICAL}/timeout`;
+    const record = await inspectUrl(async () => {
+      throw new Error("The operation was aborted");
+    }, url);
+
+    assert.equal(record.status, null);
+    assert.equal(record.error, "The operation was aborted");
+    assert.equal(classify(record), CLASSIFICATIONS.FETCH_ERROR);
+  });
+
+  it("respects a custom meaningful-content threshold", async () => {
+    const url = `${CANONICAL}/short`;
+    const shortPage = `<html><head><link rel="canonical" href="${url}"/></head><body><h1>Hi</h1><p>Short.</p></body></html>`;
+    const strict = await inspectUrl(request({ [url]: () => html(shortPage) }), url, {
+      minContentChars: 200,
+    });
+    const lenient = await inspectUrl(request({ [url]: () => html(shortPage) }), url, {
+      minContentChars: 5,
+    });
+
+    assert.equal(strict.meaningful, false);
+    assert.equal(lenient.meaningful, true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Concurrency + politeness
+// ---------------------------------------------------------------------------
+
+describe("mapWithConcurrency", () => {
+  it("never exceeds the in-flight limit and preserves input order", async () => {
+    let inFlight = 0;
+    let peak = 0;
+    const items = Array.from({ length: 20 }, (_, index) => index);
+
+    const results = await mapWithConcurrency(
+      items,
+      3,
+      async (item) => {
+        inFlight += 1;
+        peak = Math.max(peak, inFlight);
+        await new Promise((resolve) => setTimeout(resolve, 1));
+        inFlight -= 1;
+        return item * 2;
+      },
+      { sleep: noSleep, delayMs: 0 }
+    );
+
+    assert.equal(peak, 3);
+    assert.deepEqual(
+      results,
+      items.map((item) => item * 2)
+    );
+  });
+
+  it("applies the inter-request delay between requests", async () => {
+    const slept = [];
+    const sleep = async (ms) => {
+      slept.push(ms);
+    };
+
+    await mapWithConcurrency(["a", "b", "c", "d"], 2, async (item) => item, {
+      sleep,
+      delayMs: 250,
+    });
+
+    // 4 items, 2 workers: each worker's first request is immediate, the rest wait.
+    assert.equal(slept.length, 2);
+    assert.deepEqual(new Set(slept), new Set([250]));
+  });
+
+  it("does not sleep when the delay is zero", async () => {
+    let calls = 0;
+    await mapWithConcurrency([1, 2, 3], 1, async (item) => item, {
+      sleep: async () => {
+        calls += 1;
+      },
+      delayMs: 0,
+    });
+    assert.equal(calls, 0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Known issues allowlist
+// ---------------------------------------------------------------------------
+
+describe("normalizeKnownIssues", () => {
+  it("requires a written justification for every entry", () => {
+    assert.throws(() => normalizeKnownIssues([{ url: `${CANONICAL}/x` }]), /reason/);
+    assert.throws(() => normalizeKnownIssues([{ url: `${CANONICAL}/x`, reason: "   " }]), /reason/);
+  });
+
+  it("requires a matcher", () => {
+    assert.throws(() => normalizeKnownIssues([{ reason: "because" }]), /pathnameEndsWith/);
+  });
+
+  it("rejects a non-array input", () => {
+    assert.throws(() => normalizeKnownIssues("nope"), /must be an array/);
+  });
+
+  it("rejects an unknown or empty classification scope", () => {
+    assert.throws(
+      () => normalizeKnownIssues([{ pathnameEndsWith: "/x", reason: "why", classifications: [] }]),
+      /non-empty array/
+    );
+    assert.throws(
+      () =>
+        normalizeKnownIssues([
+          { pathnameEndsWith: "/x", reason: "why", classifications: ["nonsense"] },
+        ]),
+      /unknown classification/
+    );
+    assert.throws(
+      () =>
+        normalizeKnownIssues([{ pathnameEndsWith: "/x", reason: "why", classifications: ["ok"] }]),
+      /unknown classification/
+    );
+  });
+
+  it("only matches the failure modes an entry is scoped to", () => {
+    const allowlist = normalizeKnownIssues([
+      { pathnameEndsWith: "/x", reason: "client-rendered list", classifications: ["thin"] },
+    ]);
+
+    assert.ok(matchKnownIssue(allowlist, `${CANONICAL}/x`, CLASSIFICATIONS.THIN));
+    assert.equal(matchKnownIssue(allowlist, `${CANONICAL}/x`, CLASSIFICATIONS.NON_200), null);
+    assert.equal(matchKnownIssue(allowlist, `${CANONICAL}/y`, CLASSIFICATIONS.THIN), null);
+  });
+
+  it("ships a scoped, justified default allowlist", () => {
+    const normalized = normalizeKnownIssues(DEFAULT_KNOWN_ISSUES);
+    assert.ok(normalized.length > 0);
+    for (const entry of normalized) {
+      assert.ok(entry.reason.length > 20, `weak justification: ${entry.reason}`);
+      assert.ok(Array.isArray(entry.classifications), `unscoped allowlist entry: ${entry.reason}`);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// crawlSitemap end to end (injected fetch)
+// ---------------------------------------------------------------------------
+
+describe("crawlSitemap", () => {
+  const staticChild = `${CANONICAL}/sitemaps/static/sitemap.xml`;
+  const projectsChild = `${CANONICAL}/sitemaps/projects/sitemap.xml`;
+
+  const projectUrls = Array.from({ length: 500 }, (_, index) => `${CANONICAL}/project/p${index}`);
+
+  function buildRoutes(overrides = {}) {
+    const routes = {
+      [ROOT]: () => xml(sitemapIndex([staticChild, projectsChild])),
+      [staticChild]: () => xml(urlSet([`${CANONICAL}/projects`, `${CANONICAL}/communities`])),
+      [projectsChild]: () => xml(urlSet(projectUrls)),
+      [`${CANONICAL}/projects`]: () => html(page({ url: `${CANONICAL}/projects` })),
+      [`${CANONICAL}/communities`]: () => html(page({ url: `${CANONICAL}/communities` })),
+    };
+    for (const url of projectUrls) {
+      routes[url] = () => html(page({ url }));
+    }
+    return { ...routes, ...overrides };
+  }
+
+  const run = (routes, options = {}) =>
+    crawlSitemap({
+      fetch: makeFetch(routes),
+      rootSitemapUrl: ROOT,
+      samplePerChild: 10,
+      fullCrawlThreshold: 200,
+      concurrency: 2,
+      delayMs: 0,
+      sleep: noSleep,
+      now: "2026-07-31T00:00:00.000Z",
+      ...options,
+    });
+
+  it("walks index -> children -> leaves and passes when everything is indexable", async () => {
+    const report = await run(buildRoutes());
+
+    assert.equal(report.ok, true);
+    assert.equal(report.root, ROOT);
+    assert.deepEqual(report.errors, []);
+
+    const staticStats = report.children.find((child) => child.url === staticChild);
+    assert.deepEqual(staticStats, { url: staticChild, total: 2, sampled: 2, mode: "full" });
+
+    const projectStats = report.children.find((child) => child.url === projectsChild);
+    assert.deepEqual(projectStats, {
+      url: projectsChild,
+      total: 500,
+      sampled: 10,
+      mode: "sampled",
+    });
+
+    assert.equal(report.summary.crawled, 12);
+    assert.equal(report.summary.ok, 12);
+    assert.deepEqual(report.summary.failing, []);
+    assert.equal(report.timestamp, "2026-07-31T00:00:00.000Z");
+  });
+
+  it("records status, canonical, robots, title and content per URL", async () => {
+    const report = await run(buildRoutes());
+    const record = report.results.find((entry) => entry.url === `${CANONICAL}/projects`);
+
+    assert.equal(record.status, 200);
+    assert.equal(record.canonical, `${CANONICAL}/projects`);
+    assert.equal(record.title, "A page title");
+    assert.equal(record.h1, "A page heading");
+    assert.equal(record.metaRobots, null);
+    assert.ok(record.textLength > 200);
+    assert.equal(record.sitemap, staticChild);
+    assert.equal(record.classification, CLASSIFICATIONS.OK);
+  });
+
+  it("sends a descriptive user agent and never follows redirects", async () => {
+    const fetchImpl = makeFetch(buildRoutes());
+    await crawlSitemap({
+      fetch: fetchImpl,
+      rootSitemapUrl: ROOT,
+      samplePerChild: 2,
+      fullCrawlThreshold: 200,
+      concurrency: 1,
+      delayMs: 0,
+      sleep: noSleep,
+    });
+
+    for (const call of fetchImpl.calls) {
+      assert.equal(call.options.redirect, "manual");
+      assert.match(call.options.headers["user-agent"], /karmahq\.xyz/);
+      assert.ok(call.options.signal instanceof AbortSignal);
+    }
+  });
+
+  it("fails the run when a sitemap URL is not self-canonical", async () => {
+    const report = await run(
+      buildRoutes({
+        [`${CANONICAL}/communities`]: () =>
+          html(page({ url: `${CANONICAL}/communities`, canonical: `${CANONICAL}/` })),
+      })
+    );
+
+    assert.equal(report.ok, false);
+    assert.equal(report.summary.failing.length, 1);
+    assert.equal(report.summary.failing[0].url, `${CANONICAL}/communities`);
+    assert.equal(report.summary.failing[0].classification, CLASSIFICATIONS.NON_SELF_CANONICAL);
+  });
+
+  it("fails the run on a non-200, a noindex and a thin page", async () => {
+    const report = await run(
+      buildRoutes({
+        [`${CANONICAL}/projects`]: () => html("gone", { status: 410 }),
+        [`${CANONICAL}/communities`]: () =>
+          html(SHELL_HTML.replace(`${CANONICAL}/shell`, `${CANONICAL}/communities`)),
+        [`${CANONICAL}/project/p0`]: () =>
+          html(page({ url: `${CANONICAL}/project/p0` }), {
+            headers: { "x-robots-tag": "noindex" },
+          }),
+      })
+    );
+
+    assert.equal(report.ok, false);
+    const byUrl = new Map(report.summary.failing.map((entry) => [entry.url, entry.classification]));
+    assert.equal(byUrl.get(`${CANONICAL}/projects`), CLASSIFICATIONS.NON_200);
+    assert.equal(byUrl.get(`${CANONICAL}/communities`), CLASSIFICATIONS.THIN);
+    assert.equal(byUrl.get(`${CANONICAL}/project/p0`), CLASSIFICATIONS.NOINDEX);
+  });
+
+  it("suppresses an allowlisted failure but still reports it with its justification", async () => {
+    const report = await run(
+      buildRoutes({
+        [`${CANONICAL}/communities`]: () =>
+          html(SHELL_HTML.replace(`${CANONICAL}/shell`, `${CANONICAL}/communities`)),
+      }),
+      {
+        knownIssues: [
+          {
+            pathnameEndsWith: "/communities",
+            classifications: ["thin"],
+            reason: "Client-rendered directory; SSR seeding queued.",
+          },
+        ],
+      }
+    );
+
+    assert.equal(report.ok, true);
+    assert.deepEqual(report.summary.failing, []);
+    assert.equal(report.summary.allowlisted.length, 1);
+    assert.equal(report.summary.allowlisted[0].url, `${CANONICAL}/communities`);
+    assert.match(report.summary.allowlisted[0].reason, /SSR seeding queued/);
+    assert.equal(report.summary.byClassification[CLASSIFICATIONS.THIN], 1);
+  });
+
+  it("still fails a scoped-allowlisted URL that breaks in a different way", async () => {
+    const report = await run(
+      buildRoutes({ [`${CANONICAL}/communities`]: () => html("gone", { status: 410 }) }),
+      {
+        knownIssues: [
+          {
+            pathnameEndsWith: "/communities",
+            classifications: ["thin"],
+            reason: "Client-rendered directory; SSR seeding queued.",
+          },
+        ],
+      }
+    );
+
+    assert.equal(report.ok, false);
+    assert.equal(report.summary.failing.length, 1);
+    assert.equal(report.summary.failing[0].classification, CLASSIFICATIONS.NON_200);
+    assert.deepEqual(report.summary.allowlisted, []);
+  });
+
+  it("reports an unreachable child sitemap without aborting the rest of the crawl", async () => {
+    const routes = buildRoutes();
+    routes[projectsChild] = () => xml("nope", { status: 503 });
+    const report = await run(routes);
+
+    assert.equal(report.ok, false);
+    assert.equal(report.errors.length, 1);
+    assert.match(report.errors[0], /returned status 503/);
+    // The healthy child was still crawled.
+    assert.equal(report.summary.crawled, 2);
+  });
+
+  it("rejects an off-origin child sitemap before fetching it", async () => {
+    const routes = buildRoutes();
+    routes[ROOT] = () => xml(sitemapIndex([staticChild, "https://evil.example/sitemap.xml"]));
+    const fetchImpl = makeFetch(routes);
+    const report = await crawlSitemap({
+      fetch: fetchImpl,
+      rootSitemapUrl: ROOT,
+      concurrency: 1,
+      delayMs: 0,
+      sleep: noSleep,
+    });
+
+    assert.match(report.errors.join("\n"), /off-origin child sitemap rejected/);
+    assert.ok(!fetchImpl.calls.some((call) => call.url.includes("evil.example")));
+  });
+
+  it("requires an injected fetch", async () => {
+    await assert.rejects(() => crawlSitemap({ rootSitemapUrl: ROOT }), /injected `fetch`/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// CLI
+// ---------------------------------------------------------------------------
+
+describe("crawl-sitemap CLI", () => {
+  const collector = () => {
+    const lines = [];
+    return { write: (line) => lines.push(line), lines };
+  };
+
+  it("parses both --flag value and --flag=value forms", () => {
+    assert.deepEqual(parseArgs(["--concurrency", "4", "--delay-ms=500"]), {
+      concurrency: "4",
+      delayMs: "500",
+    });
+  });
+
+  it("rejects unknown flags and missing values", () => {
+    assert.throws(() => parseArgs(["--nope", "1"]), /Unknown argument/);
+    assert.throws(() => parseArgs(["--output"]), /Missing value/);
+    assert.throws(() => parseArgs(["--output", "--concurrency"]), /Missing value/);
+  });
+
+  it("gives flags precedence over env, and env over defaults", () => {
+    const fromEnv = resolveConfig({}, { CRAWL_CONCURRENCY: "7", CRAWL_DELAY_MS: "900" });
+    assert.equal(fromEnv.concurrency, 7);
+    assert.equal(fromEnv.delayMs, 900);
+
+    const fromFlags = resolveConfig({ concurrency: "2" }, { CRAWL_CONCURRENCY: "7" });
+    assert.equal(fromFlags.concurrency, 2);
+
+    const fromDefaults = resolveConfig({}, {});
+    assert.equal(fromDefaults.concurrency, 3);
+    assert.equal(fromDefaults.delayMs, 250);
+    assert.equal(fromDefaults.rootSitemapUrl, `${CANONICAL}/sitemap.xml`);
+  });
+
+  it("rejects non-numeric numeric flags", () => {
+    assert.throws(() => resolveConfig({ concurrency: "many" }, {}), /Invalid numeric value/);
+    assert.throws(() => resolveConfig({ timeoutMs: "-1" }, {}), /Invalid numeric value/);
+  });
+
+  it("writes the report to --output and exits 0 on a passing crawl", async () => {
+    const stdout = collector();
+    const writes = [];
+    const code = await main({
+      argv: ["--output", "artifacts/sitemap-crawl-report.json"],
+      env: {},
+      fetch: async () => new Response("", { status: 200 }),
+      crawl: async () => ({
+        timestamp: "2026-07-31T00:00:00.000Z",
+        root: ROOT,
+        children: [{ url: ROOT, total: 1, sampled: 1, mode: "full" }],
+        results: [],
+        summary: {
+          crawled: 1,
+          ok: 1,
+          byClassification: { ok: 1 },
+          failing: [],
+          allowlisted: [],
+          errorCount: 0,
+        },
+        knownIssues: [],
+        errors: [],
+        ok: true,
+      }),
+      stdout,
+      stderr: collector(),
+      writeFile: async (path, contents) => writes.push({ path, contents }),
+      mkdir: async () => {},
+    });
+
+    assert.equal(code, 0);
+    assert.equal(writes.length, 1);
+    assert.equal(writes[0].path, "artifacts/sitemap-crawl-report.json");
+    assert.equal(JSON.parse(writes[0].contents).ok, true);
+    assert.match(stdout.lines.join(""), /Overall: PASS/);
+  });
+
+  it("exits 1 and prints each failure when the crawl fails", async () => {
+    const stdout = collector();
+    const code = await main({
+      argv: [],
+      env: {},
+      crawl: async () => ({
+        timestamp: "2026-07-31T00:00:00.000Z",
+        root: ROOT,
+        children: [],
+        results: [],
+        summary: {
+          crawled: 1,
+          ok: 0,
+          byClassification: { "non-self-canonical": 1 },
+          failing: [
+            {
+              url: `${CANONICAL}/community/celo/projects`,
+              classification: "non-self-canonical",
+              status: 200,
+              canonical: `${CANONICAL}/community/celo`,
+              textLength: 900,
+              reason: null,
+            },
+          ],
+          allowlisted: [],
+          errorCount: 0,
+        },
+        knownIssues: [],
+        errors: [],
+        ok: false,
+      }),
+      stdout,
+      stderr: collector(),
+    });
+
+    assert.equal(code, 1);
+    const output = stdout.lines.join("");
+    assert.match(output, /non-self-canonical/);
+    assert.match(output, /Overall: FAIL/);
+  });
+
+  it("passes the default known-issues allowlist to the crawler", async () => {
+    let received;
+    await main({
+      argv: [],
+      env: {},
+      crawl: async (options) => {
+        received = options.knownIssues;
+        return emptyReport();
+      },
+      stdout: collector(),
+      stderr: collector(),
+    });
+    assert.deepEqual(received, DEFAULT_KNOWN_ISSUES);
+  });
+
+  it("loads a known-issues override file", async () => {
+    let received;
+    const override = [{ pathnameEndsWith: "/x", reason: "documented elsewhere" }];
+    await main({
+      argv: ["--known-issues", "known.json"],
+      env: {},
+      crawl: async (options) => {
+        received = options.knownIssues;
+        return emptyReport();
+      },
+      readFile: async () => JSON.stringify(override),
+      stdout: collector(),
+      stderr: collector(),
+    });
+    assert.deepEqual(received, override);
+  });
+
+  it("reports a bad known-issues file instead of crawling", async () => {
+    const stderr = collector();
+    let crawled = false;
+    const code = await main({
+      argv: ["--known-issues", "known.json"],
+      env: {},
+      crawl: async () => {
+        crawled = true;
+        return emptyReport();
+      },
+      readFile: async () => "{ not json",
+      stdout: collector(),
+      stderr,
+    });
+
+    assert.equal(code, 1);
+    assert.equal(crawled, false);
+    assert.match(stderr.lines.join(""), /Invalid JSON in known-issues file/);
+  });
+
+  it("returns 1 when writing the report fails", async () => {
+    const stderr = collector();
+    const code = await main({
+      argv: ["--output", "artifacts/report.json"],
+      env: {},
+      crawl: async () => emptyReport(),
+      stdout: collector(),
+      stderr,
+      writeFile: async () => {
+        throw new Error("disk full");
+      },
+      mkdir: async () => {},
+    });
+
+    assert.equal(code, 1);
+    assert.match(stderr.lines.join(""), /Failed to write report/);
+  });
+});
+
+function emptyReport() {
+  return {
+    timestamp: "2026-07-31T00:00:00.000Z",
+    root: ROOT,
+    children: [],
+    results: [],
+    summary: {
+      crawled: 0,
+      ok: 0,
+      byClassification: {},
+      failing: [],
+      allowlisted: [],
+      errorCount: 0,
+    },
+    knownIssues: [],
+    errors: [],
+    ok: true,
+  };
+}

--- a/scripts/indexability/crawl-sitemap.mjs
+++ b/scripts/indexability/crawl-sitemap.mjs
@@ -1,0 +1,803 @@
+/**
+ * Dependency-free ESM sitemap content crawler.
+ *
+ * Walks the sitemap index, then every child urlset, and fetches a sample of the
+ * listed pages WITHOUT executing JavaScript — exactly what a crawler that does
+ * not render sees. Per URL it records HTTP status, robots directives (header and
+ * meta), the declared canonical, the title, the first h1, and how much visible
+ * text the no-JS HTML actually contains, then classifies the URL.
+ *
+ * This never runs in CI: it hits production. `scripts/crawl-sitemap.mjs` is the
+ * manual CLI wrapper. Only these pure functions (with an injected `fetch`) are
+ * exercised by the no-network unit tests.
+ *
+ * No Node-only APIs beyond the global URL / AbortController / Date, so the
+ * module is safe to import without side effects.
+ */
+
+const DEFAULT_ROOT_SITEMAP_URL = "https://www.karmahq.xyz/sitemap.xml";
+const DEFAULT_TIMEOUT_MS = 15000;
+// Polite defaults: production is behind a WAF that will (rightly) throttle a
+// hard parallel crawl, and the point of this script is a truthful sample, not
+// speed.
+const DEFAULT_CONCURRENCY = 3;
+const DEFAULT_DELAY_MS = 250;
+// Children at or below this size are crawled in full; larger ones are sampled.
+const DEFAULT_FULL_CRAWL_THRESHOLD = 200;
+const DEFAULT_SAMPLE_PER_CHILD = 40;
+// Visible-text floor for "this page says something without JavaScript".
+const DEFAULT_MIN_CONTENT_CHARS = 200;
+// A sitemap index may list further indexes. Walk them, but stop well before an
+// accidental (or malicious) self-referential cycle turns into an infinite walk.
+const DEFAULT_MAX_SITEMAP_DEPTH = 5;
+// Sitemap protocol ceilings: 50,000 URLs and 50 MB uncompressed per document.
+// Anything larger is a bug in the producer, so refuse it instead of buffering it.
+const DEFAULT_MAX_SITEMAP_BYTES = 50 * 1024 * 1024;
+const DEFAULT_MAX_URLS_PER_SITEMAP = 50000;
+const DEFAULT_USER_AGENT =
+  "KarmaSitemapCrawler/1.0 (+https://www.karmahq.xyz; internal SEO audit; contact=engineering@karmahq.xyz)";
+
+export const CLASSIFICATIONS = Object.freeze({
+  OK: "ok",
+  NON_200: "non-200",
+  REDIRECTED: "redirected",
+  NOINDEX: "noindex",
+  NON_SELF_CANONICAL: "non-self-canonical",
+  THIN: "thin",
+  FETCH_ERROR: "fetch-error",
+});
+
+// ---------------------------------------------------------------------------
+// Public entry point
+// ---------------------------------------------------------------------------
+
+/**
+ * Crawl the sitemap tree and classify every sampled URL.
+ *
+ * @returns {Promise<{timestamp: string, root: string, children: Array, results: Array,
+ *   summary: object, knownIssues: Array, errors: string[], ok: boolean}>}
+ */
+export async function crawlSitemap({
+  fetch,
+  rootSitemapUrl = DEFAULT_ROOT_SITEMAP_URL,
+  canonicalOrigin,
+  samplePerChild = DEFAULT_SAMPLE_PER_CHILD,
+  fullCrawlThreshold = DEFAULT_FULL_CRAWL_THRESHOLD,
+  concurrency = DEFAULT_CONCURRENCY,
+  delayMs = DEFAULT_DELAY_MS,
+  timeoutMs = DEFAULT_TIMEOUT_MS,
+  minContentChars = DEFAULT_MIN_CONTENT_CHARS,
+  knownIssues = [],
+  userAgent = DEFAULT_USER_AGENT,
+  maxSitemapDepth = DEFAULT_MAX_SITEMAP_DEPTH,
+  maxSitemapBytes = DEFAULT_MAX_SITEMAP_BYTES,
+  maxUrlsPerSitemap = DEFAULT_MAX_URLS_PER_SITEMAP,
+  sleep = defaultSleep,
+  now,
+} = {}) {
+  if (typeof fetch !== "function") {
+    throw new Error("crawlSitemap requires an injected `fetch`");
+  }
+  const allowlist = normalizeKnownIssues(knownIssues);
+  const root = safeUrl(rootSitemapUrl);
+  if (!root) {
+    throw new Error(`Invalid rootSitemapUrl: "${rootSitemapUrl}"`);
+  }
+  const origin = canonicalOrigin ? normalizeOrigin(canonicalOrigin) : root.origin;
+
+  const errors = [];
+  const request = (url, consume) =>
+    timedFetch(fetch, url, { timeoutMs, redirect: "manual", userAgent, consume });
+
+  const children = [];
+  const selected = [];
+
+  // Breadth-first walk of the sitemap tree. The protocol lets an index list
+  // further indexes, so a document is only treated as a leaf once it actually
+  // parses as a urlset — never because of where it sat in the tree. `visited`
+  // makes a self-referential index terminate; `maxSitemapDepth` bounds the rest.
+  const visited = new Set();
+  const queue = [{ url: root.href, depth: 0 }];
+
+  while (queue.length > 0) {
+    const { url: documentUrl, depth } = queue.shift();
+    if (visited.has(documentUrl)) {
+      continue;
+    }
+    visited.add(documentUrl);
+
+    const doc = await fetchSitemapDocument(request, documentUrl, errors, { maxSitemapBytes });
+    if (!doc) {
+      children.push({ url: documentUrl, total: 0, sampled: 0, mode: "unavailable" });
+      continue;
+    }
+
+    if (isSitemapIndex(doc)) {
+      if (depth >= maxSitemapDepth) {
+        errors.push(`sitemap index nesting exceeded depth ${maxSitemapDepth} at ${documentUrl}`);
+        continue;
+      }
+      for (const loc of extractLocs(doc, { limit: maxUrlsPerSitemap, errors, documentUrl })) {
+        const parsed = safeUrl(loc);
+        if (!parsed) {
+          errors.push(`malformed child sitemap loc in ${documentUrl}: ${loc}`);
+          continue;
+        }
+        if (parsed.origin !== origin) {
+          errors.push(`off-origin child sitemap rejected (not fetched): ${loc}`);
+          continue;
+        }
+        queue.push({ url: parsed.href, depth: depth + 1 });
+      }
+      continue;
+    }
+
+    if (!isUrlSet(doc)) {
+      errors.push(`sitemap ${documentUrl} is neither a sitemapindex nor a urlset`);
+      continue;
+    }
+
+    const locs = dedupe(
+      extractLocs(doc, { limit: maxUrlsPerSitemap, errors, documentUrl }).filter((loc) => {
+        const parsed = safeUrl(loc);
+        if (!parsed || parsed.origin !== origin) {
+          errors.push(`off-origin or malformed leaf in ${documentUrl}: ${loc}`);
+          return false;
+        }
+        return true;
+      })
+    );
+    const sample = selectSample(locs, { fullCrawlThreshold, samplePerChild });
+    children.push({
+      url: documentUrl,
+      total: locs.length,
+      sampled: sample.length,
+      mode: locs.length <= fullCrawlThreshold ? "full" : "sampled",
+    });
+    for (const leaf of sample) {
+      selected.push({ url: leaf, sitemap: documentUrl });
+    }
+  }
+
+  const results = await mapWithConcurrency(
+    selected,
+    concurrency,
+    async ({ url, sitemap }) => {
+      const inspected = await inspectUrl(request, url, { minContentChars });
+      const classification = classify(inspected, url);
+      const allowed =
+        classification === CLASSIFICATIONS.OK
+          ? null
+          : matchKnownIssue(allowlist, url, classification, inspected);
+      return {
+        ...inspected,
+        sitemap,
+        classification,
+        allowlisted: Boolean(allowed),
+        allowlistReason: allowed ? allowed.reason : null,
+      };
+    },
+    { sleep, delayMs }
+  );
+
+  const summary = summarize(results, errors);
+  const timestamp = (now ? new Date(now) : new Date()).toISOString();
+
+  return {
+    timestamp,
+    root: root.href,
+    children,
+    results,
+    summary,
+    knownIssues: allowlist,
+    errors,
+    ok: errors.length === 0 && summary.failing.length === 0,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Sampling
+// ---------------------------------------------------------------------------
+
+/**
+ * Deterministic, evenly-strided sample. The same input list always yields the
+ * same URLs, so two runs are comparable instead of two different random walks.
+ */
+export function selectSample(
+  urls,
+  {
+    fullCrawlThreshold = DEFAULT_FULL_CRAWL_THRESHOLD,
+    samplePerChild = DEFAULT_SAMPLE_PER_CHILD,
+  } = {}
+) {
+  if (urls.length <= fullCrawlThreshold) {
+    return [...urls];
+  }
+  const size = Math.min(samplePerChild, urls.length);
+  if (size <= 0) {
+    return [];
+  }
+  const picked = [];
+  for (let index = 0; index < size; index += 1) {
+    picked.push(urls[Math.floor((index * urls.length) / size)]);
+  }
+  return picked;
+}
+
+// ---------------------------------------------------------------------------
+// Per-URL inspection
+// ---------------------------------------------------------------------------
+
+/**
+ * Fetch one page and extract everything a non-rendering crawler would see.
+ * Never throws: a transport failure becomes `{ error }` on the record.
+ */
+export async function inspectUrl(
+  request,
+  url,
+  { minContentChars = DEFAULT_MIN_CONTENT_CHARS } = {}
+) {
+  let fetched;
+  try {
+    fetched = await request(url, async (response) => ({
+      status: response?.status ?? 0,
+      location: headerValue(response, "location") || null,
+      xRobotsTag: headerValue(response, "x-robots-tag") || null,
+      contentType: headerValue(response, "content-type") || null,
+      body: isHtmlLike(headerValue(response, "content-type")) ? await response.text() : "",
+    }));
+  } catch (err) {
+    return {
+      url,
+      status: null,
+      error: errMsg(err),
+      location: null,
+      xRobotsTag: null,
+      metaRobots: null,
+      canonical: null,
+      title: null,
+      h1: null,
+      textLength: 0,
+      meaningful: false,
+    };
+  }
+
+  const html = fetched.body ?? "";
+  const canonicalHref = extractCanonical(html);
+  const textLength = visibleTextLength(html);
+  const h1 = extractFirstTagText(html, "h1");
+
+  return {
+    url,
+    status: fetched.status,
+    error: null,
+    location: fetched.location,
+    xRobotsTag: fetched.xRobotsTag,
+    metaRobots: extractMetaRobots(html),
+    canonical: canonicalHref ? (safeUrl(canonicalHref, url)?.href ?? canonicalHref) : null,
+    title: extractFirstTagText(html, "title"),
+    h1,
+    textLength,
+    meaningful: textLength >= minContentChars && Boolean(h1),
+  };
+}
+
+/**
+ * Single classification per URL, most severe first — a record is only `ok` when
+ * it is 200, indexable, self-canonical AND meaningful without JavaScript, which
+ * is exactly the acceptance criterion this crawl exists to prove.
+ */
+export function classify(record, expectedUrl = record.url) {
+  if (record.error) {
+    return CLASSIFICATIONS.FETCH_ERROR;
+  }
+  if (record.status >= 300 && record.status < 400) {
+    return CLASSIFICATIONS.REDIRECTED;
+  }
+  if (record.status !== 200) {
+    return CLASSIFICATIONS.NON_200;
+  }
+  if (hasNoindex(record.xRobotsTag) || hasNoindex(record.metaRobots)) {
+    return CLASSIFICATIONS.NOINDEX;
+  }
+  if (!isSelfCanonical(record.canonical, expectedUrl)) {
+    return CLASSIFICATIONS.NON_SELF_CANONICAL;
+  }
+  if (!record.meaningful) {
+    return CLASSIFICATIONS.THIN;
+  }
+  return CLASSIFICATIONS.OK;
+}
+
+export function isSelfCanonical(canonical, expectedUrl) {
+  if (!canonical) {
+    return false;
+  }
+  const declared = safeUrl(canonical, expectedUrl);
+  const expected = safeUrl(expectedUrl);
+  if (!declared || !expected) {
+    return false;
+  }
+  return canonicalKey(declared) === canonicalKey(expected);
+}
+
+// ---------------------------------------------------------------------------
+// Known issues (URLs queued for removal / accepted follow-ups)
+// ---------------------------------------------------------------------------
+
+const FAILURE_CLASSIFICATIONS = new Set(
+  Object.values(CLASSIFICATIONS).filter((value) => value !== CLASSIFICATIONS.OK)
+);
+
+/**
+ * An allowlist entry suppresses a failing URL's contribution to `ok`, but it
+ * must carry a written justification and it still shows up in the summary —
+ * "explicitly queued for removal with justification", never silently ignored.
+ *
+ * `classifications` narrows an entry to the failure modes it actually excuses.
+ * Without it an entry mutes everything for that URL, including a future 404 or
+ * noindex that has nothing to do with the documented issue.
+ *
+ * `minTextLength` narrows it further along the axis `thin` actually measures.
+ * A `thin` excuse is almost always "this page is a little under the threshold,
+ * for a reason we understand" — not "this page may contain nothing at all". The
+ * floor encodes the part of the page the entry claims still works, so a
+ * regression that empties the page out drops below it and fails loudly instead
+ * of landing under the same excuse.
+ */
+export function normalizeKnownIssues(entries) {
+  if (!Array.isArray(entries)) {
+    throw new Error("knownIssues must be an array");
+  }
+  return entries.map((entry, index) => {
+    if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
+      throw new Error(`knownIssues[${index}] must be an object`);
+    }
+    const reason = typeof entry.reason === "string" ? entry.reason.trim() : "";
+    if (!reason) {
+      throw new Error(`knownIssues[${index}] requires a non-empty "reason"`);
+    }
+    const { url, pathnameEndsWith, pathnameStartsWith, classifications, minTextLength } = entry;
+    if (!url && !pathnameEndsWith && !pathnameStartsWith) {
+      throw new Error(
+        `knownIssues[${index}] requires one of "url", "pathnameEndsWith", or "pathnameStartsWith"`
+      );
+    }
+    if (classifications !== undefined) {
+      if (!Array.isArray(classifications) || classifications.length === 0) {
+        throw new Error(`knownIssues[${index}].classifications must be a non-empty array`);
+      }
+      for (const value of classifications) {
+        if (!FAILURE_CLASSIFICATIONS.has(value)) {
+          throw new Error(`knownIssues[${index}] has unknown classification "${value}"`);
+        }
+      }
+    }
+    if (minTextLength !== undefined && !Number.isSafeInteger(minTextLength)) {
+      throw new Error(`knownIssues[${index}].minTextLength must be an integer`);
+    }
+    if (minTextLength !== undefined && minTextLength < 0) {
+      throw new Error(`knownIssues[${index}].minTextLength must be >= 0`);
+    }
+    return {
+      reason,
+      url: url ?? null,
+      pathnameEndsWith: pathnameEndsWith ?? null,
+      pathnameStartsWith: pathnameStartsWith ?? null,
+      classifications: classifications ? [...classifications] : null,
+      minTextLength: minTextLength ?? null,
+    };
+  });
+}
+
+/**
+ * Find the entry that excuses this failure, if any. `record` is the inspected
+ * page; entries carrying a `minTextLength` floor only apply while the page still
+ * clears it, so an entry can never grow into an excuse for a worse failure than
+ * the one it documents.
+ */
+export function matchKnownIssue(allowlist, url, classification, record) {
+  const parsed = safeUrl(url);
+  const pathname = parsed ? parsed.pathname : url;
+  const matchesPath = (entry) => {
+    if (entry.url && entry.url === url) {
+      return true;
+    }
+    if (entry.pathnameEndsWith && pathname.endsWith(entry.pathnameEndsWith)) {
+      return true;
+    }
+    if (entry.pathnameStartsWith && pathname.startsWith(entry.pathnameStartsWith)) {
+      return true;
+    }
+    return false;
+  };
+  const clearsFloor = (entry) => {
+    if (entry.minTextLength === null || entry.minTextLength === undefined) {
+      return true;
+    }
+    return Number(record?.textLength ?? 0) >= entry.minTextLength;
+  };
+  return (
+    allowlist.find(
+      (entry) =>
+        matchesPath(entry) &&
+        clearsFloor(entry) &&
+        (!entry.classifications ||
+          classification === undefined ||
+          entry.classifications.includes(classification))
+    ) ?? null
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Summary
+// ---------------------------------------------------------------------------
+
+function summarize(results, errors) {
+  const byClassification = {};
+  for (const value of Object.values(CLASSIFICATIONS)) {
+    byClassification[value] = 0;
+  }
+  const failing = [];
+  const allowlisted = [];
+
+  for (const record of results) {
+    byClassification[record.classification] = (byClassification[record.classification] ?? 0) + 1;
+    if (record.classification === CLASSIFICATIONS.OK) {
+      continue;
+    }
+    const entry = {
+      url: record.url,
+      classification: record.classification,
+      status: record.status,
+      canonical: record.canonical,
+      textLength: record.textLength,
+      reason: record.allowlistReason,
+    };
+    if (record.allowlisted) {
+      allowlisted.push(entry);
+    } else {
+      failing.push(entry);
+    }
+  }
+
+  return {
+    crawled: results.length,
+    ok: byClassification[CLASSIFICATIONS.OK],
+    byClassification,
+    failing,
+    allowlisted,
+    errorCount: errors.length,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Concurrency
+// ---------------------------------------------------------------------------
+
+/**
+ * Bounded worker pool. At most `limit` tasks are in flight, and each worker
+ * waits `delayMs` between its own requests, so the crawl stays polite.
+ * Results keep input order.
+ */
+export async function mapWithConcurrency(
+  items,
+  limit,
+  worker,
+  { sleep = defaultSleep, delayMs = 0 } = {}
+) {
+  const size = Math.max(1, Math.floor(limit) || 1);
+  const results = new Array(items.length);
+  let cursor = 0;
+
+  const runWorker = async () => {
+    let first = true;
+    for (;;) {
+      const index = cursor;
+      cursor += 1;
+      if (index >= items.length) {
+        return;
+      }
+      if (!first && delayMs > 0) {
+        await sleep(delayMs);
+      }
+      first = false;
+      results[index] = await worker(items[index], index);
+    }
+  };
+
+  await Promise.all(Array.from({ length: Math.min(size, items.length) }, runWorker));
+  return results;
+}
+
+// ---------------------------------------------------------------------------
+// HTML / XML helpers
+// ---------------------------------------------------------------------------
+
+const SCRIPT_LIKE = /<(script|style|noscript|template)\b[^>]*>[\s\S]*?<\/\1>/gi;
+const HTML_COMMENT = /<!--[\s\S]*?-->/g;
+const TAG = /<[^>]*>/g;
+
+/**
+ * Length of the text a reader sees with JavaScript disabled: script, style,
+ * noscript, template and JSON-LD payloads are removed first so a page whose
+ * only "content" is a serialized RSC payload or structured data is not counted
+ * as meaningful.
+ */
+export function visibleTextLength(html) {
+  if (!html) {
+    return 0;
+  }
+  const stripped = html
+    .replace(HTML_COMMENT, " ")
+    .replace(SCRIPT_LIKE, " ")
+    .replace(TAG, " ")
+    .replace(/&nbsp;/gi, " ");
+  return decodeHtmlEntities(stripped).replace(/\s+/g, " ").trim().length;
+}
+
+export function extractFirstTagText(html, tagName) {
+  if (!html) {
+    return null;
+  }
+  const pattern = new RegExp(`<${tagName}\\b[^>]*>([\\s\\S]*?)</${tagName}>`, "i");
+  const match = html.replace(HTML_COMMENT, " ").match(pattern);
+  if (!match) {
+    return null;
+  }
+  const text = decodeHtmlEntities(match[1].replace(TAG, " ")).replace(/\s+/g, " ").trim();
+  return text || null;
+}
+
+// Attribute-order independent: scan every <link> tag, treat rel as a
+// space-separated token list, and return the href of the first canonical link.
+export function extractCanonical(html) {
+  if (!html) {
+    return null;
+  }
+  const linkPattern = /<link\b[^>]*>/gi;
+  let match = linkPattern.exec(html);
+  while (match !== null) {
+    const rel = attributeValue(match[0], "rel");
+    if (rel?.trim().split(/\s+/).includes("canonical")) {
+      const href = attributeValue(match[0], "href");
+      if (href) {
+        return decodeHtmlEntities(href);
+      }
+    }
+    match = linkPattern.exec(html);
+  }
+  return null;
+}
+
+// Both the generic `robots` directive and Google's `googlebot` override count.
+export function extractMetaRobots(html) {
+  if (!html) {
+    return null;
+  }
+  const metaPattern = /<meta\b[^>]*>/gi;
+  const found = [];
+  let match = metaPattern.exec(html);
+  while (match !== null) {
+    const name = attributeValue(match[0], "name");
+    if (name && /^(robots|googlebot)$/i.test(name.trim())) {
+      const content = attributeValue(match[0], "content");
+      if (content) {
+        found.push(content.trim());
+      }
+    }
+    match = metaPattern.exec(html);
+  }
+  return found.length > 0 ? found.join(", ") : null;
+}
+
+// `none` is the standard shorthand for "noindex, nofollow" and keeps a page out
+// of the index just as effectively as the explicit token.
+const NOINDEX_TOKENS = new Set(["noindex", "none"]);
+
+export function hasNoindex(value) {
+  if (!value) {
+    return false;
+  }
+  return value.split(/[,\s]+/).some((token) => NOINDEX_TOKENS.has(token.trim().toLowerCase()));
+}
+
+async function fetchSitemapDocument(request, url, errors, { maxSitemapBytes } = {}) {
+  const byteCap = typeof maxSitemapBytes === "number" ? maxSitemapBytes : DEFAULT_MAX_SITEMAP_BYTES;
+  let fetched;
+  try {
+    // Read `content-length` before touching the body: an oversized document is
+    // refused without ever being buffered, so a runaway sitemap cannot take the
+    // process down before the report is written.
+    fetched = await request(url, async (response) => {
+      const status = response?.status ?? 0;
+      const declared = Number(headerValue(response, "content-length"));
+      const declaredBytes = Number.isFinite(declared) && declared > 0 ? declared : null;
+      const oversized = declaredBytes !== null && declaredBytes > byteCap;
+      return {
+        status,
+        contentType: headerValue(response, "content-type"),
+        declaredBytes,
+        oversized,
+        body: status === 200 && !oversized ? await response.text() : null,
+      };
+    });
+  } catch (err) {
+    errors.push(`sitemap fetch failed for ${url}: ${errMsg(err)}`);
+    return null;
+  }
+  if (fetched?.oversized) {
+    errors.push(`sitemap ${url} declares ${fetched.declaredBytes} bytes, above the ${byteCap} cap`);
+    return null;
+  }
+  if (!fetched || fetched.status !== 200 || !fetched.body) {
+    errors.push(`sitemap ${url} returned status ${fetched?.status ?? "unknown"}`);
+    return null;
+  }
+  if (fetched.body.length > byteCap) {
+    errors.push(`sitemap ${url} body is ${fetched.body.length} bytes, above the ${byteCap} cap`);
+    return null;
+  }
+  // A `.xml.gz` child needs inflating before any of this parses. Say so instead
+  // of reporting the generic non-XML error, which reads like a server misconfig.
+  if (/gzip/i.test(fetched.contentType ?? "")) {
+    errors.push(
+      `sitemap ${url} is gzipped ("${fetched.contentType}"); this crawler reads uncompressed XML only`
+    );
+    return null;
+  }
+  if (!/xml/i.test(fetched.contentType ?? "")) {
+    errors.push(`sitemap ${url} has non-XML content-type "${fetched.contentType ?? ""}"`);
+    return null;
+  }
+  return fetched.body;
+}
+
+function isSitemapIndex(xml) {
+  return /<sitemapindex[\s>]/i.test(xml);
+}
+
+function isUrlSet(xml) {
+  return /<urlset[\s>]/i.test(xml);
+}
+
+function extractLocs(xml, { limit = Number.POSITIVE_INFINITY, errors, documentUrl } = {}) {
+  const locs = [];
+  const pattern = /<loc>\s*([\s\S]*?)\s*<\/loc>/gi;
+  let match = pattern.exec(xml);
+  while (match !== null) {
+    if (locs.length >= limit) {
+      errors?.push(`sitemap ${documentUrl} lists more than ${limit} <loc> entries; truncated`);
+      break;
+    }
+    locs.push(decodeHtmlEntities(match[1].trim()));
+    match = pattern.exec(xml);
+  }
+  return locs;
+}
+
+function attributeValue(tag, name) {
+  const pattern = new RegExp(`\\b${name}\\s*=\\s*(?:"([^"]*)"|'([^']*)'|([^\\s>]+))`, "i");
+  const match = tag.match(pattern);
+  if (!match) {
+    return null;
+  }
+  return match[1] ?? match[2] ?? match[3] ?? null;
+}
+
+function decodeHtmlEntities(value) {
+  return (
+    value
+      .replace(/&lt;/g, "<")
+      .replace(/&gt;/g, ">")
+      .replace(/&quot;/g, '"')
+      .replace(/&apos;/g, "'")
+      .replace(/&#x([0-9a-fA-F]+);/g, (_, hex) => codePoint(parseInt(hex, 16)))
+      .replace(/&#(\d+);/g, (_, dec) => codePoint(Number(dec)))
+      // Decode &amp; last so it does not double-decode the entities above.
+      .replace(/&amp;/g, "&")
+  );
+}
+
+function codePoint(value) {
+  try {
+    return String.fromCodePoint(value);
+  } catch {
+    return "";
+  }
+}
+
+function isHtmlLike(contentType) {
+  return !contentType || /html/i.test(contentType);
+}
+
+// ---------------------------------------------------------------------------
+// Misc helpers
+// ---------------------------------------------------------------------------
+
+// One AbortController + one timer per request; the body is read inside
+// `consume` while the timer is still armed, so a stalled body aborts under the
+// same timeout instead of hanging.
+async function timedFetch(fetch, url, { timeoutMs, redirect, userAgent, consume } = {}) {
+  const controller = new AbortController();
+  const timer =
+    typeof timeoutMs === "number" && timeoutMs > 0
+      ? setTimeout(() => controller.abort(), timeoutMs)
+      : null;
+  try {
+    const options = { signal: controller.signal, headers: { "user-agent": userAgent } };
+    if (redirect) {
+      options.redirect = redirect;
+    }
+    const response = await fetch(url, options);
+    return consume ? await consume(response) : response;
+  } finally {
+    if (timer) {
+      clearTimeout(timer);
+    }
+  }
+}
+
+export function normalizeOrigin(value, label = "canonicalOrigin") {
+  const url = safeUrl(value);
+  if (!url) {
+    throw new Error(`Invalid ${label}: "${value}" is not a valid URL`);
+  }
+  if (url.protocol !== "http:" && url.protocol !== "https:") {
+    throw new Error(`Invalid ${label}: "${value}" must use http(s)`);
+  }
+  if ((url.pathname && url.pathname !== "/") || url.search || url.hash) {
+    throw new Error(`Invalid ${label}: "${value}" must be origin-only (no path, query, or hash)`);
+  }
+  return url.origin;
+}
+
+// Only a trailing slash is normalized away. The query string is part of the
+// identity of a URL: `/search?page=2` declaring `/search` canonical is a real
+// consolidation, not a self-canonical, and must not be reported as `ok`.
+function canonicalKey(url) {
+  const pathname = url.pathname.length > 1 ? url.pathname.replace(/\/+$/, "") : url.pathname;
+  return `${url.origin}${pathname}${url.search}`;
+}
+
+function dedupe(values) {
+  return [...new Set(values)];
+}
+
+function headerValue(response, name) {
+  const getter = response?.headers?.get;
+  if (typeof getter !== "function") {
+    return "";
+  }
+  return response.headers.get(name) ?? "";
+}
+
+function safeUrl(value, base) {
+  try {
+    return base === undefined ? new URL(String(value)) : new URL(String(value), String(base));
+  } catch {
+    return null;
+  }
+}
+
+function defaultSleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function errMsg(err) {
+  return err?.message ? err.message : String(err);
+}
+
+export const CRAWL_DEFAULTS = Object.freeze({
+  rootSitemapUrl: DEFAULT_ROOT_SITEMAP_URL,
+  samplePerChild: DEFAULT_SAMPLE_PER_CHILD,
+  fullCrawlThreshold: DEFAULT_FULL_CRAWL_THRESHOLD,
+  concurrency: DEFAULT_CONCURRENCY,
+  delayMs: DEFAULT_DELAY_MS,
+  timeoutMs: DEFAULT_TIMEOUT_MS,
+  minContentChars: DEFAULT_MIN_CONTENT_CHARS,
+  userAgent: DEFAULT_USER_AGENT,
+  maxSitemapDepth: DEFAULT_MAX_SITEMAP_DEPTH,
+  maxSitemapBytes: DEFAULT_MAX_SITEMAP_BYTES,
+  maxUrlsPerSitemap: DEFAULT_MAX_URLS_PER_SITEMAP,
+});


### PR DESCRIPTION
## Overview

DEV-586 (AEO-03, P0) — part of DEV-583. Makes sitemap membership mean something: every URL we submit is now the canonical of its own content, and there is a crawler that can prove it from the outside without executing JavaScript.

Three pieces:

1. Community sub-pages get self-referential canonicals and their own titles/descriptions.
2. The communities sitemap stops submitting URLs that are not canonical, content-bearing pages.
3. A dependency-free sitemap content crawler plus assertions that keep sitemap membership and canonicals from drifting apart.

## Problem

**Sitemap-listed URLs pointed their canonical somewhere else.** `funding-opportunities`, `projects`, `updates`, `impact` and `financials` under `/community/<id>/` had no `generateMetadata` of their own, so they inherited the community layout's. Every one of them advertised `<link rel="canonical" href="/community/<id>">` and reused the community root's title and description. We were submitting five URLs per community and telling crawlers to index a sixth, different one instead. Duplicate titles across the set made it worse.

**The sitemap submitted pages with nothing to index.** `browse-applications` is a fully client-rendered application-search tool — no server-rendered content, no unique metadata. `financials` is behind `FINANCIALS_ENABLED_COMMUNITIES`, so for every community outside that list the route renders an explicit "not available" state; we were submitting a near-identical thin page per community.

**Nothing could catch either problem.** The existing indexability monitor checks robots/meta directives, but it never looked at what the page actually contains, and there was no test tying the sitemap's URL set to the canonicals those URLs serve. The two could drift silently, and had.

**Hardcoded origin.** `app/sitemaps/communities/sitemap.ts` built URLs from a literal `https://www.karmahq.xyz`.

## Solution

### Canonicals (`c90c32d5f`)

Each of the five sub-pages now composes the existing `communitySubpageMetadata()` for a whitelabel-aware self-referential canonical, and supplies its own title and description. `funding-opportunities` gets a `layout.tsx` because its page is a client component and cannot export `generateMetadata`. The community fetch and the whitelabel context resolve in parallel, so this costs no extra round trip.

### Sitemap membership (`7292ca8fb`)

- `browse-applications` is dropped. It still serves 200 and consolidates onto the community root canonical — it is just no longer submitted.
- `financials` is emitted only for communities in `FINANCIALS_ENABLED_COMMUNITIES`.
- Literal origin replaced with `SITE_URL`.

`__tests__/app/community-subpage-canonicals.test.ts` derives its sub-page set **from the sitemap module itself**, then loads each route's `generateMetadata` and asserts the canonical points back at the submitted URL with a distinct title. Adding a sub-page to the sitemap without giving that route self-canonical, unique metadata fails the suite. The two cannot drift apart silently again.

### No-JS rendering assertions (`42e49c146`)

`__tests__/app/knowledge-collection-ssr.test.tsx` renders the knowledge and collection templates through `renderToString` / `renderToPipeableStream` — no effects, no hydration, no client fetches, which is exactly what a non-rendering crawler receives — and pins a heading, enough visible prose to be worth indexing, the JSON-LD, and a self-referential canonical. The project, funding-program and community-root templates already have equivalent coverage elsewhere and are not duplicated.

### Sitemap content crawler (`620bead12`)

`scripts/indexability/crawl-sitemap.mjs` walks the sitemap index and every child urlset, then fetches a sample of the listed pages without executing JavaScript. Per URL it records HTTP status, robots directives from **both** the `X-Robots-Tag` header and the meta tag, the declared canonical, the title, the first `h1`, and how much visible text the no-JS HTML contains — then classifies: `ok`, `broken`, `noindex`, `cross-canonical`, `thin`, `unavailable`. A failure names the URL and the reason; it is not a count.

Dependency-free ESM with an injectable `fetch`, so all of it is unit-tested with no network. `scripts/crawl-sitemap.mjs` is the CLI wrapper; it hits production and is **manual-only** — deliberately never wired into a workflow. Flags > `CRAWL_*` env > defaults. Polite defaults (concurrency 3, 250 ms delay) because production sits behind a WAF.

Known issues live in an allowlist where every entry carries a written justification **and a `minTextLength` floor**, so an entry excuses one specific measured gap rather than muting a whole route class — if the page regresses below its floor, it fails anyway.

### CI (`066b074bc`)

The crawler's two no-network suites join the existing `node --test` step in `indexability-monitor.yml`, with a comment recording why the crawler itself is absent.

## Testing steps

```bash
# Unit (vitest)
pnpm vitest run --project unit \
  __tests__/app/community-subpage-canonicals.test.ts \
  __tests__/app/sitemaps/communities/sitemap.test.ts \
  __tests__/app/knowledge-collection-ssr.test.tsx
# 3 files, 25 tests passing

# Crawler (node --test, no network)
node --test \
  scripts/indexability/__tests__/crawl-sitemap.test.mjs \
  scripts/indexability/__tests__/crawl-sitemap-robustness.test.mjs
# 67 tests passing

pnpm typecheck   # clean
pnpm biome check <changed files>   # clean
node scripts/quality-gate.js       # no regressions; oversized files Δ0, biome -32
```

Manual crawl (hits production, do not run in CI):

```bash
node scripts/crawl-sitemap.mjs --output artifacts/sitemap-crawl-report.json
```

A baseline crawl against production was captured before the change; the community sub-page URLs show up as `cross-canonical` there, which is the failure this PR fixes.

To verify by hand after deploy: open `/community/<id>/projects` on a preview, view source, and confirm `<link rel="canonical">` points at that same path (and at the bare `/projects` on a whitelabel domain), with a title distinct from the community root.

## Risk / scope notes

- **Metadata-only for the five routes.** No rendering, data fetching or routing changes — `generateMetadata` additions and one pass-through `layout.tsx`.
- **Sitemap shrinks.** `browse-applications` disappears for every community and `financials` for all but the enabled ones. Both still return 200; they are de-listed, not removed. Expect a drop in submitted-URL count in Search Console and a corresponding rise in the valid ratio.
- **Canonical changes are re-indexing events.** These five URLs previously consolidated onto the community root. They now stand alone, so they will be re-crawled and re-assessed. This is the intent, but the effect is not instant.
- **Whitelabel behaviour is inherited, not invented.** `communitySubpageMetadata()` already existed and already mirrors the community layout's whitelabel prefix handling; this PR only calls it from more places.
- **The crawler is not in any CI path.** Only its no-network unit tests run in the monitor workflow. Nothing in CI reaches out to production.
- **The allowlist has exactly one entry** (`/funding-opportunities` / `thin`) with a floor and a written justification, and it is queued for SSR seeding as a follow-up.

## Review notes

Two independent reviews ran over this branch. What they raised and how it was resolved:

**High — the known-issues allowlist could mute a whole route class.** The `funding-opportunities` / `thin` entry was a wildcard: if every one of those pages regressed to a bare `<h1>`, each would be allowlisted and the crawl would still exit 0. Fixed by adding a `minTextLength` floor to the entry format. An entry now only excuses the gap between what *does* render server-side (the community header's heading and prose) and the threshold; drop below the floor and the header itself has regressed, which the entry does not cover. The comment states the floor must be calibrated against a real crawl report and never raised to turn a red run green.

**Nested sitemap indexes were treated as leaves.** A child document that is itself a `<sitemapindex>` had its `<loc>` sitemap URLs fetched as if they were pages, so no entity URL was ever inspected. Replaced the two-level walk with a depth-tracked queue that re-classifies each fetched document, bounded by `maxSitemapDepth` (5) so a self-referential index cannot loop forever.

**Canonical comparison ignored query strings.** `/search?page=2` declaring `/search` as canonical was classified `ok`. `canonicalKey` now includes `url.search`, so a query URL that canonicalises elsewhere is correctly reported `cross-canonical`. A companion assertion keeps our own collection canonicals query-free.

**`<meta name="robots" content="none">` was not recognised.** `none` is the standard shorthand for `noindex, nofollow`; only the literal `noindex` token was matched, so such a page was classified indexable. Now matched via a `NOINDEX_TOKENS` set covering both.

**Unbounded sitemap bodies.** Documents were read fully into memory with no ceiling — an accidentally huge sitemap or a decompression bomb would kill the crawl before any partial report was written. Added the sitemap protocol's own limits as hard caps: 50 MB per document and 50,000 URLs per urlset. Exceeding either is recorded as an error against that document rather than crashing the run.

**Gzipped children were silently unavailable.** A `.xml.gz` child served as `application/x-gzip` was marked unavailable with no explanation. The crawler still reads uncompressed XML only, but now emits an explicit error naming the URL and its content type, so the limitation is visible in the report instead of looking like a fetch failure.

**Regex sitemap parsing accepts malformed XML.** Acknowledged and deliberately not fixed: adding an XML parser would break the dependency-free constraint that lets this run as a bare `node` script. The crawler's job is auditing content, not validating sitemap syntax — Search Console already reports malformed sitemaps. The structural guards above (depth, byte and URL ceilings, explicit per-document errors) bound the blast radius.

**The `/communities` no-JS test proved less than it appeared to.** It asserted JSON-LD and metadata while the listing itself was mocked away, so an empty body to a crawler would still have passed. Rewritten to assert a server-rendered shell is present, and — more importantly — the test now documents that it does **not** claim the page is meaningful without JavaScript. The listing is genuinely client-rendered, the crawler reports it as `thin`, and no allowlist entry suppresses that. Honest signal over a green assertion.

Two pre-existing anti-pattern findings in `financials/page.tsx` (empty catch in the KYC prefetch) and `projects/page.tsx` (missing `error.tsx`) were confirmed to predate this branch and are left alone rather than folded into a metadata PR.

---

## Correction: sub-pages consolidate onto the root, they do not self-canonical

An earlier revision of this PR gave `funding-opportunities`, `projects`, `updates`, `impact`
and `financials` self-referential canonicals and submitted them to the sitemap. That was the
wrong branch of the AEO-03 finding, and it has been reversed.

A self-canonical asserts a page deserves to rank on its own. Crawling production as Googlebot
with JavaScript disabled (2026-08-03) showed none of them do:

| Route | Visible text without JS |
| --- | --- |
| `/community/celo` | 5,570 chars |
| `/community/celo/projects` | 5,578 chars — **99.9% identical to the root, zero unique words** |
| `/community/celo/funding-opportunities` | 406 chars |
| `/community/celo/updates` | 475 chars |
| `/community/celo/impact` | 613 chars |
| `/community/celo/financials` | 501 chars |
| `/community/celo/reports` | 406 chars |

Submitting these would ask Google to index five client-rendered shells plus a literal duplicate
of a URL already in the sitemap — splitting the signals the umbrella canonical currently
consolidates, and inviting `/projects` to cannibalise the community root.

**What changed:** the communities sitemap emits community roots only; the five sub-pages drop
their self-canonical and keep inheriting the community root canonical from the layout. They
still serve 200 — they are de-listed, not removed.

**What is kept:** the unique titles and descriptions. They cost nothing while the pages are
consolidated, they fix the doubled `| Karma | Karma` suffix that is live on production today,
and they are ready the moment a page earns its canonical.

**The gate now works in both directions.** `__tests__/app/community-subpage-canonicals.test.ts`
asserts (1) the sitemap contains roots and nothing else, and (2) no shell sub-page declares a
canonical. Re-adding a sub-page to the sitemap fails the first; adding a canonical fails the
second. Server-rendered content, canonical and sitemap entry can only move together.

**The path forward is unchanged, just correctly ordered:** server-render a sub-page first
(`updates` and `impact` answer genuinely distinct queries and deserve to rank), then give it a
canonical and a sitemap entry in the same change.

`reports` already declared its own canonical before this branch; that is left alone as
pre-existing, and it is kept out of the sitemap along with the others.

### Known, deliberately out of scope
An empty catch in the KYC prefetch at `financials/page.tsx` trips the anti-pattern checker. It
predates this branch — `main` reports the same finding at L:69 — and is unrelated to canonicals,
so it is not mixed into this diff.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added clearer, community-specific titles and descriptions for project and funding pages.
  - Added a manual sitemap health-check tool with configurable crawling and reports.

- **Improvements**
  - Community sitemaps now include only canonical community landing pages, reducing duplicate entries.
  - Community sub-pages consistently inherit canonical URLs and avoid query-string variants.
  - Improved server-rendered content and metadata for knowledge, project, and community pages.

- **Tests**
  - Expanded coverage for sitemap integrity, canonical URLs, metadata, no-JavaScript rendering, and crawler edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->