### PR TITLE
chore: harden the llms.txt workflow, route knowledge links through PAGES, version CodeRabbit config

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,20 @@
+# yaml-language-server: $schema=https://storage.googleapis.com/coderabbit_public_assets/schema.v2.json
+
+# Keep using the CodeRabbit UI settings for everything not set in this file.
+# Without `inheritance: true` a repository .coderabbit.yaml becomes the only
+# configuration source, and every value configured in the UI silently reverts
+# to the schema default.
+inheritance: true
+
+reviews:
+  pre_merge_checks:
+    docstrings:
+      # The schema default is 80%, which does not describe this codebase:
+      # 607 of 1862 files under app/, components/, utilities/ and hooks/
+      # contain any /** */ block (~32%). No CLAUDE.md here requires docstrings
+      # and the project prefers sparse commenting, so an 80% bar flags ordinary
+      # PRs. The check is scored per-PR from the changed files, so it still has
+      # signal: 30% sits just under the measured rate, catching a PR that adds
+      # a large block of wholly undocumented code without penalising routine
+      # changes. Re-measure before raising this.
+      threshold: 30

--- a/.github/workflows/generate-llms-txt.yml
+++ b/.github/workflows/generate-llms-txt.yml
@@ -68,8 +68,12 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const title = 'Scheduled llms.txt regeneration failed';
+            // Identifies the tracker this workflow owns. Matching on title alone
+            // would let an unrelated issue of the same name collect these comments.
+            const marker = '<!-- llms-txt-regeneration-failure -->';
             const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
             const body = [
+              marker,
               `The **${context.workflow}** workflow failed, so \`public/llms.txt\` and`,
               '`public/llms-full.txt` were not regenerated.',
               '',
@@ -90,7 +94,8 @@ jobs:
               per_page: 100,
             });
             const openIssue = existing.find(
-              (issue) => !issue.pull_request && issue.title === title
+              (issue) =>
+                !issue.pull_request && issue.title === title && issue.body?.includes(marker)
             );
 
             if (openIssue) {

--- a/.github/workflows/generate-llms-txt.yml
+++ b/.github/workflows/generate-llms-txt.yml
@@ -17,6 +17,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      # Needed by the failure notification step below, which opens/updates an issue.
+      issues: write
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -47,5 +49,64 @@ jobs:
             echo "No changes to commit"
           else
             git commit -m "docs: regenerate llms.txt files"
-            git push
+            # --no-verify skips the husky pre-push hook, which runs `pnpm typecheck`.
+            # That hook exists to stop humans pushing code that does not compile; this
+            # job only writes two generated .txt files and every PR is typechecked by
+            # CI anyway, so here it only adds a hidden failure mode. On 2026-07-01 the
+            # push was rejected by an unrelated type error in
+            # src/features/home/components/rotating-word.test.tsx and llms.txt went
+            # un-regenerated for a whole month. Do not remove this flag.
+            git push --no-verify
           fi
+
+      # A scheduled job that fails is invisible to everyone who is not watching the
+      # Actions tab — see the July 2026 outage above. Turn a failed run into an issue.
+      - name: Open an issue on failure
+        if: failure()
+        uses: actions/github-script@v8
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const title = 'Scheduled llms.txt regeneration failed';
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const body = [
+              `The **${context.workflow}** workflow failed, so \`public/llms.txt\` and`,
+              '`public/llms-full.txt` were not regenerated.',
+              '',
+              `- Run: ${runUrl}`,
+              `- Trigger: \`${context.eventName}\``,
+              `- Commit: \`${context.sha}\``,
+              '',
+              'Check the run logs, fix the cause, then re-run the workflow manually',
+              '(Actions → Generate llms.txt → Run workflow).',
+            ].join('\n');
+
+            // Reuse a single open issue with a stable title so repeated monthly
+            // failures comment on it instead of piling up new issues.
+            const existing = await github.paginate(github.rest.issues.listForRepo, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              per_page: 100,
+            });
+            const openIssue = existing.find(
+              (issue) => !issue.pull_request && issue.title === title
+            );
+
+            if (openIssue) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: openIssue.number,
+                body,
+              });
+              console.log(`Commented on existing issue #${openIssue.number}`);
+            } else {
+              const created = await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title,
+                body,
+              });
+              console.log(`Created issue #${created.data.number}`);
+            }

--- a/__tests__/utilities/pages.test.ts
+++ b/__tests__/utilities/pages.test.ts
@@ -174,8 +174,14 @@ describe("PAGES constants", () => {
         .map((entry) => path.join(dir, entry.name, "page.tsx"))
         .concat(path.join(dir, "page.tsx"));
 
+      // A quote immediately before the path catches a hardcoded route in any
+      // string form — "/knowledge", '/knowledge' and `/knowledge`. Asserting on
+      // the bare substring would not work: every article imports
+      // `@/app/knowledge/articleDates`, so the path appears legitimately.
+      const hardcodedRoute = /["'`]\/knowledge/;
+
       for (const page of pages) {
-        expect(readFileSync(page, "utf8")).not.toContain('"/knowledge');
+        expect(readFileSync(page, "utf8")).not.toMatch(hardcodedRoute);
       }
     });
   });

--- a/__tests__/utilities/pages.test.ts
+++ b/__tests__/utilities/pages.test.ts
@@ -1,3 +1,5 @@
+import { readdirSync, readFileSync } from "node:fs";
+import path from "node:path";
 import { PAGES } from "@/utilities/pages";
 
 describe("PAGES constants", () => {
@@ -139,6 +141,42 @@ describe("PAGES constants", () => {
       const path1 = PAGES.BLOG_POST("post-a");
       const path2 = PAGES.BLOG_POST("post-b");
       expect(path1).not.toBe(path2);
+    });
+  });
+
+  describe("PAGES.KNOWLEDGE", () => {
+    it("ROOT is /knowledge", () => {
+      expect(PAGES.KNOWLEDGE.ROOT).toBe("/knowledge");
+    });
+
+    it("ARTICLE builds a slug path under the index route", () => {
+      expect(PAGES.KNOWLEDGE.ARTICLE("grant-lifecycle")).toBe("/knowledge/grant-lifecycle");
+      expect(PAGES.KNOWLEDGE.ARTICLE("onchain-reputation")).toBe("/knowledge/onchain-reputation");
+    });
+
+    it("ARTICLE resolves every article directory to its own route", () => {
+      const dir = path.resolve(__dirname, "../../app/knowledge");
+      const slugs = readdirSync(dir, { withFileTypes: true })
+        .filter((entry) => entry.isDirectory())
+        .map((entry) => entry.name);
+
+      expect(slugs.length).toBeGreaterThan(0);
+      for (const slug of slugs) {
+        expect(PAGES.KNOWLEDGE.ARTICLE(slug)).toBe(`${PAGES.KNOWLEDGE.ROOT}/${slug}`);
+      }
+      expect(new Set(slugs.map(PAGES.KNOWLEDGE.ARTICLE)).size).toBe(slugs.length);
+    });
+
+    it("is the only source of knowledge routes in the article pages", () => {
+      const dir = path.resolve(__dirname, "../../app/knowledge");
+      const pages = readdirSync(dir, { withFileTypes: true })
+        .filter((entry) => entry.isDirectory())
+        .map((entry) => path.join(dir, entry.name, "page.tsx"))
+        .concat(path.join(dir, "page.tsx"));
+
+      for (const page of pages) {
+        expect(readFileSync(page, "utf8")).not.toContain('"/knowledge');
+      }
     });
   });
 });

--- a/app/knowledge/ai-grant-evaluation/page.tsx
+++ b/app/knowledge/ai-grant-evaluation/page.tsx
@@ -6,12 +6,13 @@ import { ArticlePublishedDate } from "@/components/Knowledge/ArticlePublishedDat
 import { ArticleJsonLd } from "@/components/Seo/ArticleJsonLd";
 import { BreadcrumbJsonLd } from "@/components/Seo/BreadcrumbJsonLd";
 import { customMetadata } from "@/utilities/meta";
+import { PAGES } from "@/utilities/pages";
 
 export const metadata: Metadata = customMetadata({
   title: "AI-Assisted Grant Evaluation at Scale",
   description:
     "Learn how AI-assisted evaluation helps grant programs process hundreds of applications without sacrificing review quality. Explore practical approaches to scaling.",
-  path: "/knowledge/ai-grant-evaluation",
+  path: PAGES.KNOWLEDGE.ARTICLE("ai-grant-evaluation"),
   ogType: "article",
 });
 
@@ -23,21 +24,27 @@ export default function AiGrantEvaluationPage() {
       <Breadcrumbs
         items={[
           { label: "Home", href: "/" },
-          { label: "Knowledge", href: "/knowledge" },
-          { label: "AI-Assisted Grant Evaluation", href: "/knowledge/ai-grant-evaluation" },
+          { label: "Knowledge", href: PAGES.KNOWLEDGE.ROOT },
+          {
+            label: "AI-Assisted Grant Evaluation",
+            href: PAGES.KNOWLEDGE.ARTICLE("ai-grant-evaluation"),
+          },
         ]}
       />
       <ArticleJsonLd
         title="AI-Assisted Grant Evaluation at Scale"
         description="Learn how AI-assisted evaluation helps grant programs process hundreds of applications without sacrificing review quality. Explore practical approaches to scaling."
-        url="/knowledge/ai-grant-evaluation"
+        url={PAGES.KNOWLEDGE.ARTICLE("ai-grant-evaluation")}
         datePublished={PUBLISHED_AT}
       />
       <BreadcrumbJsonLd
         items={[
           { name: "Home", url: "/" },
-          { name: "Knowledge", url: "/knowledge" },
-          { name: "AI-Assisted Grant Evaluation", url: "/knowledge/ai-grant-evaluation" },
+          { name: "Knowledge", url: PAGES.KNOWLEDGE.ROOT },
+          {
+            name: "AI-Assisted Grant Evaluation",
+            url: PAGES.KNOWLEDGE.ARTICLE("ai-grant-evaluation"),
+          },
         ]}
       />
       <article className="space-y-8">
@@ -98,25 +105,25 @@ export default function AiGrantEvaluationPage() {
           <h2 className="text-xl font-semibold">Related articles</h2>
           <div className="space-y-1">
             <Link
-              href="/knowledge/grant-lifecycle"
+              href={PAGES.KNOWLEDGE.ARTICLE("grant-lifecycle")}
               className="block text-blue-600 hover:underline dark:text-blue-400"
             >
               → The grant lifecycle
             </Link>
             <Link
-              href="/knowledge/grant-accountability"
+              href={PAGES.KNOWLEDGE.ARTICLE("grant-accountability")}
               className="block text-blue-600 hover:underline dark:text-blue-400"
             >
               → Grant accountability
             </Link>
             <Link
-              href="/knowledge/dao-grant-milestones"
+              href={PAGES.KNOWLEDGE.ARTICLE("dao-grant-milestones")}
               className="block text-blue-600 hover:underline dark:text-blue-400"
             >
               → DAO grant milestones
             </Link>
             <Link
-              href="/knowledge/why-grant-programs-fail"
+              href={PAGES.KNOWLEDGE.ARTICLE("why-grant-programs-fail")}
               className="block text-blue-600 hover:underline dark:text-blue-400"
             >
               → Why grant programs fail

--- a/app/knowledge/dao-grant-milestones/page.tsx
+++ b/app/knowledge/dao-grant-milestones/page.tsx
@@ -6,12 +6,13 @@ import { ArticlePublishedDate } from "@/components/Knowledge/ArticlePublishedDat
 import { ArticleJsonLd } from "@/components/Seo/ArticleJsonLd";
 import { BreadcrumbJsonLd } from "@/components/Seo/BreadcrumbJsonLd";
 import { customMetadata } from "@/utilities/meta";
+import { PAGES } from "@/utilities/pages";
 
 export const metadata: Metadata = customMetadata({
   title: "How DAOs Track Grant Milestones",
   description:
     "Explore how DAOs define, track, and evaluate grant milestones. Compare approaches from spreadsheets to modular platforms and learn the tradeoffs of each method.",
-  path: "/knowledge/dao-grant-milestones",
+  path: PAGES.KNOWLEDGE.ARTICLE("dao-grant-milestones"),
   ogType: "article",
 });
 
@@ -23,21 +24,21 @@ export default function DaoGrantMilestonesPage() {
       <Breadcrumbs
         items={[
           { label: "Home", href: "/" },
-          { label: "Knowledge", href: "/knowledge" },
-          { label: "DAO Grant Milestones", href: "/knowledge/dao-grant-milestones" },
+          { label: "Knowledge", href: PAGES.KNOWLEDGE.ROOT },
+          { label: "DAO Grant Milestones", href: PAGES.KNOWLEDGE.ARTICLE("dao-grant-milestones") },
         ]}
       />
       <ArticleJsonLd
         title="How DAOs Track Grant Milestones"
         description="Explore how DAOs define, track, and evaluate grant milestones. Compare approaches from spreadsheets to modular platforms and learn the tradeoffs of each method."
-        url="/knowledge/dao-grant-milestones"
+        url={PAGES.KNOWLEDGE.ARTICLE("dao-grant-milestones")}
         datePublished={PUBLISHED_AT}
       />
       <BreadcrumbJsonLd
         items={[
           { name: "Home", url: "/" },
-          { name: "Knowledge", url: "/knowledge" },
-          { name: "DAO Grant Milestones", url: "/knowledge/dao-grant-milestones" },
+          { name: "Knowledge", url: PAGES.KNOWLEDGE.ROOT },
+          { name: "DAO Grant Milestones", url: PAGES.KNOWLEDGE.ARTICLE("dao-grant-milestones") },
         ]}
       />
       <article className="space-y-8">
@@ -116,31 +117,31 @@ export default function DaoGrantMilestonesPage() {
           <h2 className="text-xl font-semibold">Related articles</h2>
           <div className="space-y-1">
             <Link
-              href="/knowledge/ai-grant-evaluation"
+              href={PAGES.KNOWLEDGE.ARTICLE("ai-grant-evaluation")}
               className="block text-blue-600 hover:underline dark:text-blue-400"
             >
               → AI-assisted grant evaluation
             </Link>
             <Link
-              href="/knowledge/milestones-vs-impact"
+              href={PAGES.KNOWLEDGE.ARTICLE("milestones-vs-impact")}
               className="block text-blue-600 hover:underline dark:text-blue-400"
             >
               → Milestones vs impact
             </Link>
             <Link
-              href="/knowledge/grant-lifecycle"
+              href={PAGES.KNOWLEDGE.ARTICLE("grant-lifecycle")}
               className="block text-blue-600 hover:underline dark:text-blue-400"
             >
               → The grant lifecycle
             </Link>
             <Link
-              href="/knowledge/manual-vs-platform-grant-tracking"
+              href={PAGES.KNOWLEDGE.ARTICLE("manual-vs-platform-grant-tracking")}
               className="block text-blue-600 hover:underline dark:text-blue-400"
             >
               → Manual vs platform grant tracking
             </Link>
             <Link
-              href="/knowledge/grant-accountability"
+              href={PAGES.KNOWLEDGE.ARTICLE("grant-accountability")}
               className="block text-blue-600 hover:underline dark:text-blue-400"
             >
               → Grant accountability

--- a/app/knowledge/funding-distribution-mechanisms/page.tsx
+++ b/app/knowledge/funding-distribution-mechanisms/page.tsx
@@ -6,6 +6,7 @@ import { ArticlePublishedDate } from "@/components/Knowledge/ArticlePublishedDat
 import { ArticleJsonLd } from "@/components/Seo/ArticleJsonLd";
 import { BreadcrumbJsonLd } from "@/components/Seo/BreadcrumbJsonLd";
 import { customMetadata } from "@/utilities/meta";
+import { PAGES } from "@/utilities/pages";
 
 const title = "Grant Funding Distribution Mechanisms Explained";
 const description =
@@ -14,7 +15,7 @@ const description =
 export const metadata: Metadata = customMetadata({
   title,
   description,
-  path: "/knowledge/funding-distribution-mechanisms",
+  path: PAGES.KNOWLEDGE.ARTICLE("funding-distribution-mechanisms"),
   ogType: "article",
 });
 
@@ -26,26 +27,26 @@ export default function FundingDistributionMechanismsPage() {
       <Breadcrumbs
         items={[
           { label: "Home", href: "/" },
-          { label: "Knowledge", href: "/knowledge" },
+          { label: "Knowledge", href: PAGES.KNOWLEDGE.ROOT },
           {
             label: "Funding Distribution Mechanisms",
-            href: "/knowledge/funding-distribution-mechanisms",
+            href: PAGES.KNOWLEDGE.ARTICLE("funding-distribution-mechanisms"),
           },
         ]}
       />
       <ArticleJsonLd
         title={title}
         description={description}
-        url="/knowledge/funding-distribution-mechanisms"
+        url={PAGES.KNOWLEDGE.ARTICLE("funding-distribution-mechanisms")}
         datePublished={PUBLISHED_AT}
       />
       <BreadcrumbJsonLd
         items={[
           { name: "Home", url: "/" },
-          { name: "Knowledge", url: "/knowledge" },
+          { name: "Knowledge", url: PAGES.KNOWLEDGE.ROOT },
           {
             name: "Funding Distribution Mechanisms",
-            url: "/knowledge/funding-distribution-mechanisms",
+            url: PAGES.KNOWLEDGE.ARTICLE("funding-distribution-mechanisms"),
           },
         ]}
       />
@@ -110,19 +111,19 @@ export default function FundingDistributionMechanismsPage() {
           <h2 className="text-xl font-semibold">Related articles</h2>
           <div className="space-y-1">
             <Link
-              href="/knowledge/grant-lifecycle"
+              href={PAGES.KNOWLEDGE.ARTICLE("grant-lifecycle")}
               className="block text-blue-600 hover:underline dark:text-blue-400"
             >
               → The grant lifecycle
             </Link>
             <Link
-              href="/knowledge/grant-fund-disbursement"
+              href={PAGES.KNOWLEDGE.ARTICLE("grant-fund-disbursement")}
               className="block text-blue-600 hover:underline dark:text-blue-400"
             >
               → Grant fund disbursement
             </Link>
             <Link
-              href="/knowledge/whitelabel-funding-platforms"
+              href={PAGES.KNOWLEDGE.ARTICLE("whitelabel-funding-platforms")}
               className="block text-blue-600 hover:underline dark:text-blue-400"
             >
               → Whitelabel funding platforms

--- a/app/knowledge/grant-accountability/page.tsx
+++ b/app/knowledge/grant-accountability/page.tsx
@@ -6,12 +6,13 @@ import { ArticlePublishedDate } from "@/components/Knowledge/ArticlePublishedDat
 import { ArticleJsonLd } from "@/components/Seo/ArticleJsonLd";
 import { BreadcrumbJsonLd } from "@/components/Seo/BreadcrumbJsonLd";
 import { customMetadata } from "@/utilities/meta";
+import { PAGES } from "@/utilities/pages";
 
 export const metadata: Metadata = customMetadata({
   title: "What Is Grant Accountability in Open Funding?",
   description:
     "Grant accountability turns funding promises into persistent execution history. Discover how to track funded projects and improve capital allocation over time.",
-  path: "/knowledge/grant-accountability",
+  path: PAGES.KNOWLEDGE.ARTICLE("grant-accountability"),
   ogType: "article",
 });
 
@@ -23,21 +24,21 @@ export default function GrantAccountabilityPage() {
       <Breadcrumbs
         items={[
           { label: "Home", href: "/" },
-          { label: "Knowledge", href: "/knowledge" },
-          { label: "Grant Accountability", href: "/knowledge/grant-accountability" },
+          { label: "Knowledge", href: PAGES.KNOWLEDGE.ROOT },
+          { label: "Grant Accountability", href: PAGES.KNOWLEDGE.ARTICLE("grant-accountability") },
         ]}
       />
       <ArticleJsonLd
         title="What Is Grant Accountability in Open Funding?"
         description="Grant accountability turns funding promises into persistent execution history. Discover how to track funded projects and improve capital allocation over time."
-        url="/knowledge/grant-accountability"
+        url={PAGES.KNOWLEDGE.ARTICLE("grant-accountability")}
         datePublished={PUBLISHED_AT}
       />
       <BreadcrumbJsonLd
         items={[
           { name: "Home", url: "/" },
-          { name: "Knowledge", url: "/knowledge" },
-          { name: "Grant Accountability", url: "/knowledge/grant-accountability" },
+          { name: "Knowledge", url: PAGES.KNOWLEDGE.ROOT },
+          { name: "Grant Accountability", url: PAGES.KNOWLEDGE.ARTICLE("grant-accountability") },
         ]}
       />
       <article className="space-y-8">
@@ -105,37 +106,37 @@ export default function GrantAccountabilityPage() {
           <h2 className="text-xl font-semibold">Related articles</h2>
           <div className="space-y-1">
             <Link
-              href="/knowledge/why-grant-programs-fail"
+              href={PAGES.KNOWLEDGE.ARTICLE("why-grant-programs-fail")}
               className="block text-blue-600 hover:underline dark:text-blue-400"
             >
               → Why grant programs fail
             </Link>
             <Link
-              href="/knowledge/grant-lifecycle"
+              href={PAGES.KNOWLEDGE.ARTICLE("grant-lifecycle")}
               className="block text-blue-600 hover:underline dark:text-blue-400"
             >
               → The grant lifecycle
             </Link>
             <Link
-              href="/knowledge/impact-measurement"
+              href={PAGES.KNOWLEDGE.ARTICLE("impact-measurement")}
               className="block text-blue-600 hover:underline dark:text-blue-400"
             >
               → Impact measurement
             </Link>
             <Link
-              href="/knowledge/project-registry"
+              href={PAGES.KNOWLEDGE.ARTICLE("project-registry")}
               className="block text-blue-600 hover:underline dark:text-blue-400"
             >
               → Public project registries
             </Link>
             <Link
-              href="/knowledge/grant-document-signing"
+              href={PAGES.KNOWLEDGE.ARTICLE("grant-document-signing")}
               className="block text-blue-600 hover:underline dark:text-blue-400"
             >
               → Document signing in grants
             </Link>
             <Link
-              href="/knowledge/funding-distribution-mechanisms"
+              href={PAGES.KNOWLEDGE.ARTICLE("funding-distribution-mechanisms")}
               className="block text-blue-600 hover:underline dark:text-blue-400"
             >
               → Funding distribution mechanisms

--- a/app/knowledge/grant-document-signing/page.tsx
+++ b/app/knowledge/grant-document-signing/page.tsx
@@ -6,12 +6,13 @@ import { ArticlePublishedDate } from "@/components/Knowledge/ArticlePublishedDat
 import { ArticleJsonLd } from "@/components/Seo/ArticleJsonLd";
 import { BreadcrumbJsonLd } from "@/components/Seo/BreadcrumbJsonLd";
 import { customMetadata } from "@/utilities/meta";
+import { PAGES } from "@/utilities/pages";
 
 export const metadata: Metadata = customMetadata({
   title: "Document Signing in Grant Programs",
   description:
     "Understand why grant agreements must be tracked as part of the funding workflow. Learn how integrated document signing prevents operational chaos and payment delays.",
-  path: "/knowledge/grant-document-signing",
+  path: PAGES.KNOWLEDGE.ARTICLE("grant-document-signing"),
   ogType: "article",
 });
 
@@ -23,21 +24,21 @@ export default function GrantDocumentSigningPage() {
       <Breadcrumbs
         items={[
           { label: "Home", href: "/" },
-          { label: "Knowledge", href: "/knowledge" },
-          { label: "Document Signing", href: "/knowledge/grant-document-signing" },
+          { label: "Knowledge", href: PAGES.KNOWLEDGE.ROOT },
+          { label: "Document Signing", href: PAGES.KNOWLEDGE.ARTICLE("grant-document-signing") },
         ]}
       />
       <ArticleJsonLd
         title="Document Signing in Grant Programs"
         description="Understand why grant agreements must be tracked as part of the funding workflow. Learn how integrated document signing prevents operational chaos and payment delays."
-        url="/knowledge/grant-document-signing"
+        url={PAGES.KNOWLEDGE.ARTICLE("grant-document-signing")}
         datePublished={PUBLISHED_AT}
       />
       <BreadcrumbJsonLd
         items={[
           { name: "Home", url: "/" },
-          { name: "Knowledge", url: "/knowledge" },
-          { name: "Document Signing", url: "/knowledge/grant-document-signing" },
+          { name: "Knowledge", url: PAGES.KNOWLEDGE.ROOT },
+          { name: "Document Signing", url: PAGES.KNOWLEDGE.ARTICLE("grant-document-signing") },
         ]}
       />
       <article className="space-y-8">
@@ -87,25 +88,25 @@ export default function GrantDocumentSigningPage() {
           <h2 className="text-xl font-semibold">Related articles</h2>
           <div className="space-y-1">
             <Link
-              href="/knowledge/grant-lifecycle"
+              href={PAGES.KNOWLEDGE.ARTICLE("grant-lifecycle")}
               className="block text-blue-600 hover:underline dark:text-blue-400"
             >
               → The grant lifecycle
             </Link>
             <Link
-              href="/knowledge/grant-accountability"
+              href={PAGES.KNOWLEDGE.ARTICLE("grant-accountability")}
               className="block text-blue-600 hover:underline dark:text-blue-400"
             >
               → Grant accountability
             </Link>
             <Link
-              href="/knowledge/grant-kyc"
+              href={PAGES.KNOWLEDGE.ARTICLE("grant-kyc")}
               className="block text-blue-600 hover:underline dark:text-blue-400"
             >
               → KYC in grant programs
             </Link>
             <Link
-              href="/knowledge/grant-fund-disbursement"
+              href={PAGES.KNOWLEDGE.ARTICLE("grant-fund-disbursement")}
               className="block text-blue-600 hover:underline dark:text-blue-400"
             >
               → Grant fund disbursement

--- a/app/knowledge/grant-fund-disbursement/page.tsx
+++ b/app/knowledge/grant-fund-disbursement/page.tsx
@@ -6,12 +6,13 @@ import { ArticlePublishedDate } from "@/components/Knowledge/ArticlePublishedDat
 import { ArticleJsonLd } from "@/components/Seo/ArticleJsonLd";
 import { BreadcrumbJsonLd } from "@/components/Seo/BreadcrumbJsonLd";
 import { customMetadata } from "@/utilities/meta";
+import { PAGES } from "@/utilities/pages";
 
 export const metadata: Metadata = customMetadata({
   title: "Grant Fund Disbursement Coordination",
   description:
     "Learn how grant payments are safely triggered once KYC, signing, and approvals are complete. Explore best practices for coordinating fund disbursement at scale.",
-  path: "/knowledge/grant-fund-disbursement",
+  path: PAGES.KNOWLEDGE.ARTICLE("grant-fund-disbursement"),
   ogType: "article",
 });
 
@@ -23,21 +24,21 @@ export default function GrantFundDisbursementPage() {
       <Breadcrumbs
         items={[
           { label: "Home", href: "/" },
-          { label: "Knowledge", href: "/knowledge" },
-          { label: "Fund Disbursement", href: "/knowledge/grant-fund-disbursement" },
+          { label: "Knowledge", href: PAGES.KNOWLEDGE.ROOT },
+          { label: "Fund Disbursement", href: PAGES.KNOWLEDGE.ARTICLE("grant-fund-disbursement") },
         ]}
       />
       <ArticleJsonLd
         title="Grant Fund Disbursement Coordination"
         description="Learn how grant payments are safely triggered once KYC, signing, and approvals are complete. Explore best practices for coordinating fund disbursement at scale."
-        url="/knowledge/grant-fund-disbursement"
+        url={PAGES.KNOWLEDGE.ARTICLE("grant-fund-disbursement")}
         datePublished={PUBLISHED_AT}
       />
       <BreadcrumbJsonLd
         items={[
           { name: "Home", url: "/" },
-          { name: "Knowledge", url: "/knowledge" },
-          { name: "Fund Disbursement", url: "/knowledge/grant-fund-disbursement" },
+          { name: "Knowledge", url: PAGES.KNOWLEDGE.ROOT },
+          { name: "Fund Disbursement", url: PAGES.KNOWLEDGE.ARTICLE("grant-fund-disbursement") },
         ]}
       />
       <article className="space-y-8">
@@ -90,25 +91,25 @@ export default function GrantFundDisbursementPage() {
           <h2 className="text-xl font-semibold">Related articles</h2>
           <div className="space-y-1">
             <Link
-              href="/knowledge/grant-kyc"
+              href={PAGES.KNOWLEDGE.ARTICLE("grant-kyc")}
               className="block text-blue-600 hover:underline dark:text-blue-400"
             >
               → KYC in grant programs
             </Link>
             <Link
-              href="/knowledge/grant-lifecycle"
+              href={PAGES.KNOWLEDGE.ARTICLE("grant-lifecycle")}
               className="block text-blue-600 hover:underline dark:text-blue-400"
             >
               → The grant lifecycle
             </Link>
             <Link
-              href="/knowledge/grant-document-signing"
+              href={PAGES.KNOWLEDGE.ARTICLE("grant-document-signing")}
               className="block text-blue-600 hover:underline dark:text-blue-400"
             >
               → Document signing in grants
             </Link>
             <Link
-              href="/knowledge/grant-accountability"
+              href={PAGES.KNOWLEDGE.ARTICLE("grant-accountability")}
               className="block text-blue-600 hover:underline dark:text-blue-400"
             >
               → Grant accountability

--- a/app/knowledge/grant-kyc/page.tsx
+++ b/app/knowledge/grant-kyc/page.tsx
@@ -6,12 +6,13 @@ import { ArticlePublishedDate } from "@/components/Knowledge/ArticlePublishedDat
 import { ArticleJsonLd } from "@/components/Seo/ArticleJsonLd";
 import { BreadcrumbJsonLd } from "@/components/Seo/BreadcrumbJsonLd";
 import { customMetadata } from "@/utilities/meta";
+import { PAGES } from "@/utilities/pages";
 
 export const metadata: Metadata = customMetadata({
   title: "KYC in Grant and Funding Programs",
   description:
     "Learn how identity verification integrates into grant workflows without slowing down funding. Explore KYC best practices for compliance and operational efficiency.",
-  path: "/knowledge/grant-kyc",
+  path: PAGES.KNOWLEDGE.ARTICLE("grant-kyc"),
   ogType: "article",
 });
 
@@ -23,21 +24,21 @@ export default function GrantKycPage() {
       <Breadcrumbs
         items={[
           { label: "Home", href: "/" },
-          { label: "Knowledge", href: "/knowledge" },
-          { label: "KYC in Grant Programs", href: "/knowledge/grant-kyc" },
+          { label: "Knowledge", href: PAGES.KNOWLEDGE.ROOT },
+          { label: "KYC in Grant Programs", href: PAGES.KNOWLEDGE.ARTICLE("grant-kyc") },
         ]}
       />
       <ArticleJsonLd
         title="KYC in Grant and Funding Programs"
         description="Learn how identity verification integrates into grant workflows without slowing down funding. Explore KYC best practices for compliance and operational efficiency."
-        url="/knowledge/grant-kyc"
+        url={PAGES.KNOWLEDGE.ARTICLE("grant-kyc")}
         datePublished={PUBLISHED_AT}
       />
       <BreadcrumbJsonLd
         items={[
           { name: "Home", url: "/" },
-          { name: "Knowledge", url: "/knowledge" },
-          { name: "KYC in Grant Programs", url: "/knowledge/grant-kyc" },
+          { name: "Knowledge", url: PAGES.KNOWLEDGE.ROOT },
+          { name: "KYC in Grant Programs", url: PAGES.KNOWLEDGE.ARTICLE("grant-kyc") },
         ]}
       />
       <article className="space-y-8">
@@ -88,25 +89,25 @@ export default function GrantKycPage() {
           <h2 className="text-xl font-semibold">Related articles</h2>
           <div className="space-y-1">
             <Link
-              href="/knowledge/grant-lifecycle"
+              href={PAGES.KNOWLEDGE.ARTICLE("grant-lifecycle")}
               className="block text-blue-600 hover:underline dark:text-blue-400"
             >
               → The grant lifecycle
             </Link>
             <Link
-              href="/knowledge/grant-fund-disbursement"
+              href={PAGES.KNOWLEDGE.ARTICLE("grant-fund-disbursement")}
               className="block text-blue-600 hover:underline dark:text-blue-400"
             >
               → Grant fund disbursement
             </Link>
             <Link
-              href="/knowledge/grant-document-signing"
+              href={PAGES.KNOWLEDGE.ARTICLE("grant-document-signing")}
               className="block text-blue-600 hover:underline dark:text-blue-400"
             >
               → Document signing in grants
             </Link>
             <Link
-              href="/knowledge/grant-accountability"
+              href={PAGES.KNOWLEDGE.ARTICLE("grant-accountability")}
               className="block text-blue-600 hover:underline dark:text-blue-400"
             >
               → Grant accountability

--- a/app/knowledge/grant-lifecycle/page.tsx
+++ b/app/knowledge/grant-lifecycle/page.tsx
@@ -7,12 +7,13 @@ import { ArticleJsonLd } from "@/components/Seo/ArticleJsonLd";
 import { BreadcrumbJsonLd } from "@/components/Seo/BreadcrumbJsonLd";
 import { HowToJsonLd } from "@/components/Seo/HowToJsonLd";
 import { customMetadata } from "@/utilities/meta";
+import { PAGES } from "@/utilities/pages";
 
 export const metadata: Metadata = customMetadata({
   title: "The Grant Lifecycle: From Proposal to Verified Impact",
   description:
     "Follow the complete grant process from proposal submission to verified impact. Learn the 10 stages every funding program needs to track and coordinate.",
-  path: "/knowledge/grant-lifecycle",
+  path: PAGES.KNOWLEDGE.ARTICLE("grant-lifecycle"),
   ogType: "article",
 });
 
@@ -24,21 +25,21 @@ export default function GrantLifecyclePage() {
       <Breadcrumbs
         items={[
           { label: "Home", href: "/" },
-          { label: "Knowledge", href: "/knowledge" },
-          { label: "The Grant Lifecycle", href: "/knowledge/grant-lifecycle" },
+          { label: "Knowledge", href: PAGES.KNOWLEDGE.ROOT },
+          { label: "The Grant Lifecycle", href: PAGES.KNOWLEDGE.ARTICLE("grant-lifecycle") },
         ]}
       />
       <ArticleJsonLd
         title="The Grant Lifecycle: From Proposal to Verified Impact"
         description="Follow the complete grant process from proposal submission to verified impact. Learn the 10 stages every funding program needs to track and coordinate."
-        url="/knowledge/grant-lifecycle"
+        url={PAGES.KNOWLEDGE.ARTICLE("grant-lifecycle")}
         datePublished={PUBLISHED_AT}
       />
       <BreadcrumbJsonLd
         items={[
           { name: "Home", url: "/" },
-          { name: "Knowledge", url: "/knowledge" },
-          { name: "The Grant Lifecycle", url: "/knowledge/grant-lifecycle" },
+          { name: "Knowledge", url: PAGES.KNOWLEDGE.ROOT },
+          { name: "The Grant Lifecycle", url: PAGES.KNOWLEDGE.ARTICLE("grant-lifecycle") },
         ]}
       />
       <HowToJsonLd
@@ -163,7 +164,7 @@ export default function GrantLifecyclePage() {
             </p>
             <p>
               <Link
-                href="/knowledge/ai-grant-evaluation"
+                href={PAGES.KNOWLEDGE.ARTICLE("ai-grant-evaluation")}
                 className="text-blue-600 hover:underline dark:text-blue-400"
               >
                 → Related: AI-assisted grant evaluation
@@ -203,7 +204,7 @@ export default function GrantLifecyclePage() {
             </p>
             <p>
               <Link
-                href="/knowledge/grant-kyc"
+                href={PAGES.KNOWLEDGE.ARTICLE("grant-kyc")}
                 className="text-blue-600 hover:underline dark:text-blue-400"
               >
                 → Related: KYC in grant programs
@@ -232,7 +233,7 @@ export default function GrantLifecyclePage() {
             </p>
             <p>
               <Link
-                href="/knowledge/grant-document-signing"
+                href={PAGES.KNOWLEDGE.ARTICLE("grant-document-signing")}
                 className="text-blue-600 hover:underline dark:text-blue-400"
               >
                 → Related: Document signing in grants
@@ -259,7 +260,7 @@ export default function GrantLifecyclePage() {
             </p>
             <p>
               <Link
-                href="/knowledge/grant-fund-disbursement"
+                href={PAGES.KNOWLEDGE.ARTICLE("grant-fund-disbursement")}
                 className="text-blue-600 hover:underline dark:text-blue-400"
               >
                 → Related: Grant fund disbursement
@@ -282,7 +283,7 @@ export default function GrantLifecyclePage() {
             </p>
             <p>
               <Link
-                href="/knowledge/dao-grant-milestones"
+                href={PAGES.KNOWLEDGE.ARTICLE("dao-grant-milestones")}
                 className="text-blue-600 hover:underline dark:text-blue-400"
               >
                 → Related: DAO grant milestones
@@ -307,7 +308,7 @@ export default function GrantLifecyclePage() {
             </p>
             <p>
               <Link
-                href="/knowledge/project-registry"
+                href={PAGES.KNOWLEDGE.ARTICLE("project-registry")}
                 className="text-blue-600 hover:underline dark:text-blue-400"
               >
                 → Related: Public project registries
@@ -332,7 +333,7 @@ export default function GrantLifecyclePage() {
             </p>
             <p>
               <Link
-                href="/knowledge/impact-measurement"
+                href={PAGES.KNOWLEDGE.ARTICLE("impact-measurement")}
                 className="text-blue-600 hover:underline dark:text-blue-400"
               >
                 → Related: Impact measurement
@@ -355,13 +356,13 @@ export default function GrantLifecyclePage() {
             </p>
             <div className="space-y-1">
               <Link
-                href="/knowledge/onchain-reputation"
+                href={PAGES.KNOWLEDGE.ARTICLE("onchain-reputation")}
                 className="block text-blue-600 hover:underline dark:text-blue-400"
               >
                 → Related: Onchain reputation
               </Link>
               <Link
-                href="/knowledge/reputation-compounding"
+                href={PAGES.KNOWLEDGE.ARTICLE("reputation-compounding")}
                 className="block text-blue-600 hover:underline dark:text-blue-400"
               >
                 → Related: Reputation compounding
@@ -374,25 +375,25 @@ export default function GrantLifecyclePage() {
           <h2 className="text-xl font-semibold">Related articles</h2>
           <div className="space-y-1">
             <Link
-              href="/knowledge/grant-accountability"
+              href={PAGES.KNOWLEDGE.ARTICLE("grant-accountability")}
               className="block text-blue-600 hover:underline dark:text-blue-400"
             >
               → Grant accountability
             </Link>
             <Link
-              href="/knowledge/why-grant-programs-fail"
+              href={PAGES.KNOWLEDGE.ARTICLE("why-grant-programs-fail")}
               className="block text-blue-600 hover:underline dark:text-blue-400"
             >
               → Why grant programs fail
             </Link>
             <Link
-              href="/knowledge/milestones-vs-impact"
+              href={PAGES.KNOWLEDGE.ARTICLE("milestones-vs-impact")}
               className="block text-blue-600 hover:underline dark:text-blue-400"
             >
               → Milestones vs impact
             </Link>
             <Link
-              href="/knowledge/impact-verification"
+              href={PAGES.KNOWLEDGE.ARTICLE("impact-verification")}
               className="block text-blue-600 hover:underline dark:text-blue-400"
             >
               → Impact verification

--- a/app/knowledge/how-funders-use-project-profiles/page.tsx
+++ b/app/knowledge/how-funders-use-project-profiles/page.tsx
@@ -6,6 +6,7 @@ import { ArticlePublishedDate } from "@/components/Knowledge/ArticlePublishedDat
 import { ArticleJsonLd } from "@/components/Seo/ArticleJsonLd";
 import { BreadcrumbJsonLd } from "@/components/Seo/BreadcrumbJsonLd";
 import { customMetadata } from "@/utilities/meta";
+import { PAGES } from "@/utilities/pages";
 
 const title = "How Funders Use Project Profiles to Evaluate Work";
 const description =
@@ -14,7 +15,7 @@ const description =
 export const metadata: Metadata = customMetadata({
   title,
   description,
-  path: "/knowledge/how-funders-use-project-profiles",
+  path: PAGES.KNOWLEDGE.ARTICLE("how-funders-use-project-profiles"),
   ogType: "article",
 });
 
@@ -26,26 +27,26 @@ export default function HowFundersUseProjectProfilesPage() {
       <Breadcrumbs
         items={[
           { label: "Home", href: "/" },
-          { label: "Knowledge", href: "/knowledge" },
+          { label: "Knowledge", href: PAGES.KNOWLEDGE.ROOT },
           {
             label: "How Funders Use Project Profiles",
-            href: "/knowledge/how-funders-use-project-profiles",
+            href: PAGES.KNOWLEDGE.ARTICLE("how-funders-use-project-profiles"),
           },
         ]}
       />
       <ArticleJsonLd
         title={title}
         description={description}
-        url="/knowledge/how-funders-use-project-profiles"
+        url={PAGES.KNOWLEDGE.ARTICLE("how-funders-use-project-profiles")}
         datePublished={PUBLISHED_AT}
       />
       <BreadcrumbJsonLd
         items={[
           { name: "Home", url: "/" },
-          { name: "Knowledge", url: "/knowledge" },
+          { name: "Knowledge", url: PAGES.KNOWLEDGE.ROOT },
           {
             name: "How Funders Use Project Profiles",
-            url: "/knowledge/how-funders-use-project-profiles",
+            url: PAGES.KNOWLEDGE.ARTICLE("how-funders-use-project-profiles"),
           },
         ]}
       />
@@ -110,7 +111,7 @@ export default function HowFundersUseProjectProfilesPage() {
           </p>
           <p className="pt-2">
             <Link
-              href="/create-project-profile"
+              href={PAGES.CREATE_PROJECT_PROFILE}
               className="text-blue-600 hover:underline dark:text-blue-400 font-semibold"
             >
               → Create your project profile
@@ -122,19 +123,19 @@ export default function HowFundersUseProjectProfilesPage() {
           <h2 className="text-xl font-semibold">Related articles</h2>
           <div className="space-y-1">
             <Link
-              href="/knowledge/project-profiles"
+              href={PAGES.KNOWLEDGE.ARTICLE("project-profiles")}
               className="block text-blue-600 hover:underline dark:text-blue-400"
             >
               → What are project profiles?
             </Link>
             <Link
-              href="/knowledge/onchain-reputation"
+              href={PAGES.KNOWLEDGE.ARTICLE("onchain-reputation")}
               className="block text-blue-600 hover:underline dark:text-blue-400"
             >
               → What is onchain reputation?
             </Link>
             <Link
-              href="/knowledge/grant-accountability"
+              href={PAGES.KNOWLEDGE.ARTICLE("grant-accountability")}
               className="block text-blue-600 hover:underline dark:text-blue-400"
             >
               → Grant accountability

--- a/app/knowledge/impact-measurement/page.tsx
+++ b/app/knowledge/impact-measurement/page.tsx
@@ -6,12 +6,13 @@ import { ArticlePublishedDate } from "@/components/Knowledge/ArticlePublishedDat
 import { ArticleJsonLd } from "@/components/Seo/ArticleJsonLd";
 import { BreadcrumbJsonLd } from "@/components/Seo/BreadcrumbJsonLd";
 import { customMetadata } from "@/utilities/meta";
+import { PAGES } from "@/utilities/pages";
 
 export const metadata: Metadata = customMetadata({
   title: "Impact Measurement for Funded Projects",
   description:
     "Discover how funded work connects to verifiable outputs and outcomes. Learn practical approaches to measuring impact and improving capital allocation decisions.",
-  path: "/knowledge/impact-measurement",
+  path: PAGES.KNOWLEDGE.ARTICLE("impact-measurement"),
   ogType: "article",
 });
 
@@ -23,21 +24,21 @@ export default function ImpactMeasurementPage() {
       <Breadcrumbs
         items={[
           { label: "Home", href: "/" },
-          { label: "Knowledge", href: "/knowledge" },
-          { label: "Impact Measurement", href: "/knowledge/impact-measurement" },
+          { label: "Knowledge", href: PAGES.KNOWLEDGE.ROOT },
+          { label: "Impact Measurement", href: PAGES.KNOWLEDGE.ARTICLE("impact-measurement") },
         ]}
       />
       <ArticleJsonLd
         title="Impact Measurement for Funded Projects"
         description="Discover how funded work connects to verifiable outputs and outcomes. Learn practical approaches to measuring impact and improving capital allocation decisions."
-        url="/knowledge/impact-measurement"
+        url={PAGES.KNOWLEDGE.ARTICLE("impact-measurement")}
         datePublished={PUBLISHED_AT}
       />
       <BreadcrumbJsonLd
         items={[
           { name: "Home", url: "/" },
-          { name: "Knowledge", url: "/knowledge" },
-          { name: "Impact Measurement", url: "/knowledge/impact-measurement" },
+          { name: "Knowledge", url: PAGES.KNOWLEDGE.ROOT },
+          { name: "Impact Measurement", url: PAGES.KNOWLEDGE.ARTICLE("impact-measurement") },
         ]}
       />
       <article className="space-y-8">
@@ -94,25 +95,25 @@ export default function ImpactMeasurementPage() {
           <h2 className="text-xl font-semibold">Related articles</h2>
           <div className="space-y-1">
             <Link
-              href="/knowledge/milestones-vs-impact"
+              href={PAGES.KNOWLEDGE.ARTICLE("milestones-vs-impact")}
               className="block text-blue-600 hover:underline dark:text-blue-400"
             >
               → Milestones vs impact
             </Link>
             <Link
-              href="/knowledge/grant-lifecycle"
+              href={PAGES.KNOWLEDGE.ARTICLE("grant-lifecycle")}
               className="block text-blue-600 hover:underline dark:text-blue-400"
             >
               → The grant lifecycle
             </Link>
             <Link
-              href="/knowledge/impact-verification"
+              href={PAGES.KNOWLEDGE.ARTICLE("impact-verification")}
               className="block text-blue-600 hover:underline dark:text-blue-400"
             >
               → Impact verification
             </Link>
             <Link
-              href="/knowledge/grant-accountability"
+              href={PAGES.KNOWLEDGE.ARTICLE("grant-accountability")}
               className="block text-blue-600 hover:underline dark:text-blue-400"
             >
               → Grant accountability

--- a/app/knowledge/impact-verification/page.tsx
+++ b/app/knowledge/impact-verification/page.tsx
@@ -6,12 +6,13 @@ import { ArticlePublishedDate } from "@/components/Knowledge/ArticlePublishedDat
 import { ArticleJsonLd } from "@/components/Seo/ArticleJsonLd";
 import { BreadcrumbJsonLd } from "@/components/Seo/BreadcrumbJsonLd";
 import { customMetadata } from "@/utilities/meta";
+import { PAGES } from "@/utilities/pages";
 
 export const metadata: Metadata = customMetadata({
   title: "How to Verify Impact Without Centralized Auditors",
   description:
     "Learn how impact can be verified through transparent documentation, peer review, and public evidence instead of relying solely on centralized audits.",
-  path: "/knowledge/impact-verification",
+  path: PAGES.KNOWLEDGE.ARTICLE("impact-verification"),
   ogType: "article",
 });
 
@@ -23,21 +24,21 @@ export default function ImpactVerificationPage() {
       <Breadcrumbs
         items={[
           { label: "Home", href: "/" },
-          { label: "Knowledge", href: "/knowledge" },
-          { label: "Impact Verification", href: "/knowledge/impact-verification" },
+          { label: "Knowledge", href: PAGES.KNOWLEDGE.ROOT },
+          { label: "Impact Verification", href: PAGES.KNOWLEDGE.ARTICLE("impact-verification") },
         ]}
       />
       <ArticleJsonLd
         title="How to Verify Impact Without Centralized Auditors"
         description="Learn how impact can be verified through transparent documentation, peer review, and public evidence instead of relying solely on centralized audits."
-        url="/knowledge/impact-verification"
+        url={PAGES.KNOWLEDGE.ARTICLE("impact-verification")}
         datePublished={PUBLISHED_AT}
       />
       <BreadcrumbJsonLd
         items={[
           { name: "Home", url: "/" },
-          { name: "Knowledge", url: "/knowledge" },
-          { name: "Impact Verification", url: "/knowledge/impact-verification" },
+          { name: "Knowledge", url: PAGES.KNOWLEDGE.ROOT },
+          { name: "Impact Verification", url: PAGES.KNOWLEDGE.ARTICLE("impact-verification") },
         ]}
       />
       <article className="space-y-8">
@@ -85,25 +86,25 @@ export default function ImpactVerificationPage() {
           <h2 className="text-xl font-semibold">Related articles</h2>
           <div className="space-y-1">
             <Link
-              href="/knowledge/impact-measurement"
+              href={PAGES.KNOWLEDGE.ARTICLE("impact-measurement")}
               className="block text-blue-600 hover:underline dark:text-blue-400"
             >
               → Impact measurement
             </Link>
             <Link
-              href="/knowledge/milestones-vs-impact"
+              href={PAGES.KNOWLEDGE.ARTICLE("milestones-vs-impact")}
               className="block text-blue-600 hover:underline dark:text-blue-400"
             >
               → Milestones vs impact
             </Link>
             <Link
-              href="/knowledge/grant-accountability"
+              href={PAGES.KNOWLEDGE.ARTICLE("grant-accountability")}
               className="block text-blue-600 hover:underline dark:text-blue-400"
             >
               → Grant accountability
             </Link>
             <Link
-              href="/knowledge/grant-lifecycle"
+              href={PAGES.KNOWLEDGE.ARTICLE("grant-lifecycle")}
               className="block text-blue-600 hover:underline dark:text-blue-400"
             >
               → The grant lifecycle

--- a/app/knowledge/manual-vs-platform-grant-tracking/page.tsx
+++ b/app/knowledge/manual-vs-platform-grant-tracking/page.tsx
@@ -6,12 +6,13 @@ import { ArticlePublishedDate } from "@/components/Knowledge/ArticlePublishedDat
 import { ArticleJsonLd } from "@/components/Seo/ArticleJsonLd";
 import { BreadcrumbJsonLd } from "@/components/Seo/BreadcrumbJsonLd";
 import { customMetadata } from "@/utilities/meta";
+import { PAGES } from "@/utilities/pages";
 
 export const metadata: Metadata = customMetadata({
   title: "Manual vs Platform-Based Grant Tracking",
   description:
     "Compare spreadsheets and documents with dedicated funding platforms for grant tracking. Learn when manual tools break down and when structured platforms scale better.",
-  path: "/knowledge/manual-vs-platform-grant-tracking",
+  path: PAGES.KNOWLEDGE.ARTICLE("manual-vs-platform-grant-tracking"),
   ogType: "article",
 });
 
@@ -23,26 +24,26 @@ export default function ManualVsPlatformGrantTrackingPage() {
       <Breadcrumbs
         items={[
           { label: "Home", href: "/" },
-          { label: "Knowledge", href: "/knowledge" },
+          { label: "Knowledge", href: PAGES.KNOWLEDGE.ROOT },
           {
             label: "Manual vs Platform Grant Tracking",
-            href: "/knowledge/manual-vs-platform-grant-tracking",
+            href: PAGES.KNOWLEDGE.ARTICLE("manual-vs-platform-grant-tracking"),
           },
         ]}
       />
       <ArticleJsonLd
         title="Manual vs Platform-Based Grant Tracking"
         description="Compare spreadsheets and documents with dedicated funding platforms for grant tracking. Learn when manual tools break down and when structured platforms scale better."
-        url="/knowledge/manual-vs-platform-grant-tracking"
+        url={PAGES.KNOWLEDGE.ARTICLE("manual-vs-platform-grant-tracking")}
         datePublished={PUBLISHED_AT}
       />
       <BreadcrumbJsonLd
         items={[
           { name: "Home", url: "/" },
-          { name: "Knowledge", url: "/knowledge" },
+          { name: "Knowledge", url: PAGES.KNOWLEDGE.ROOT },
           {
             name: "Manual vs Platform Grant Tracking",
-            url: "/knowledge/manual-vs-platform-grant-tracking",
+            url: PAGES.KNOWLEDGE.ARTICLE("manual-vs-platform-grant-tracking"),
           },
         ]}
       />
@@ -90,25 +91,25 @@ export default function ManualVsPlatformGrantTrackingPage() {
           <h2 className="text-xl font-semibold">Related articles</h2>
           <div className="space-y-1">
             <Link
-              href="/knowledge/dao-grant-milestones"
+              href={PAGES.KNOWLEDGE.ARTICLE("dao-grant-milestones")}
               className="block text-blue-600 hover:underline dark:text-blue-400"
             >
               → DAO grant milestones
             </Link>
             <Link
-              href="/knowledge/grant-accountability"
+              href={PAGES.KNOWLEDGE.ARTICLE("grant-accountability")}
               className="block text-blue-600 hover:underline dark:text-blue-400"
             >
               → Grant accountability
             </Link>
             <Link
-              href="/knowledge/grant-lifecycle"
+              href={PAGES.KNOWLEDGE.ARTICLE("grant-lifecycle")}
               className="block text-blue-600 hover:underline dark:text-blue-400"
             >
               → The grant lifecycle
             </Link>
             <Link
-              href="/knowledge/why-grant-programs-fail"
+              href={PAGES.KNOWLEDGE.ARTICLE("why-grant-programs-fail")}
               className="block text-blue-600 hover:underline dark:text-blue-400"
             >
               → Why grant programs fail

--- a/app/knowledge/milestones-vs-impact/page.tsx
+++ b/app/knowledge/milestones-vs-impact/page.tsx
@@ -6,12 +6,13 @@ import { ArticlePublishedDate } from "@/components/Knowledge/ArticlePublishedDat
 import { ArticleJsonLd } from "@/components/Seo/ArticleJsonLd";
 import { BreadcrumbJsonLd } from "@/components/Seo/BreadcrumbJsonLd";
 import { customMetadata } from "@/utilities/meta";
+import { PAGES } from "@/utilities/pages";
 
 export const metadata: Metadata = customMetadata({
   title: "Grant Milestones vs Impact",
   description:
     "Milestones track work done while impact tracks change created. Learn why separating these concepts is critical for honest evaluation of funded projects.",
-  path: "/knowledge/milestones-vs-impact",
+  path: PAGES.KNOWLEDGE.ARTICLE("milestones-vs-impact"),
   ogType: "article",
 });
 
@@ -23,21 +24,21 @@ export default function MilestonesVsImpactPage() {
       <Breadcrumbs
         items={[
           { label: "Home", href: "/" },
-          { label: "Knowledge", href: "/knowledge" },
-          { label: "Milestones vs Impact", href: "/knowledge/milestones-vs-impact" },
+          { label: "Knowledge", href: PAGES.KNOWLEDGE.ROOT },
+          { label: "Milestones vs Impact", href: PAGES.KNOWLEDGE.ARTICLE("milestones-vs-impact") },
         ]}
       />
       <ArticleJsonLd
         title="Grant Milestones vs Impact"
         description="Milestones track work done while impact tracks change created. Learn why separating these concepts is critical for honest evaluation of funded projects."
-        url="/knowledge/milestones-vs-impact"
+        url={PAGES.KNOWLEDGE.ARTICLE("milestones-vs-impact")}
         datePublished={PUBLISHED_AT}
       />
       <BreadcrumbJsonLd
         items={[
           { name: "Home", url: "/" },
-          { name: "Knowledge", url: "/knowledge" },
-          { name: "Milestones vs Impact", url: "/knowledge/milestones-vs-impact" },
+          { name: "Knowledge", url: PAGES.KNOWLEDGE.ROOT },
+          { name: "Milestones vs Impact", url: PAGES.KNOWLEDGE.ARTICLE("milestones-vs-impact") },
         ]}
       />
       <article className="space-y-8">
@@ -91,31 +92,31 @@ export default function MilestonesVsImpactPage() {
           <h2 className="text-xl font-semibold">Related articles</h2>
           <div className="space-y-1">
             <Link
-              href="/knowledge/impact-measurement"
+              href={PAGES.KNOWLEDGE.ARTICLE("impact-measurement")}
               className="block text-blue-600 hover:underline dark:text-blue-400"
             >
               → Impact measurement
             </Link>
             <Link
-              href="/knowledge/impact-verification"
+              href={PAGES.KNOWLEDGE.ARTICLE("impact-verification")}
               className="block text-blue-600 hover:underline dark:text-blue-400"
             >
               → Impact verification
             </Link>
             <Link
-              href="/knowledge/dao-grant-milestones"
+              href={PAGES.KNOWLEDGE.ARTICLE("dao-grant-milestones")}
               className="block text-blue-600 hover:underline dark:text-blue-400"
             >
               → DAO grant milestones
             </Link>
             <Link
-              href="/knowledge/grant-lifecycle"
+              href={PAGES.KNOWLEDGE.ARTICLE("grant-lifecycle")}
               className="block text-blue-600 hover:underline dark:text-blue-400"
             >
               → The grant lifecycle
             </Link>
             <Link
-              href="/knowledge/grant-accountability"
+              href={PAGES.KNOWLEDGE.ARTICLE("grant-accountability")}
               className="block text-blue-600 hover:underline dark:text-blue-400"
             >
               → Grant accountability

--- a/app/knowledge/onchain-project-profiles/page.tsx
+++ b/app/knowledge/onchain-project-profiles/page.tsx
@@ -6,6 +6,7 @@ import { ArticlePublishedDate } from "@/components/Knowledge/ArticlePublishedDat
 import { ArticleJsonLd } from "@/components/Seo/ArticleJsonLd";
 import { BreadcrumbJsonLd } from "@/components/Seo/BreadcrumbJsonLd";
 import { customMetadata } from "@/utilities/meta";
+import { PAGES } from "@/utilities/pages";
 
 const title = "Onchain Project Profiles (Without Blockchain Complexity)";
 const description =
@@ -14,7 +15,7 @@ const description =
 export const metadata: Metadata = customMetadata({
   title,
   description,
-  path: "/knowledge/onchain-project-profiles",
+  path: PAGES.KNOWLEDGE.ARTICLE("onchain-project-profiles"),
   ogType: "article",
 });
 
@@ -26,21 +27,27 @@ export default function OnchainProjectProfilesPage() {
       <Breadcrumbs
         items={[
           { label: "Home", href: "/" },
-          { label: "Knowledge", href: "/knowledge" },
-          { label: "Onchain Project Profiles", href: "/knowledge/onchain-project-profiles" },
+          { label: "Knowledge", href: PAGES.KNOWLEDGE.ROOT },
+          {
+            label: "Onchain Project Profiles",
+            href: PAGES.KNOWLEDGE.ARTICLE("onchain-project-profiles"),
+          },
         ]}
       />
       <ArticleJsonLd
         title={title}
         description={description}
-        url="/knowledge/onchain-project-profiles"
+        url={PAGES.KNOWLEDGE.ARTICLE("onchain-project-profiles")}
         datePublished={PUBLISHED_AT}
       />
       <BreadcrumbJsonLd
         items={[
           { name: "Home", url: "/" },
-          { name: "Knowledge", url: "/knowledge" },
-          { name: "Onchain Project Profiles", url: "/knowledge/onchain-project-profiles" },
+          { name: "Knowledge", url: PAGES.KNOWLEDGE.ROOT },
+          {
+            name: "Onchain Project Profiles",
+            url: PAGES.KNOWLEDGE.ARTICLE("onchain-project-profiles"),
+          },
         ]}
       />
       <article className="space-y-8">
@@ -108,7 +115,7 @@ export default function OnchainProjectProfilesPage() {
           </p>
           <p className="pt-2">
             <Link
-              href="/create-project-profile"
+              href={PAGES.CREATE_PROJECT_PROFILE}
               className="text-blue-600 hover:underline dark:text-blue-400 font-semibold"
             >
               → Create your project profile
@@ -120,13 +127,13 @@ export default function OnchainProjectProfilesPage() {
           <h2 className="text-xl font-semibold">Related articles</h2>
           <div className="space-y-1">
             <Link
-              href="/knowledge/project-profiles"
+              href={PAGES.KNOWLEDGE.ARTICLE("project-profiles")}
               className="block text-blue-600 hover:underline dark:text-blue-400"
             >
               → What are project profiles?
             </Link>
             <Link
-              href="/knowledge/onchain-reputation"
+              href={PAGES.KNOWLEDGE.ARTICLE("onchain-reputation")}
               className="block text-blue-600 hover:underline dark:text-blue-400"
             >
               → What is onchain reputation?

--- a/app/knowledge/onchain-reputation/page.tsx
+++ b/app/knowledge/onchain-reputation/page.tsx
@@ -6,6 +6,7 @@ import { ArticlePublishedDate } from "@/components/Knowledge/ArticlePublishedDat
 import { ArticleJsonLd } from "@/components/Seo/ArticleJsonLd";
 import { BreadcrumbJsonLd } from "@/components/Seo/BreadcrumbJsonLd";
 import { customMetadata } from "@/utilities/meta";
+import { PAGES } from "@/utilities/pages";
 
 const title = "What Is Onchain Reputation in Open Funding?";
 const description =
@@ -14,7 +15,7 @@ const description =
 export const metadata: Metadata = customMetadata({
   title,
   description,
-  path: "/knowledge/onchain-reputation",
+  path: PAGES.KNOWLEDGE.ARTICLE("onchain-reputation"),
   ogType: "article",
 });
 
@@ -26,21 +27,21 @@ export default function OnchainReputationPage() {
       <Breadcrumbs
         items={[
           { label: "Home", href: "/" },
-          { label: "Knowledge", href: "/knowledge" },
-          { label: "Onchain Reputation", href: "/knowledge/onchain-reputation" },
+          { label: "Knowledge", href: PAGES.KNOWLEDGE.ROOT },
+          { label: "Onchain Reputation", href: PAGES.KNOWLEDGE.ARTICLE("onchain-reputation") },
         ]}
       />
       <ArticleJsonLd
         title={title}
         description={description}
-        url="/knowledge/onchain-reputation"
+        url={PAGES.KNOWLEDGE.ARTICLE("onchain-reputation")}
         datePublished={PUBLISHED_AT}
       />
       <BreadcrumbJsonLd
         items={[
           { name: "Home", url: "/" },
-          { name: "Knowledge", url: "/knowledge" },
-          { name: "Onchain Reputation", url: "/knowledge/onchain-reputation" },
+          { name: "Knowledge", url: PAGES.KNOWLEDGE.ROOT },
+          { name: "Onchain Reputation", url: PAGES.KNOWLEDGE.ARTICLE("onchain-reputation") },
         ]}
       />
       <article className="space-y-8">
@@ -150,25 +151,25 @@ export default function OnchainReputationPage() {
           <h2 className="text-xl font-semibold">Related articles</h2>
           <div className="space-y-1">
             <Link
-              href="/knowledge/project-profiles"
+              href={PAGES.KNOWLEDGE.ARTICLE("project-profiles")}
               className="block text-blue-600 hover:underline dark:text-blue-400"
             >
               → What are project profiles?
             </Link>
             <Link
-              href="/knowledge/reputation-compounding"
+              href={PAGES.KNOWLEDGE.ARTICLE("reputation-compounding")}
               className="block text-blue-600 hover:underline dark:text-blue-400"
             >
               → How reputation compounds in open funding
             </Link>
             <Link
-              href="/knowledge/project-reputation"
+              href={PAGES.KNOWLEDGE.ARTICLE("project-reputation")}
               className="block text-blue-600 hover:underline dark:text-blue-400"
             >
               → How projects build reputation through funding
             </Link>
             <Link
-              href="/knowledge/grant-accountability"
+              href={PAGES.KNOWLEDGE.ARTICLE("grant-accountability")}
               className="block text-blue-600 hover:underline dark:text-blue-400"
             >
               → Grant accountability

--- a/app/knowledge/page.tsx
+++ b/app/knowledge/page.tsx
@@ -15,8 +15,13 @@ export const metadata: Metadata = customMetadata({
   ogType: "website",
 });
 
+interface ArticleLinkProps {
+  slug: string;
+  children: ReactNode;
+}
+
 /** Shared markup for every article link in the index list. */
-function ArticleLink({ slug, children }: { slug: string; children: ReactNode }) {
+function ArticleLink({ slug, children }: ArticleLinkProps) {
   return (
     <p>
       <Link

--- a/app/knowledge/page.tsx
+++ b/app/knowledge/page.tsx
@@ -1,17 +1,33 @@
 import type { Metadata } from "next";
 import Link from "next/link";
+import type { ReactNode } from "react";
 import { Breadcrumbs } from "@/components/Breadcrumbs";
 import { BreadcrumbJsonLd } from "@/components/Seo/BreadcrumbJsonLd";
 import { CollectionPageJsonLd } from "@/components/Seo/CollectionPageJsonLd";
 import { customMetadata } from "@/utilities/meta";
+import { PAGES } from "@/utilities/pages";
 
 export const metadata: Metadata = customMetadata({
   title: "Grant Funding Knowledge Base",
   description:
     "A reference guide to modern funding systems. Learn about grant accountability, impact verification, onchain reputation, project profiles, and capital allocation.",
-  path: "/knowledge",
+  path: PAGES.KNOWLEDGE.ROOT,
   ogType: "website",
 });
+
+/** Shared markup for every article link in the index list. */
+function ArticleLink({ slug, children }: { slug: string; children: ReactNode }) {
+  return (
+    <p>
+      <Link
+        href={PAGES.KNOWLEDGE.ARTICLE(slug)}
+        className="text-blue-600 hover:underline dark:text-blue-400"
+      >
+        {children}
+      </Link>
+    </p>
+  );
+}
 
 export default function KnowledgePage() {
   return (
@@ -19,18 +35,18 @@ export default function KnowledgePage() {
       <Breadcrumbs
         items={[
           { label: "Home", href: "/" },
-          { label: "Knowledge", href: "/knowledge" },
+          { label: "Knowledge", href: PAGES.KNOWLEDGE.ROOT },
         ]}
       />
       <CollectionPageJsonLd
         name="Grant Funding Knowledge Base"
         description="A reference guide to modern funding systems. Learn about grant accountability, impact verification, onchain reputation, project profiles, and capital allocation."
-        url="/knowledge"
+        url={PAGES.KNOWLEDGE.ROOT}
       />
       <BreadcrumbJsonLd
         items={[
           { name: "Home", url: "/" },
-          { name: "Knowledge", url: "/knowledge" },
+          { name: "Knowledge", url: PAGES.KNOWLEDGE.ROOT },
         ]}
       />
       <article className="space-y-12">
@@ -90,14 +106,7 @@ export default function KnowledgePage() {
               How funded projects are tracked after money is disbursed, and why post-funding
               execution matters more than selection alone.
             </p>
-            <p>
-              <Link
-                href="/knowledge/grant-accountability"
-                className="text-blue-600 hover:underline dark:text-blue-400"
-              >
-                → Grant accountability
-              </Link>
-            </p>
+            <ArticleLink slug="grant-accountability">→ Grant accountability</ArticleLink>
           </div>
 
           <div className="space-y-4">
@@ -106,14 +115,7 @@ export default function KnowledgePage() {
               A structural analysis of why many funding programs struggle to produce consistent
               outcomes despite strong applicant pools.
             </p>
-            <p>
-              <Link
-                href="/knowledge/why-grant-programs-fail"
-                className="text-blue-600 hover:underline dark:text-blue-400"
-              >
-                → Why grant programs fail
-              </Link>
-            </p>
+            <ArticleLink slug="why-grant-programs-fail">→ Why grant programs fail</ArticleLink>
           </div>
 
           <div className="space-y-4">
@@ -122,14 +124,7 @@ export default function KnowledgePage() {
               A practical breakdown of how DAOs define, track, and evaluate grant milestones — and
               the tradeoffs of different approaches.
             </p>
-            <p>
-              <Link
-                href="/knowledge/dao-grant-milestones"
-                className="text-blue-600 hover:underline dark:text-blue-400"
-              >
-                → DAO grant milestones
-              </Link>
-            </p>
+            <ArticleLink slug="dao-grant-milestones">→ DAO grant milestones</ArticleLink>
           </div>
 
           <div className="space-y-4">
@@ -138,14 +133,7 @@ export default function KnowledgePage() {
               What reputation actually means in open systems, how it differs from tokens or
               identity, and why execution history matters.
             </p>
-            <p>
-              <Link
-                href="/knowledge/onchain-reputation"
-                className="text-blue-600 hover:underline dark:text-blue-400"
-              >
-                → Onchain reputation
-              </Link>
-            </p>
+            <ArticleLink slug="onchain-reputation">→ Onchain reputation</ArticleLink>
           </div>
 
           <div className="space-y-4">
@@ -154,14 +142,7 @@ export default function KnowledgePage() {
               How projects build credibility over time by documenting work, completing milestones,
               and creating verifiable records.
             </p>
-            <p>
-              <Link
-                href="/knowledge/project-reputation"
-                className="text-blue-600 hover:underline dark:text-blue-400"
-              >
-                → Project reputation
-              </Link>
-            </p>
+            <ArticleLink slug="project-reputation">→ Project reputation</ArticleLink>
           </div>
 
           <div className="space-y-4">
@@ -170,14 +151,7 @@ export default function KnowledgePage() {
               Why execution milestones and real-world impact must be treated as separate but related
               concepts.
             </p>
-            <p>
-              <Link
-                href="/knowledge/milestones-vs-impact"
-                className="text-blue-600 hover:underline dark:text-blue-400"
-              >
-                → Milestones vs impact
-              </Link>
-            </p>
+            <ArticleLink slug="milestones-vs-impact">→ Milestones vs impact</ArticleLink>
           </div>
 
           <div className="space-y-4">
@@ -186,14 +160,7 @@ export default function KnowledgePage() {
               How impact can be measured and verified without relying solely on centralized auditors
               or one-off reports.
             </p>
-            <p>
-              <Link
-                href="/knowledge/impact-verification"
-                className="text-blue-600 hover:underline dark:text-blue-400"
-              >
-                → Impact verification
-              </Link>
-            </p>
+            <ArticleLink slug="impact-verification">→ Impact verification</ArticleLink>
           </div>
 
           <div className="space-y-4">
@@ -202,14 +169,9 @@ export default function KnowledgePage() {
               A comparison of spreadsheets, documents, and dedicated funding platforms — and when
               each breaks down.
             </p>
-            <p>
-              <Link
-                href="/knowledge/manual-vs-platform-grant-tracking"
-                className="text-blue-600 hover:underline dark:text-blue-400"
-              >
-                → Manual vs platform tracking
-              </Link>
-            </p>
+            <ArticleLink slug="manual-vs-platform-grant-tracking">
+              → Manual vs platform tracking
+            </ArticleLink>
           </div>
 
           <div className="space-y-4">
@@ -218,14 +180,7 @@ export default function KnowledgePage() {
               Why reputation acts as cumulative memory in open funding systems, and how it improves
               decision-making over time.
             </p>
-            <p>
-              <Link
-                href="/knowledge/reputation-compounding"
-                className="text-blue-600 hover:underline dark:text-blue-400"
-              >
-                → Reputation compounding
-              </Link>
-            </p>
+            <ArticleLink slug="reputation-compounding">→ Reputation compounding</ArticleLink>
           </div>
 
           <div className="space-y-4">
@@ -234,14 +189,7 @@ export default function KnowledgePage() {
               A complete view of the grant process, from proposal to verified impact and long-term
               learning.
             </p>
-            <p>
-              <Link
-                href="/knowledge/grant-lifecycle"
-                className="text-blue-600 hover:underline dark:text-blue-400"
-              >
-                → Grant lifecycle
-              </Link>
-            </p>
+            <ArticleLink slug="grant-lifecycle">→ Grant lifecycle</ArticleLink>
           </div>
         </section>
 
@@ -257,7 +205,7 @@ export default function KnowledgePage() {
             <li>
               Start with the{" "}
               <Link
-                href="/knowledge/grant-lifecycle"
+                href={PAGES.KNOWLEDGE.ARTICLE("grant-lifecycle")}
                 className="text-blue-600 hover:underline dark:text-blue-400"
               >
                 grant lifecycle
@@ -267,7 +215,7 @@ export default function KnowledgePage() {
             <li>
               Start with{" "}
               <Link
-                href="/knowledge/grant-accountability"
+                href={PAGES.KNOWLEDGE.ARTICLE("grant-accountability")}
                 className="text-blue-600 hover:underline dark:text-blue-400"
               >
                 grant accountability
@@ -277,7 +225,7 @@ export default function KnowledgePage() {
             <li>
               Start with{" "}
               <Link
-                href="/knowledge/onchain-reputation"
+                href={PAGES.KNOWLEDGE.ARTICLE("onchain-reputation")}
                 className="text-blue-600 hover:underline dark:text-blue-400"
               >
                 onchain reputation
@@ -388,14 +336,7 @@ export default function KnowledgePage() {
             <p className="text-gray-700 dark:text-gray-300">
               How funding programs scale application review without sacrificing rigor.
             </p>
-            <p>
-              <Link
-                href="/knowledge/ai-grant-evaluation"
-                className="text-blue-600 hover:underline dark:text-blue-400"
-              >
-                → AI-assisted grant evaluation
-              </Link>
-            </p>
+            <ArticleLink slug="ai-grant-evaluation">→ AI-assisted grant evaluation</ArticleLink>
           </div>
 
           <div className="space-y-4">
@@ -403,14 +344,7 @@ export default function KnowledgePage() {
             <p className="text-gray-700 dark:text-gray-300">
               Why communities maintain public records of funded projects and their progress.
             </p>
-            <p>
-              <Link
-                href="/knowledge/project-registry"
-                className="text-blue-600 hover:underline dark:text-blue-400"
-              >
-                → Project registries
-              </Link>
-            </p>
+            <ArticleLink slug="project-registry">→ Project registries</ArticleLink>
           </div>
 
           <div className="space-y-4">
@@ -418,14 +352,7 @@ export default function KnowledgePage() {
             <p className="text-gray-700 dark:text-gray-300">
               How identity verification is coordinated without slowing down funding.
             </p>
-            <p>
-              <Link
-                href="/knowledge/grant-kyc"
-                className="text-blue-600 hover:underline dark:text-blue-400"
-              >
-                → KYC and compliance
-              </Link>
-            </p>
+            <ArticleLink slug="grant-kyc">→ KYC and compliance</ArticleLink>
           </div>
 
           <div className="space-y-4">
@@ -433,14 +360,7 @@ export default function KnowledgePage() {
             <p className="text-gray-700 dark:text-gray-300">
               Why grant agreements must be tracked as part of the funding workflow.
             </p>
-            <p>
-              <Link
-                href="/knowledge/grant-document-signing"
-                className="text-blue-600 hover:underline dark:text-blue-400"
-              >
-                → Document signing
-              </Link>
-            </p>
+            <ArticleLink slug="grant-document-signing">→ Document signing</ArticleLink>
           </div>
 
           <div className="space-y-4">
@@ -448,14 +368,9 @@ export default function KnowledgePage() {
             <p className="text-gray-700 dark:text-gray-300">
               How payments are safely triggered once requirements are met.
             </p>
-            <p>
-              <Link
-                href="/knowledge/grant-fund-disbursement"
-                className="text-blue-600 hover:underline dark:text-blue-400"
-              >
-                → Fund disbursement coordination
-              </Link>
-            </p>
+            <ArticleLink slug="grant-fund-disbursement">
+              → Fund disbursement coordination
+            </ArticleLink>
           </div>
 
           <div className="space-y-4">
@@ -463,14 +378,7 @@ export default function KnowledgePage() {
             <p className="text-gray-700 dark:text-gray-300">
               How funded work is connected to verifiable outputs and outcomes.
             </p>
-            <p>
-              <Link
-                href="/knowledge/impact-measurement"
-                className="text-blue-600 hover:underline dark:text-blue-400"
-              >
-                → Impact measurement
-              </Link>
-            </p>
+            <ArticleLink slug="impact-measurement">→ Impact measurement</ArticleLink>
           </div>
 
           <div className="space-y-4">
@@ -478,14 +386,9 @@ export default function KnowledgePage() {
             <p className="text-gray-700 dark:text-gray-300">
               Why ecosystems run funding programs under their own brand using shared infrastructure.
             </p>
-            <p>
-              <Link
-                href="/knowledge/whitelabel-funding-platforms"
-                className="text-blue-600 hover:underline dark:text-blue-400"
-              >
-                → Whitelabel funding platforms
-              </Link>
-            </p>
+            <ArticleLink slug="whitelabel-funding-platforms">
+              → Whitelabel funding platforms
+            </ArticleLink>
           </div>
 
           <div className="space-y-4">
@@ -493,14 +396,9 @@ export default function KnowledgePage() {
             <p className="text-gray-700 dark:text-gray-300">
               How different funding goals require different payment structures.
             </p>
-            <p>
-              <Link
-                href="/knowledge/funding-distribution-mechanisms"
-                className="text-blue-600 hover:underline dark:text-blue-400"
-              >
-                → Funding distribution mechanisms
-              </Link>
-            </p>
+            <ArticleLink slug="funding-distribution-mechanisms">
+              → Funding distribution mechanisms
+            </ArticleLink>
           </div>
 
           <div className="space-y-4">
@@ -530,14 +428,7 @@ export default function KnowledgePage() {
               A public, shareable page where projects document funding, milestones, updates, and
               outcomes over time.
             </p>
-            <p>
-              <Link
-                href="/knowledge/project-profiles"
-                className="text-blue-600 hover:underline dark:text-blue-400"
-              >
-                → What is a project profile?
-              </Link>
-            </p>
+            <ArticleLink slug="project-profiles">→ What is a project profile?</ArticleLink>
           </div>
 
           <div className="space-y-4">
@@ -545,14 +436,9 @@ export default function KnowledgePage() {
             <p className="text-gray-700 dark:text-gray-300">
               How profiles help grantees show funders what happens after funding.
             </p>
-            <p>
-              <Link
-                href="/knowledge/why-grantees-need-project-profiles"
-                className="text-blue-600 hover:underline dark:text-blue-400"
-              >
-                → Why grantees need project profiles
-              </Link>
-            </p>
+            <ArticleLink slug="why-grantees-need-project-profiles">
+              → Why grantees need project profiles
+            </ArticleLink>
           </div>
 
           <div className="space-y-4">
@@ -560,14 +446,9 @@ export default function KnowledgePage() {
             <p className="text-gray-700 dark:text-gray-300">
               Why project profiles serve as global resumes for funded work.
             </p>
-            <p>
-              <Link
-                href="/knowledge/project-profiles-as-resumes"
-                className="text-blue-600 hover:underline dark:text-blue-400"
-              >
-                → Project profiles as resumes
-              </Link>
-            </p>
+            <ArticleLink slug="project-profiles-as-resumes">
+              → Project profiles as resumes
+            </ArticleLink>
           </div>
 
           <div className="space-y-4">
@@ -575,14 +456,9 @@ export default function KnowledgePage() {
             <p className="text-gray-700 dark:text-gray-300">
               How consistent public updates build trust more than perfect outcomes.
             </p>
-            <p>
-              <Link
-                href="/knowledge/project-updates-and-reputation"
-                className="text-blue-600 hover:underline dark:text-blue-400"
-              >
-                → Building reputation through updates
-              </Link>
-            </p>
+            <ArticleLink slug="project-updates-and-reputation">
+              → Building reputation through updates
+            </ArticleLink>
           </div>
 
           <div className="space-y-4">
@@ -590,14 +466,9 @@ export default function KnowledgePage() {
             <p className="text-gray-700 dark:text-gray-300">
               How project profiles work for both technical and non-technical work.
             </p>
-            <p>
-              <Link
-                href="/knowledge/project-profiles-software-vs-nonsoftware"
-                className="text-blue-600 hover:underline dark:text-blue-400"
-              >
-                → Software vs non-software projects
-              </Link>
-            </p>
+            <ArticleLink slug="project-profiles-software-vs-nonsoftware">
+              → Software vs non-software projects
+            </ArticleLink>
           </div>
 
           <div className="space-y-4">
@@ -605,14 +476,7 @@ export default function KnowledgePage() {
             <p className="text-gray-700 dark:text-gray-300">
               How onchain storage provides credibility without blockchain complexity.
             </p>
-            <p>
-              <Link
-                href="/knowledge/onchain-project-profiles"
-                className="text-blue-600 hover:underline dark:text-blue-400"
-              >
-                → Onchain project profiles
-              </Link>
-            </p>
+            <ArticleLink slug="onchain-project-profiles">→ Onchain project profiles</ArticleLink>
           </div>
 
           <div className="space-y-4">
@@ -620,14 +484,9 @@ export default function KnowledgePage() {
             <p className="text-gray-700 dark:text-gray-300">
               How funders evaluate projects based on execution history, not just proposals.
             </p>
-            <p>
-              <Link
-                href="/knowledge/how-funders-use-project-profiles"
-                className="text-blue-600 hover:underline dark:text-blue-400"
-              >
-                → How funders use project profiles
-              </Link>
-            </p>
+            <ArticleLink slug="how-funders-use-project-profiles">
+              → How funders use project profiles
+            </ArticleLink>
           </div>
         </section>
 

--- a/app/knowledge/project-profiles-as-resumes/page.tsx
+++ b/app/knowledge/project-profiles-as-resumes/page.tsx
@@ -6,6 +6,7 @@ import { ArticlePublishedDate } from "@/components/Knowledge/ArticlePublishedDat
 import { ArticleJsonLd } from "@/components/Seo/ArticleJsonLd";
 import { BreadcrumbJsonLd } from "@/components/Seo/BreadcrumbJsonLd";
 import { customMetadata } from "@/utilities/meta";
+import { PAGES } from "@/utilities/pages";
 
 const title = "Project Profiles as a Global Resume for Funded Work";
 const description =
@@ -14,7 +15,7 @@ const description =
 export const metadata: Metadata = customMetadata({
   title,
   description,
-  path: "/knowledge/project-profiles-as-resumes",
+  path: PAGES.KNOWLEDGE.ARTICLE("project-profiles-as-resumes"),
   ogType: "article",
 });
 
@@ -26,21 +27,27 @@ export default function ProjectProfilesAsResumesPage() {
       <Breadcrumbs
         items={[
           { label: "Home", href: "/" },
-          { label: "Knowledge", href: "/knowledge" },
-          { label: "Project Profiles as Resumes", href: "/knowledge/project-profiles-as-resumes" },
+          { label: "Knowledge", href: PAGES.KNOWLEDGE.ROOT },
+          {
+            label: "Project Profiles as Resumes",
+            href: PAGES.KNOWLEDGE.ARTICLE("project-profiles-as-resumes"),
+          },
         ]}
       />
       <ArticleJsonLd
         title={title}
         description={description}
-        url="/knowledge/project-profiles-as-resumes"
+        url={PAGES.KNOWLEDGE.ARTICLE("project-profiles-as-resumes")}
         datePublished={PUBLISHED_AT}
       />
       <BreadcrumbJsonLd
         items={[
           { name: "Home", url: "/" },
-          { name: "Knowledge", url: "/knowledge" },
-          { name: "Project Profiles as Resumes", url: "/knowledge/project-profiles-as-resumes" },
+          { name: "Knowledge", url: PAGES.KNOWLEDGE.ROOT },
+          {
+            name: "Project Profiles as Resumes",
+            url: PAGES.KNOWLEDGE.ARTICLE("project-profiles-as-resumes"),
+          },
         ]}
       />
       <article className="space-y-8">
@@ -107,7 +114,7 @@ export default function ProjectProfilesAsResumesPage() {
           </p>
           <p className="pt-2">
             <Link
-              href="/create-project-profile"
+              href={PAGES.CREATE_PROJECT_PROFILE}
               className="text-blue-600 hover:underline dark:text-blue-400 font-semibold"
             >
               → Create your project profile
@@ -119,13 +126,13 @@ export default function ProjectProfilesAsResumesPage() {
           <h2 className="text-xl font-semibold">Related articles</h2>
           <div className="space-y-1">
             <Link
-              href="/knowledge/project-profiles"
+              href={PAGES.KNOWLEDGE.ARTICLE("project-profiles")}
               className="block text-blue-600 hover:underline dark:text-blue-400"
             >
               → What are project profiles?
             </Link>
             <Link
-              href="/knowledge/why-grantees-need-project-profiles"
+              href={PAGES.KNOWLEDGE.ARTICLE("why-grantees-need-project-profiles")}
               className="block text-blue-600 hover:underline dark:text-blue-400"
             >
               → Why grantees need project profiles

--- a/app/knowledge/project-profiles-software-vs-nonsoftware/page.tsx
+++ b/app/knowledge/project-profiles-software-vs-nonsoftware/page.tsx
@@ -6,6 +6,7 @@ import { ArticlePublishedDate } from "@/components/Knowledge/ArticlePublishedDat
 import { ArticleJsonLd } from "@/components/Seo/ArticleJsonLd";
 import { BreadcrumbJsonLd } from "@/components/Seo/BreadcrumbJsonLd";
 import { customMetadata } from "@/utilities/meta";
+import { PAGES } from "@/utilities/pages";
 
 const title = "Project Profiles for Software vs Non-Software Projects";
 const description =
@@ -14,7 +15,7 @@ const description =
 export const metadata: Metadata = customMetadata({
   title,
   description,
-  path: "/knowledge/project-profiles-software-vs-nonsoftware",
+  path: PAGES.KNOWLEDGE.ARTICLE("project-profiles-software-vs-nonsoftware"),
   ogType: "article",
 });
 
@@ -26,26 +27,26 @@ export default function ProjectProfilesSoftwareVsNonsoftwarePage() {
       <Breadcrumbs
         items={[
           { label: "Home", href: "/" },
-          { label: "Knowledge", href: "/knowledge" },
+          { label: "Knowledge", href: PAGES.KNOWLEDGE.ROOT },
           {
             label: "Software vs Non-Software Profiles",
-            href: "/knowledge/project-profiles-software-vs-nonsoftware",
+            href: PAGES.KNOWLEDGE.ARTICLE("project-profiles-software-vs-nonsoftware"),
           },
         ]}
       />
       <ArticleJsonLd
         title={title}
         description={description}
-        url="/knowledge/project-profiles-software-vs-nonsoftware"
+        url={PAGES.KNOWLEDGE.ARTICLE("project-profiles-software-vs-nonsoftware")}
         datePublished={PUBLISHED_AT}
       />
       <BreadcrumbJsonLd
         items={[
           { name: "Home", url: "/" },
-          { name: "Knowledge", url: "/knowledge" },
+          { name: "Knowledge", url: PAGES.KNOWLEDGE.ROOT },
           {
             name: "Software vs Non-Software Profiles",
-            url: "/knowledge/project-profiles-software-vs-nonsoftware",
+            url: PAGES.KNOWLEDGE.ARTICLE("project-profiles-software-vs-nonsoftware"),
           },
         ]}
       />
@@ -119,7 +120,7 @@ export default function ProjectProfilesSoftwareVsNonsoftwarePage() {
           </p>
           <p className="pt-2">
             <Link
-              href="/create-project-profile"
+              href={PAGES.CREATE_PROJECT_PROFILE}
               className="text-blue-600 hover:underline dark:text-blue-400 font-semibold"
             >
               → Create your project profile
@@ -131,13 +132,13 @@ export default function ProjectProfilesSoftwareVsNonsoftwarePage() {
           <h2 className="text-xl font-semibold">Related articles</h2>
           <div className="space-y-1">
             <Link
-              href="/knowledge/project-profiles"
+              href={PAGES.KNOWLEDGE.ARTICLE("project-profiles")}
               className="block text-blue-600 hover:underline dark:text-blue-400"
             >
               → What are project profiles?
             </Link>
             <Link
-              href="/knowledge/onchain-project-profiles"
+              href={PAGES.KNOWLEDGE.ARTICLE("onchain-project-profiles")}
               className="block text-blue-600 hover:underline dark:text-blue-400"
             >
               → Onchain project profiles explained

--- a/app/knowledge/project-profiles/page.tsx
+++ b/app/knowledge/project-profiles/page.tsx
@@ -6,6 +6,7 @@ import { ArticlePublishedDate } from "@/components/Knowledge/ArticlePublishedDat
 import { ArticleJsonLd } from "@/components/Seo/ArticleJsonLd";
 import { BreadcrumbJsonLd } from "@/components/Seo/BreadcrumbJsonLd";
 import { customMetadata } from "@/utilities/meta";
+import { PAGES } from "@/utilities/pages";
 
 const title = "What Are Project Profiles for Funded Work?";
 const description =
@@ -14,7 +15,7 @@ const description =
 export const metadata: Metadata = customMetadata({
   title,
   description,
-  path: "/knowledge/project-profiles",
+  path: PAGES.KNOWLEDGE.ARTICLE("project-profiles"),
   ogType: "article",
 });
 
@@ -26,21 +27,21 @@ export default function ProjectProfilesPage() {
       <Breadcrumbs
         items={[
           { label: "Home", href: "/" },
-          { label: "Knowledge", href: "/knowledge" },
-          { label: "Project Profiles", href: "/knowledge/project-profiles" },
+          { label: "Knowledge", href: PAGES.KNOWLEDGE.ROOT },
+          { label: "Project Profiles", href: PAGES.KNOWLEDGE.ARTICLE("project-profiles") },
         ]}
       />
       <ArticleJsonLd
         title={title}
         description={description}
-        url="/knowledge/project-profiles"
+        url={PAGES.KNOWLEDGE.ARTICLE("project-profiles")}
         datePublished={PUBLISHED_AT}
       />
       <BreadcrumbJsonLd
         items={[
           { name: "Home", url: "/" },
-          { name: "Knowledge", url: "/knowledge" },
-          { name: "Project Profiles", url: "/knowledge/project-profiles" },
+          { name: "Knowledge", url: PAGES.KNOWLEDGE.ROOT },
+          { name: "Project Profiles", url: PAGES.KNOWLEDGE.ARTICLE("project-profiles") },
         ]}
       />
       <article className="space-y-8">
@@ -148,7 +149,7 @@ export default function ProjectProfilesPage() {
           </p>
           <p className="pt-2">
             <Link
-              href="/create-project-profile"
+              href={PAGES.CREATE_PROJECT_PROFILE}
               className="text-blue-600 hover:underline dark:text-blue-400 font-semibold"
             >
               → Create your project profile
@@ -160,19 +161,19 @@ export default function ProjectProfilesPage() {
           <h2 className="text-xl font-semibold">Related articles</h2>
           <div className="space-y-1">
             <Link
-              href="/knowledge/why-grantees-need-project-profiles"
+              href={PAGES.KNOWLEDGE.ARTICLE("why-grantees-need-project-profiles")}
               className="block text-blue-600 hover:underline dark:text-blue-400"
             >
               → Why grantees need project profiles
             </Link>
             <Link
-              href="/knowledge/how-funders-use-project-profiles"
+              href={PAGES.KNOWLEDGE.ARTICLE("how-funders-use-project-profiles")}
               className="block text-blue-600 hover:underline dark:text-blue-400"
             >
               → How funders use project profiles
             </Link>
             <Link
-              href="/knowledge/onchain-project-profiles"
+              href={PAGES.KNOWLEDGE.ARTICLE("onchain-project-profiles")}
               className="block text-blue-600 hover:underline dark:text-blue-400"
             >
               → Onchain project profiles explained

--- a/app/knowledge/project-registry/page.tsx
+++ b/app/knowledge/project-registry/page.tsx
@@ -6,6 +6,7 @@ import { ArticlePublishedDate } from "@/components/Knowledge/ArticlePublishedDat
 import { ArticleJsonLd } from "@/components/Seo/ArticleJsonLd";
 import { BreadcrumbJsonLd } from "@/components/Seo/BreadcrumbJsonLd";
 import { customMetadata } from "@/utilities/meta";
+import { PAGES } from "@/utilities/pages";
 
 const title = "Public Project Registries for Funded Work";
 const description =
@@ -14,7 +15,7 @@ const description =
 export const metadata: Metadata = customMetadata({
   title,
   description,
-  path: "/knowledge/project-registry",
+  path: PAGES.KNOWLEDGE.ARTICLE("project-registry"),
   ogType: "article",
 });
 
@@ -26,21 +27,21 @@ export default function ProjectRegistryPage() {
       <Breadcrumbs
         items={[
           { label: "Home", href: "/" },
-          { label: "Knowledge", href: "/knowledge" },
-          { label: "Project Registry", href: "/knowledge/project-registry" },
+          { label: "Knowledge", href: PAGES.KNOWLEDGE.ROOT },
+          { label: "Project Registry", href: PAGES.KNOWLEDGE.ARTICLE("project-registry") },
         ]}
       />
       <ArticleJsonLd
         title={title}
         description={description}
-        url="/knowledge/project-registry"
+        url={PAGES.KNOWLEDGE.ARTICLE("project-registry")}
         datePublished={PUBLISHED_AT}
       />
       <BreadcrumbJsonLd
         items={[
           { name: "Home", url: "/" },
-          { name: "Knowledge", url: "/knowledge" },
-          { name: "Project Registry", url: "/knowledge/project-registry" },
+          { name: "Knowledge", url: PAGES.KNOWLEDGE.ROOT },
+          { name: "Project Registry", url: PAGES.KNOWLEDGE.ARTICLE("project-registry") },
         ]}
       />
       <article className="space-y-8">
@@ -93,19 +94,19 @@ export default function ProjectRegistryPage() {
           <h2 className="text-xl font-semibold">Related articles</h2>
           <div className="space-y-1">
             <Link
-              href="/knowledge/project-profiles"
+              href={PAGES.KNOWLEDGE.ARTICLE("project-profiles")}
               className="block text-blue-600 hover:underline dark:text-blue-400"
             >
               → What are project profiles?
             </Link>
             <Link
-              href="/knowledge/grant-accountability"
+              href={PAGES.KNOWLEDGE.ARTICLE("grant-accountability")}
               className="block text-blue-600 hover:underline dark:text-blue-400"
             >
               → Grant accountability
             </Link>
             <Link
-              href="/knowledge/grant-lifecycle"
+              href={PAGES.KNOWLEDGE.ARTICLE("grant-lifecycle")}
               className="block text-blue-600 hover:underline dark:text-blue-400"
             >
               → The grant lifecycle

--- a/app/knowledge/project-reputation/page.tsx
+++ b/app/knowledge/project-reputation/page.tsx
@@ -6,6 +6,7 @@ import { ArticlePublishedDate } from "@/components/Knowledge/ArticlePublishedDat
 import { ArticleJsonLd } from "@/components/Seo/ArticleJsonLd";
 import { BreadcrumbJsonLd } from "@/components/Seo/BreadcrumbJsonLd";
 import { customMetadata } from "@/utilities/meta";
+import { PAGES } from "@/utilities/pages";
 
 const title = "How Projects Build Reputation Through Funding";
 const description =
@@ -14,7 +15,7 @@ const description =
 export const metadata: Metadata = customMetadata({
   title,
   description,
-  path: "/knowledge/project-reputation",
+  path: PAGES.KNOWLEDGE.ARTICLE("project-reputation"),
   ogType: "article",
 });
 
@@ -26,21 +27,21 @@ export default function ProjectReputationPage() {
       <Breadcrumbs
         items={[
           { label: "Home", href: "/" },
-          { label: "Knowledge", href: "/knowledge" },
-          { label: "Project Reputation", href: "/knowledge/project-reputation" },
+          { label: "Knowledge", href: PAGES.KNOWLEDGE.ROOT },
+          { label: "Project Reputation", href: PAGES.KNOWLEDGE.ARTICLE("project-reputation") },
         ]}
       />
       <ArticleJsonLd
         title={title}
         description={description}
-        url="/knowledge/project-reputation"
+        url={PAGES.KNOWLEDGE.ARTICLE("project-reputation")}
         datePublished={PUBLISHED_AT}
       />
       <BreadcrumbJsonLd
         items={[
           { name: "Home", url: "/" },
-          { name: "Knowledge", url: "/knowledge" },
-          { name: "Project Reputation", url: "/knowledge/project-reputation" },
+          { name: "Knowledge", url: PAGES.KNOWLEDGE.ROOT },
+          { name: "Project Reputation", url: PAGES.KNOWLEDGE.ARTICLE("project-reputation") },
         ]}
       />
       <article className="space-y-8">
@@ -89,25 +90,25 @@ export default function ProjectReputationPage() {
           <h2 className="text-xl font-semibold">Related articles</h2>
           <div className="space-y-1">
             <Link
-              href="/knowledge/onchain-reputation"
+              href={PAGES.KNOWLEDGE.ARTICLE("onchain-reputation")}
               className="block text-blue-600 hover:underline dark:text-blue-400"
             >
               → What is onchain reputation?
             </Link>
             <Link
-              href="/knowledge/reputation-compounding"
+              href={PAGES.KNOWLEDGE.ARTICLE("reputation-compounding")}
               className="block text-blue-600 hover:underline dark:text-blue-400"
             >
               → How reputation compounds in open funding
             </Link>
             <Link
-              href="/knowledge/project-profiles"
+              href={PAGES.KNOWLEDGE.ARTICLE("project-profiles")}
               className="block text-blue-600 hover:underline dark:text-blue-400"
             >
               → What are project profiles?
             </Link>
             <Link
-              href="/knowledge/project-registry"
+              href={PAGES.KNOWLEDGE.ARTICLE("project-registry")}
               className="block text-blue-600 hover:underline dark:text-blue-400"
             >
               → Public project registries

--- a/app/knowledge/project-updates-and-reputation/page.tsx
+++ b/app/knowledge/project-updates-and-reputation/page.tsx
@@ -6,6 +6,7 @@ import { ArticlePublishedDate } from "@/components/Knowledge/ArticlePublishedDat
 import { ArticleJsonLd } from "@/components/Seo/ArticleJsonLd";
 import { BreadcrumbJsonLd } from "@/components/Seo/BreadcrumbJsonLd";
 import { customMetadata } from "@/utilities/meta";
+import { PAGES } from "@/utilities/pages";
 
 const title = "How Projects Build Reputation Through Public Updates";
 const description =
@@ -14,7 +15,7 @@ const description =
 export const metadata: Metadata = customMetadata({
   title,
   description,
-  path: "/knowledge/project-updates-and-reputation",
+  path: PAGES.KNOWLEDGE.ARTICLE("project-updates-and-reputation"),
   ogType: "article",
 });
 
@@ -26,26 +27,26 @@ export default function ProjectUpdatesAndReputationPage() {
       <Breadcrumbs
         items={[
           { label: "Home", href: "/" },
-          { label: "Knowledge", href: "/knowledge" },
+          { label: "Knowledge", href: PAGES.KNOWLEDGE.ROOT },
           {
             label: "Project Updates and Reputation",
-            href: "/knowledge/project-updates-and-reputation",
+            href: PAGES.KNOWLEDGE.ARTICLE("project-updates-and-reputation"),
           },
         ]}
       />
       <ArticleJsonLd
         title={title}
         description={description}
-        url="/knowledge/project-updates-and-reputation"
+        url={PAGES.KNOWLEDGE.ARTICLE("project-updates-and-reputation")}
         datePublished={PUBLISHED_AT}
       />
       <BreadcrumbJsonLd
         items={[
           { name: "Home", url: "/" },
-          { name: "Knowledge", url: "/knowledge" },
+          { name: "Knowledge", url: PAGES.KNOWLEDGE.ROOT },
           {
             name: "Project Updates and Reputation",
-            url: "/knowledge/project-updates-and-reputation",
+            url: PAGES.KNOWLEDGE.ARTICLE("project-updates-and-reputation"),
           },
         ]}
       />
@@ -117,7 +118,7 @@ export default function ProjectUpdatesAndReputationPage() {
           </p>
           <p className="pt-2">
             <Link
-              href="/create-project-profile"
+              href={PAGES.CREATE_PROJECT_PROFILE}
               className="text-blue-600 hover:underline dark:text-blue-400 font-semibold"
             >
               → Create your project profile
@@ -129,13 +130,13 @@ export default function ProjectUpdatesAndReputationPage() {
           <h2 className="text-xl font-semibold">Related articles</h2>
           <div className="space-y-1">
             <Link
-              href="/knowledge/reputation-compounding"
+              href={PAGES.KNOWLEDGE.ARTICLE("reputation-compounding")}
               className="block text-blue-600 hover:underline dark:text-blue-400"
             >
               → How reputation compounds in open funding
             </Link>
             <Link
-              href="/knowledge/project-profiles"
+              href={PAGES.KNOWLEDGE.ARTICLE("project-profiles")}
               className="block text-blue-600 hover:underline dark:text-blue-400"
             >
               → What are project profiles?

--- a/app/knowledge/reputation-compounding/page.tsx
+++ b/app/knowledge/reputation-compounding/page.tsx
@@ -6,6 +6,7 @@ import { ArticlePublishedDate } from "@/components/Knowledge/ArticlePublishedDat
 import { ArticleJsonLd } from "@/components/Seo/ArticleJsonLd";
 import { BreadcrumbJsonLd } from "@/components/Seo/BreadcrumbJsonLd";
 import { customMetadata } from "@/utilities/meta";
+import { PAGES } from "@/utilities/pages";
 
 const title = "How Reputation Compounds in Open Funding Systems";
 const description =
@@ -14,7 +15,7 @@ const description =
 export const metadata: Metadata = customMetadata({
   title,
   description,
-  path: "/knowledge/reputation-compounding",
+  path: PAGES.KNOWLEDGE.ARTICLE("reputation-compounding"),
   ogType: "article",
 });
 
@@ -26,21 +27,27 @@ export default function ReputationCompoundingPage() {
       <Breadcrumbs
         items={[
           { label: "Home", href: "/" },
-          { label: "Knowledge", href: "/knowledge" },
-          { label: "Reputation Compounding", href: "/knowledge/reputation-compounding" },
+          { label: "Knowledge", href: PAGES.KNOWLEDGE.ROOT },
+          {
+            label: "Reputation Compounding",
+            href: PAGES.KNOWLEDGE.ARTICLE("reputation-compounding"),
+          },
         ]}
       />
       <ArticleJsonLd
         title={title}
         description={description}
-        url="/knowledge/reputation-compounding"
+        url={PAGES.KNOWLEDGE.ARTICLE("reputation-compounding")}
         datePublished={PUBLISHED_AT}
       />
       <BreadcrumbJsonLd
         items={[
           { name: "Home", url: "/" },
-          { name: "Knowledge", url: "/knowledge" },
-          { name: "Reputation Compounding", url: "/knowledge/reputation-compounding" },
+          { name: "Knowledge", url: PAGES.KNOWLEDGE.ROOT },
+          {
+            name: "Reputation Compounding",
+            url: PAGES.KNOWLEDGE.ARTICLE("reputation-compounding"),
+          },
         ]}
       />
       <article className="space-y-8">
@@ -83,25 +90,25 @@ export default function ReputationCompoundingPage() {
           <h2 className="text-xl font-semibold">Related articles</h2>
           <div className="space-y-1">
             <Link
-              href="/knowledge/onchain-reputation"
+              href={PAGES.KNOWLEDGE.ARTICLE("onchain-reputation")}
               className="block text-blue-600 hover:underline dark:text-blue-400"
             >
               → What is onchain reputation?
             </Link>
             <Link
-              href="/knowledge/project-reputation"
+              href={PAGES.KNOWLEDGE.ARTICLE("project-reputation")}
               className="block text-blue-600 hover:underline dark:text-blue-400"
             >
               → How projects build reputation through funding
             </Link>
             <Link
-              href="/knowledge/project-updates-and-reputation"
+              href={PAGES.KNOWLEDGE.ARTICLE("project-updates-and-reputation")}
               className="block text-blue-600 hover:underline dark:text-blue-400"
             >
               → Project updates and reputation
             </Link>
             <Link
-              href="/knowledge/impact-measurement"
+              href={PAGES.KNOWLEDGE.ARTICLE("impact-measurement")}
               className="block text-blue-600 hover:underline dark:text-blue-400"
             >
               → Impact measurement

--- a/app/knowledge/whitelabel-funding-platforms/page.tsx
+++ b/app/knowledge/whitelabel-funding-platforms/page.tsx
@@ -6,6 +6,7 @@ import { ArticlePublishedDate } from "@/components/Knowledge/ArticlePublishedDat
 import { ArticleJsonLd } from "@/components/Seo/ArticleJsonLd";
 import { BreadcrumbJsonLd } from "@/components/Seo/BreadcrumbJsonLd";
 import { customMetadata } from "@/utilities/meta";
+import { PAGES } from "@/utilities/pages";
 
 const title = "Whitelabel Funding Platforms for DAO Ecosystems";
 const description =
@@ -14,7 +15,7 @@ const description =
 export const metadata: Metadata = customMetadata({
   title,
   description,
-  path: "/knowledge/whitelabel-funding-platforms",
+  path: PAGES.KNOWLEDGE.ARTICLE("whitelabel-funding-platforms"),
   ogType: "article",
 });
 
@@ -26,24 +27,27 @@ export default function WhitelabelFundingPlatformsPage() {
       <Breadcrumbs
         items={[
           { label: "Home", href: "/" },
-          { label: "Knowledge", href: "/knowledge" },
+          { label: "Knowledge", href: PAGES.KNOWLEDGE.ROOT },
           {
             label: "Whitelabel Funding Platforms",
-            href: "/knowledge/whitelabel-funding-platforms",
+            href: PAGES.KNOWLEDGE.ARTICLE("whitelabel-funding-platforms"),
           },
         ]}
       />
       <ArticleJsonLd
         title={title}
         description={description}
-        url="/knowledge/whitelabel-funding-platforms"
+        url={PAGES.KNOWLEDGE.ARTICLE("whitelabel-funding-platforms")}
         datePublished={PUBLISHED_AT}
       />
       <BreadcrumbJsonLd
         items={[
           { name: "Home", url: "/" },
-          { name: "Knowledge", url: "/knowledge" },
-          { name: "Whitelabel Funding Platforms", url: "/knowledge/whitelabel-funding-platforms" },
+          { name: "Knowledge", url: PAGES.KNOWLEDGE.ROOT },
+          {
+            name: "Whitelabel Funding Platforms",
+            url: PAGES.KNOWLEDGE.ARTICLE("whitelabel-funding-platforms"),
+          },
         ]}
       />
       <article className="space-y-8">
@@ -93,19 +97,19 @@ export default function WhitelabelFundingPlatformsPage() {
           <h2 className="text-xl font-semibold">Related articles</h2>
           <div className="space-y-1">
             <Link
-              href="/knowledge/grant-lifecycle"
+              href={PAGES.KNOWLEDGE.ARTICLE("grant-lifecycle")}
               className="block text-blue-600 hover:underline dark:text-blue-400"
             >
               → The grant lifecycle
             </Link>
             <Link
-              href="/knowledge/grant-accountability"
+              href={PAGES.KNOWLEDGE.ARTICLE("grant-accountability")}
               className="block text-blue-600 hover:underline dark:text-blue-400"
             >
               → Grant accountability
             </Link>
             <Link
-              href="/knowledge/funding-distribution-mechanisms"
+              href={PAGES.KNOWLEDGE.ARTICLE("funding-distribution-mechanisms")}
               className="block text-blue-600 hover:underline dark:text-blue-400"
             >
               → Funding distribution mechanisms

--- a/app/knowledge/why-grant-programs-fail/page.tsx
+++ b/app/knowledge/why-grant-programs-fail/page.tsx
@@ -6,12 +6,13 @@ import { ArticlePublishedDate } from "@/components/Knowledge/ArticlePublishedDat
 import { ArticleJsonLd } from "@/components/Seo/ArticleJsonLd";
 import { BreadcrumbJsonLd } from "@/components/Seo/BreadcrumbJsonLd";
 import { customMetadata } from "@/utilities/meta";
+import { PAGES } from "@/utilities/pages";
 
 export const metadata: Metadata = customMetadata({
   title: "Why Most Grant Programs Fail After Funding",
   description:
     "Grant programs fail at post-funding follow-through, not project selection. Learn the structural reasons and how to build systems that learn from outcomes.",
-  path: "/knowledge/why-grant-programs-fail",
+  path: PAGES.KNOWLEDGE.ARTICLE("why-grant-programs-fail"),
   ogType: "article",
 });
 
@@ -23,21 +24,27 @@ export default function WhyGrantProgramsFailPage() {
       <Breadcrumbs
         items={[
           { label: "Home", href: "/" },
-          { label: "Knowledge", href: "/knowledge" },
-          { label: "Why Grant Programs Fail", href: "/knowledge/why-grant-programs-fail" },
+          { label: "Knowledge", href: PAGES.KNOWLEDGE.ROOT },
+          {
+            label: "Why Grant Programs Fail",
+            href: PAGES.KNOWLEDGE.ARTICLE("why-grant-programs-fail"),
+          },
         ]}
       />
       <ArticleJsonLd
         title="Why Most Grant Programs Fail After Funding"
         description="Grant programs fail at post-funding follow-through, not project selection. Learn the structural reasons and how to build systems that learn from outcomes."
-        url="/knowledge/why-grant-programs-fail"
+        url={PAGES.KNOWLEDGE.ARTICLE("why-grant-programs-fail")}
         datePublished={PUBLISHED_AT}
       />
       <BreadcrumbJsonLd
         items={[
           { name: "Home", url: "/" },
-          { name: "Knowledge", url: "/knowledge" },
-          { name: "Why Grant Programs Fail", url: "/knowledge/why-grant-programs-fail" },
+          { name: "Knowledge", url: PAGES.KNOWLEDGE.ROOT },
+          {
+            name: "Why Grant Programs Fail",
+            url: PAGES.KNOWLEDGE.ARTICLE("why-grant-programs-fail"),
+          },
         ]}
       />
       <article className="space-y-8">
@@ -100,31 +107,31 @@ export default function WhyGrantProgramsFailPage() {
           <h2 className="text-xl font-semibold">Related articles</h2>
           <div className="space-y-1">
             <Link
-              href="/knowledge/grant-accountability"
+              href={PAGES.KNOWLEDGE.ARTICLE("grant-accountability")}
               className="block text-blue-600 hover:underline dark:text-blue-400"
             >
               → Grant accountability
             </Link>
             <Link
-              href="/knowledge/grant-lifecycle"
+              href={PAGES.KNOWLEDGE.ARTICLE("grant-lifecycle")}
               className="block text-blue-600 hover:underline dark:text-blue-400"
             >
               → The grant lifecycle
             </Link>
             <Link
-              href="/knowledge/impact-measurement"
+              href={PAGES.KNOWLEDGE.ARTICLE("impact-measurement")}
               className="block text-blue-600 hover:underline dark:text-blue-400"
             >
               → Impact measurement
             </Link>
             <Link
-              href="/knowledge/dao-grant-milestones"
+              href={PAGES.KNOWLEDGE.ARTICLE("dao-grant-milestones")}
               className="block text-blue-600 hover:underline dark:text-blue-400"
             >
               → DAO grant milestones
             </Link>
             <Link
-              href="/knowledge/manual-vs-platform-grant-tracking"
+              href={PAGES.KNOWLEDGE.ARTICLE("manual-vs-platform-grant-tracking")}
               className="block text-blue-600 hover:underline dark:text-blue-400"
             >
               → Manual vs platform grant tracking

--- a/app/knowledge/why-grantees-need-project-profiles/page.tsx
+++ b/app/knowledge/why-grantees-need-project-profiles/page.tsx
@@ -6,6 +6,7 @@ import { ArticlePublishedDate } from "@/components/Knowledge/ArticlePublishedDat
 import { ArticleJsonLd } from "@/components/Seo/ArticleJsonLd";
 import { BreadcrumbJsonLd } from "@/components/Seo/BreadcrumbJsonLd";
 import { customMetadata } from "@/utilities/meta";
+import { PAGES } from "@/utilities/pages";
 
 const title = "Why Grantees Need Project Profiles";
 const description =
@@ -14,7 +15,7 @@ const description =
 export const metadata: Metadata = customMetadata({
   title,
   description,
-  path: "/knowledge/why-grantees-need-project-profiles",
+  path: PAGES.KNOWLEDGE.ARTICLE("why-grantees-need-project-profiles"),
   ogType: "article",
 });
 
@@ -26,26 +27,26 @@ export default function WhyGranteesNeedProjectProfilesPage() {
       <Breadcrumbs
         items={[
           { label: "Home", href: "/" },
-          { label: "Knowledge", href: "/knowledge" },
+          { label: "Knowledge", href: PAGES.KNOWLEDGE.ROOT },
           {
             label: "Why Grantees Need Project Profiles",
-            href: "/knowledge/why-grantees-need-project-profiles",
+            href: PAGES.KNOWLEDGE.ARTICLE("why-grantees-need-project-profiles"),
           },
         ]}
       />
       <ArticleJsonLd
         title={title}
         description={description}
-        url="/knowledge/why-grantees-need-project-profiles"
+        url={PAGES.KNOWLEDGE.ARTICLE("why-grantees-need-project-profiles")}
         datePublished={PUBLISHED_AT}
       />
       <BreadcrumbJsonLd
         items={[
           { name: "Home", url: "/" },
-          { name: "Knowledge", url: "/knowledge" },
+          { name: "Knowledge", url: PAGES.KNOWLEDGE.ROOT },
           {
             name: "Why Grantees Need Project Profiles",
-            url: "/knowledge/why-grantees-need-project-profiles",
+            url: PAGES.KNOWLEDGE.ARTICLE("why-grantees-need-project-profiles"),
           },
         ]}
       />
@@ -122,7 +123,7 @@ export default function WhyGranteesNeedProjectProfilesPage() {
           </p>
           <p className="pt-2">
             <Link
-              href="/create-project-profile"
+              href={PAGES.CREATE_PROJECT_PROFILE}
               className="text-blue-600 hover:underline dark:text-blue-400 font-semibold"
             >
               → Create your project profile
@@ -134,13 +135,13 @@ export default function WhyGranteesNeedProjectProfilesPage() {
           <h2 className="text-xl font-semibold">Related articles</h2>
           <div className="space-y-1">
             <Link
-              href="/knowledge/project-profiles"
+              href={PAGES.KNOWLEDGE.ARTICLE("project-profiles")}
               className="block text-blue-600 hover:underline dark:text-blue-400"
             >
               → What are project profiles?
             </Link>
             <Link
-              href="/knowledge/project-profiles-as-resumes"
+              href={PAGES.KNOWLEDGE.ARTICLE("project-profiles-as-resumes")}
               className="block text-blue-600 hover:underline dark:text-blue-400"
             >
               → Project profiles as resumes for funded work

--- a/src/features/ask-karma/config.ts
+++ b/src/features/ask-karma/config.ts
@@ -45,7 +45,7 @@ const DEFAULT_CONFIG: AskKarmaConfig = {
       description: "Browse active programs accepting applications",
       links: [
         { label: "View open rounds", href: PAGES.REGISTRY.ROOT },
-        { label: "How applications work", href: "/knowledge/grant-lifecycle" },
+        { label: "How applications work", href: PAGES.KNOWLEDGE.ARTICLE("grant-lifecycle") },
       ],
     },
     {
@@ -60,7 +60,7 @@ const DEFAULT_CONFIG: AskKarmaConfig = {
       links: [
         { label: "Submit a milestone update", href: PAGES.MY_PROJECTS },
         { label: "Update project profile", href: PAGES.MY_PROJECTS },
-        { label: "FAQs", href: "/knowledge/project-updates-and-reputation" },
+        { label: "FAQs", href: PAGES.KNOWLEDGE.ARTICLE("project-updates-and-reputation") },
       ],
     },
   ],

--- a/utilities/pages.ts
+++ b/utilities/pages.ts
@@ -185,6 +185,10 @@ export const PAGES = {
     PUBLIC_SCORECARD: (slug: string) => `/s/${slug}`,
     OG_IMAGE: (slug: string) => `/api/scanner/og/${slug}`,
   },
+  KNOWLEDGE: {
+    ROOT: `/knowledge`,
+    ARTICLE: (slug: string) => `/knowledge/${slug}`,
+  },
   BLOG: `/blog`,
   BLOG_POST: (slug: string) => `/blog/${slug}`,
   BLOG_PREVIEW_EXIT: `/api/blog/preview/exit`,


### PR DESCRIPTION
## Overview

Three independent pieces of tooling debt surfaced while shipping the AEO work, each in its own
commit. No product behaviour changes.

## 1. The monthly `llms.txt` job could skip a month without anyone noticing

`generate-llms-txt.yml` pushed with a bare `git push`, which fires the husky pre-push hook —
whose entire body is `pnpm typecheck`. So **any** unrelated type error anywhere on main blocked
this workflow's push.

That is not hypothetical. On 2026-07-01 the run generated the files correctly, committed them,
then the push was rejected because of an error in `src/features/home/components/rotating-word.test.tsx`,
a file with nothing to do with this job. `llms.txt` went un-regenerated for a month, and nobody
noticed, because a failed scheduled run is invisible outside the Actions tab.

- The push now uses `--no-verify`, with a comment citing that failure so the flag is not
  "helpfully" removed later. The hook exists to stop humans pushing code that does not compile;
  this job writes two generated `.txt` files and every PR is typechecked by CI independently.
- A failure now opens a GitHub issue via `actions/github-script@v8` (the version the repo's other
  13 workflow usages already pin) using the built-in `GITHUB_TOKEN` — **no new secret**. Repeat
  failures comment on the same issue instead of piling up new ones.
- The job gains `issues: write` alongside its existing `contents: write`.

## 2. Knowledge links now go through `PAGES`

288 hardcoded route literals across the 26 knowledge pages — `Link` hrefs, breadcrumbs, JSON-LD
`url`s, and metadata paths — replaced with a new top-level `PAGES.KNOWLEDGE` (`ROOT` and
`ARTICLE(slug)`), matching the file's existing conventions. `[ROUTES]` findings on these files
drop from 26 files to **0**.

Two things worth a reviewer's eye:

- **`src/features/ask-karma/config.ts`** is included. It was the only other place in the repo
  with knowledge *page links*, and it already imported `PAGES` for its sibling entries.
- **`app/knowledge/page.tsx` was refactored, not just edited.** It sat at exactly its 644-line
  entry in `quality-baseline.json`, so even adding the `PAGES` import would have tripped the
  oversized-file gate. Rather than delete a line to squeak under, the 25 repeated link blocks
  were extracted into a local `ArticleLink`, bringing the file to 503 lines and out of the
  oversized set entirely. Every call passes a single string child, so `renderToString` emits no
  `<!-- -->` separator and the markup is byte-identical — pinned by the existing no-JS SSR test.

## 3. CodeRabbit config is now in the repo

All CodeRabbit behaviour lived in the web UI: unreviewable, unversioned, and the docstring
pre-merge check sat at the schema default of 80%. That does not describe this codebase — 607 of
1862 files under `app/`, `components/`, `utilities/` and `hooks/` contain any docblock, about
**32%**. Nothing in either `CLAUDE.md` requires docstrings and the house style prefers sparse
comments. The threshold is set to 30, just under the measured rate, so it still catches a PR that
adds a large block of wholly undocumented code without penalising routine work.

> **`inheritance: true` is load-bearing, not decoration.** Per the published schema, `inheritance`
> defaults to `false`, and repository YAML outranks both repository and organisation UI settings.
> A "minimal" config without it would have made this file the *only* configuration source and
> silently reverted every UI-configured setting to schema defaults. Setting it true is what keeps
> this a single-setting change.

Every key was validated against the published schema
(`https://storage.googleapis.com/coderabbit_public_assets/schema.v2.json`, root
`additionalProperties: false`) with a Draft 2020-12 validator: **0 errors**.

### Please do this before merging

Comment `@coderabbitai configuration` on this PR. It returns the fully-resolved config annotated
with each setting's source, which is the only way to confirm from outside the UI that the
inheritance chain preserved your existing settings rather than dropping any to defaults.

Two caveats on the threshold: the 32% is a **file-level** measure (a file with one docblock counts
as covered), so if CodeRabbit scores per-function the true rate is lower and 30 may still warn
occasionally — acceptable in `warning` mode. The comment in the file says to re-measure before
raising it.

## Testing

- `pnpm typecheck` clean; Biome clean on all 29 changed files.
- Workflow YAML parsed and structure re-verified (triggers, permissions, step order, the
  unchanged `generate-llms` step, and that only `public/llms.txt` / `llms-full.txt` are staged).
- `.coderabbit.yaml` schema-validated, 0 errors.
- `grep` proves no hardcoded `/knowledge` route literals remain in `app/` outside the sitemap
  generator, which builds absolute URLs and is out of scope.
- Anti-pattern checker: `[ROUTES]` = 0 on the touched files. The `[LOADING]`/`[ERROR]` findings
  there are pre-existing and deliberately untouched — see the note below.
- Targeted suites green: `pages`, `appRouteTemplates`, `knowledge-collection-ssr`, `ArticleJsonLd`,
  plus the ask-karma and `generate-llms-txt` script tests.

## Deliberately out of scope

The 25 knowledge pages are missing `loading.tsx` / `error.tsx`, which `gap-app-v2/CLAUDE.md`
requires of every route. None of them fetch anything, so a `loading.tsx` would never render — that
is a question about the rule rather than a bug in these pages, and it is not mixed in here.

Part of DEV-583.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency across Knowledge Center navigation, breadcrumbs, related articles, metadata, and structured links.
  * Reduced the risk of broken or mismatched article URLs while preserving existing destinations.
  * Updated project-profile links and Ask Karma references to use reliable shared routes.

* **Quality Improvements**
  * Added automated coverage to verify Knowledge Center routes remain unique and correctly generated.
  * Improved workflow failure reporting with consolidated issue notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->