### PR TITLE
feat(seo): model no-JS visibility in the sitemap crawler

### DIFF
--- a/scripts/crawl-sitemap.mjs
+++ b/scripts/crawl-sitemap.mjs
@@ -16,7 +16,11 @@ import {
 } from "node:fs/promises";
 import { dirname } from "node:path";
 import { pathToFileURL } from "node:url";
-import { CRAWL_DEFAULTS, crawlSitemap } from "./indexability/crawl-sitemap.mjs";
+import {
+  assertVisibilityMode,
+  CRAWL_DEFAULTS,
+  crawlSitemap,
+} from "./indexability/crawl-sitemap.mjs";
 
 /**
  * URLs that are knowingly not yet "200 + indexable + self-canonical + meaningful
@@ -47,6 +51,7 @@ const DEFAULTS = Object.freeze({
   delayMs: String(CRAWL_DEFAULTS.delayMs),
   timeoutMs: String(CRAWL_DEFAULTS.timeoutMs),
   minContentChars: String(CRAWL_DEFAULTS.minContentChars),
+  visibilityMode: CRAWL_DEFAULTS.visibilityMode,
 });
 
 const FLAG_TO_KEY = Object.freeze({
@@ -58,6 +63,7 @@ const FLAG_TO_KEY = Object.freeze({
   "--delay-ms": "delayMs",
   "--timeout-ms": "timeoutMs",
   "--min-content-chars": "minContentChars",
+  "--visibility-mode": "visibilityMode",
   "--known-issues": "knownIssues",
   "--output": "output",
 });
@@ -71,6 +77,7 @@ const ENV_NAMES = Object.freeze({
   delayMs: "CRAWL_DELAY_MS",
   timeoutMs: "CRAWL_TIMEOUT_MS",
   minContentChars: "CRAWL_MIN_CONTENT_CHARS",
+  visibilityMode: "CRAWL_VISIBILITY_MODE",
   knownIssues: "CRAWL_KNOWN_ISSUES",
   output: "CRAWL_OUTPUT",
 });
@@ -147,6 +154,10 @@ export function resolveConfig(flags, env) {
       "--min-content-chars",
       0
     ),
+    // "no-js" measures what a scripting-disabled renderer displays (hidden
+    // streamed chunks excluded, noscript included); "raw" preserves the
+    // pre-DEV-586 raw-markup counting for comparison with older reports.
+    visibilityMode: assertVisibilityMode(pick("visibilityMode", DEFAULTS.visibilityMode)),
     knownIssues: pick("knownIssues", undefined),
     output: pick("output", undefined),
   };
@@ -192,6 +203,7 @@ export async function main({
       delayMs: config.delayMs,
       timeoutMs: config.timeoutMs,
       minContentChars: config.minContentChars,
+      visibilityMode: config.visibilityMode,
       knownIssues,
     });
   } catch (err) {

--- a/scripts/indexability/__tests__/crawl-sitemap.test.mjs
+++ b/scripts/indexability/__tests__/crawl-sitemap.test.mjs
@@ -2,12 +2,14 @@ import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 import { DEFAULT_KNOWN_ISSUES, main, parseArgs, resolveConfig } from "../../crawl-sitemap.mjs";
 import {
+  assertVisibilityMode,
   CLASSIFICATIONS,
   classify,
   crawlSitemap,
   extractCanonical,
   extractFirstTagText,
   extractMetaRobots,
+  extractNoJsVisibleHtml,
   hasNoindex,
   inspectUrl,
   isSelfCanonical,
@@ -140,6 +142,176 @@ describe("HTML extraction", () => {
       ),
       "Impact & Outcomes"
     );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// No-JS visibility model (DEV-586, follow-up to the PR #1967 QA finding)
+// ---------------------------------------------------------------------------
+
+describe("extractNoJsVisibleHtml", () => {
+  // The exact shape that motivated this model: Next streams the page segment
+  // as a hidden div revealed only by client-side script, with a loading
+  // fallback as the visible page. Raw counting saw the hidden prose and passed
+  // find-funders; a no-JS renderer showed only the spinner.
+  const STREAMED_SHELL =
+    `<body><main class="spinner">Loading</main>` +
+    `<div hidden id="S:0"><h1>Streamed heading</h1><p>${PARAGRAPH}</p></div>` +
+    `<script>$RC("B:0","S:0")</script></body>`;
+
+  it("excludes text inside a hidden streamed chunk", () => {
+    const visible = extractNoJsVisibleHtml(STREAMED_SHELL);
+    assert.equal(visibleTextLength(visible), "Loading".length);
+    assert.equal(extractFirstTagText(visible, "h1"), null);
+  });
+
+  it("counts noscript content as visible, for both text and h1", () => {
+    const visible = extractNoJsVisibleHtml(
+      `<body><noscript><h1>NoJS hero</h1><p>${PARAGRAPH}</p></noscript>` +
+        `<div hidden id="S:0"><h1>Streamed heading</h1></div></body>`
+    );
+    assert.equal(extractFirstTagText(visible, "h1"), "NoJS hero");
+    assert.ok(visibleTextLength(visible) > 200);
+  });
+
+  it("an h1 in a hidden chunk plus an h1 in noscript is satisfied by the noscript one only", () => {
+    const visible = extractNoJsVisibleHtml(
+      `<body><div hidden id="S:0"><h1>Hidden first</h1></div>` +
+        `<noscript><h1>Visible second</h1></noscript></body>`
+    );
+    assert.equal(extractFirstTagText(visible, "h1"), "Visible second");
+  });
+
+  // Precedence: `hidden` always wins. A hidden element inside a noscript is
+  // parsed as normal DOM by a scripting-disabled renderer and its `hidden`
+  // attribute is honored; a noscript inside a hidden element is inside a
+  // subtree that never renders at all.
+  it("keeps a hidden element inside noscript invisible (noscript > div[hidden])", () => {
+    const visible = extractNoJsVisibleHtml(
+      "<body><noscript><div hidden>secret</div><p>shown</p></noscript></body>"
+    );
+    assert.equal(visibleTextLength(visible), "shown".length);
+  });
+
+  it("keeps a noscript inside a hidden element invisible (div[hidden] > noscript)", () => {
+    const visible = extractNoJsVisibleHtml(
+      "<body><div hidden><noscript><h1>never rendered</h1></noscript></div><p>ok</p></body>"
+    );
+    assert.equal(extractFirstTagText(visible, "h1"), null);
+    assert.equal(visibleTextLength(visible), "ok".length);
+  });
+
+  it('treats hidden="", hidden="hidden" and hidden="until-found" all as hidden', () => {
+    for (const variant of ['hidden=""', 'hidden="hidden"', 'hidden="until-found"', "hidden"]) {
+      const visible = extractNoJsVisibleHtml(`<body><div ${variant}>gone</div><p>kept</p></body>`);
+      assert.equal(visibleTextLength(visible), "kept".length, variant);
+    }
+  });
+
+  it('does not false-positive on attribute VALUES containing "hidden"', () => {
+    const visible = extractNoJsVisibleHtml(
+      '<body><p class="is hidden" data-state="hidden">visible text</p></body>'
+    );
+    assert.equal(visibleTextLength(visible), "visible text".length);
+  });
+
+  it("still drops script/style/template content, including inside noscript", () => {
+    const visible = extractNoJsVisibleHtml(
+      `<body><noscript><style>.a{color:red}</style>real</noscript>` +
+        `<template><h1>inert</h1></template></body>`
+    );
+    assert.equal(visibleTextLength(visible), "real".length);
+    assert.equal(extractFirstTagText(visible, "h1"), null);
+  });
+
+  it("handles nested hidden elements without resurrecting inner content", () => {
+    const visible = extractNoJsVisibleHtml(
+      "<body><div hidden><section><div hidden><p>deep</p></div><p>mid</p></section></div><p>out</p></body>"
+    );
+    assert.equal(visibleTextLength(visible), "out".length);
+  });
+
+  it("is not fooled by void elements inside a hidden subtree", () => {
+    const visible = extractNoJsVisibleHtml(
+      '<body><div hidden><img src="x"><br><p>still hidden</p></div><p>seen</p></body>'
+    );
+    assert.equal(visibleTextLength(visible), "seen".length);
+  });
+
+  it("returns an empty string for empty input", () => {
+    assert.equal(extractNoJsVisibleHtml(""), "");
+    assert.equal(extractNoJsVisibleHtml(null), "");
+  });
+});
+
+describe("inspectUrl visibility modes", () => {
+  const url = `${CANONICAL}/streamed`;
+  // Everything meaningful hidden; a noscript h1 + prose present. The two modes
+  // must disagree about this page: raw counts the hidden prose (and finds the
+  // hidden h1 first), no-js sees only fallback + noscript.
+  const STREAMED_PAGE =
+    `<!doctype html><html><head><title>Streamed</title>` +
+    `<link rel="canonical" href="${url}"/></head>` +
+    `<body><main>Loading</main>` +
+    `<noscript><h1>Crawler hero</h1></noscript>` +
+    `<div hidden id="S:0"><h1>Streamed heading</h1><p>${PARAGRAPH}</p></div></body></html>`;
+
+  const request = async (requested, consume) =>
+    consume(
+      new Response(STREAMED_PAGE, {
+        status: 200,
+        headers: { "content-type": "text/html; charset=utf-8" },
+      })
+    );
+
+  it("no-js mode (the default) classifies a hidden-chunk page as thin", async () => {
+    const record = await inspectUrl(request, url);
+
+    assert.equal(record.visibilityMode, "no-js");
+    assert.equal(record.h1, "Crawler hero");
+    assert.ok(record.textLength < 100, `textLength ${record.textLength}`);
+    assert.ok(record.rawTextLength > 200, `rawTextLength ${record.rawTextLength}`);
+    assert.equal(record.meaningful, false);
+    assert.equal(classify(record, url), CLASSIFICATIONS.THIN);
+  });
+
+  it("raw mode preserves the historical counting for old-report comparability", async () => {
+    const record = await inspectUrl(request, url, { visibilityMode: "raw" });
+
+    assert.equal(record.visibilityMode, "raw");
+    // Historical semantics exactly: the first h1 in raw document order (here
+    // the noscript one — the old extractor never modeled visibility at all)
+    // and a text length that counts the hidden chunk's prose.
+    assert.equal(record.h1, "Crawler hero");
+    assert.equal(record.textLength, record.rawTextLength);
+    assert.ok(record.rawTextLength > 200, `rawTextLength ${record.rawTextLength}`);
+    assert.equal(record.meaningful, true);
+    assert.equal(classify(record, url), CLASSIFICATIONS.OK);
+  });
+
+  it("a page whose h1 and prose live in noscript is meaningful in no-js mode", async () => {
+    const noscriptUrl = `${CANONICAL}/noscript-page`;
+    const noscriptRequest = async (_requested, consume) =>
+      consume(
+        new Response(
+          `<!doctype html><html><head><title>T</title>` +
+            `<link rel="canonical" href="${noscriptUrl}"/></head>` +
+            `<body><noscript><h1>Hero</h1><p>${PARAGRAPH}</p></noscript></body></html>`,
+          { status: 200, headers: { "content-type": "text/html; charset=utf-8" } }
+        )
+      );
+
+    const record = await inspectUrl(noscriptRequest, noscriptUrl);
+    assert.equal(record.meaningful, true);
+    assert.equal(classify(record, noscriptUrl), CLASSIFICATIONS.OK);
+  });
+
+  it("rejects an unknown visibility mode", async () => {
+    await assert.rejects(
+      () => inspectUrl(request, url, { visibilityMode: "rendered" }),
+      /Invalid visibilityMode/
+    );
+    assert.throws(() => assertVisibilityMode("rendered"), /Invalid visibilityMode/);
   });
 });
 
@@ -681,6 +853,17 @@ describe("crawl-sitemap CLI", () => {
     assert.equal(fromDefaults.concurrency, 3);
     assert.equal(fromDefaults.delayMs, 250);
     assert.equal(fromDefaults.rootSitemapUrl, `${CANONICAL}/sitemap.xml`);
+  });
+
+  it("defaults to no-js visibility, accepts raw, and rejects anything else", () => {
+    assert.equal(resolveConfig({}, {}).visibilityMode, "no-js");
+    assert.equal(resolveConfig({ visibilityMode: "raw" }, {}).visibilityMode, "raw");
+    assert.equal(resolveConfig({}, { CRAWL_VISIBILITY_MODE: "raw" }).visibilityMode, "raw");
+    assert.equal(parseArgs(["--visibility-mode", "raw"]).visibilityMode, "raw");
+    assert.throws(
+      () => resolveConfig({ visibilityMode: "rendered" }, {}),
+      /Invalid visibilityMode/
+    );
   });
 
   it("rejects non-numeric numeric flags", () => {

--- a/scripts/indexability/crawl-sitemap.mjs
+++ b/scripts/indexability/crawl-sitemap.mjs
@@ -37,6 +37,23 @@ const DEFAULT_MAX_URLS_PER_SITEMAP = 50000;
 const DEFAULT_USER_AGENT =
   "KarmaSitemapCrawler/1.0 (+https://www.karmahq.xyz; internal SEO audit; contact=engineering@karmahq.xyz)";
 
+// How `textLength` / `h1` model the reader. `no-js` is the truthful default:
+// it excludes `hidden` subtrees (streamed Suspense chunks) and includes
+// `<noscript>` content. `raw` preserves the historical raw-markup counting for
+// comparison against older reports.
+export const VISIBILITY_MODES = Object.freeze({
+  NO_JS: "no-js",
+  RAW: "raw",
+});
+const DEFAULT_VISIBILITY_MODE = VISIBILITY_MODES.NO_JS;
+
+export function assertVisibilityMode(value) {
+  if (value !== VISIBILITY_MODES.NO_JS && value !== VISIBILITY_MODES.RAW) {
+    throw new Error(`Invalid visibilityMode: "${value}" (expected "no-js" or "raw")`);
+  }
+  return value;
+}
+
 export const CLASSIFICATIONS = Object.freeze({
   OK: "ok",
   NON_200: "non-200",
@@ -67,6 +84,7 @@ export async function crawlSitemap({
   delayMs = DEFAULT_DELAY_MS,
   timeoutMs = DEFAULT_TIMEOUT_MS,
   minContentChars = DEFAULT_MIN_CONTENT_CHARS,
+  visibilityMode = DEFAULT_VISIBILITY_MODE,
   knownIssues = [],
   userAgent = DEFAULT_USER_AGENT,
   maxSitemapDepth = DEFAULT_MAX_SITEMAP_DEPTH,
@@ -78,6 +96,7 @@ export async function crawlSitemap({
   if (typeof fetch !== "function") {
     throw new Error("crawlSitemap requires an injected `fetch`");
   }
+  assertVisibilityMode(visibilityMode);
   const allowlist = normalizeKnownIssues(knownIssues);
   const root = safeUrl(rootSitemapUrl);
   if (!root) {
@@ -163,7 +182,7 @@ export async function crawlSitemap({
     selected,
     concurrency,
     async ({ url, sitemap }) => {
-      const inspected = await inspectUrl(request, url, { minContentChars });
+      const inspected = await inspectUrl(request, url, { minContentChars, visibilityMode });
       const classification = classify(inspected, url);
       const allowed =
         classification === CLASSIFICATIONS.OK
@@ -186,6 +205,7 @@ export async function crawlSitemap({
   return {
     timestamp,
     root: root.href,
+    visibilityMode,
     children,
     results,
     summary,
@@ -231,12 +251,21 @@ export function selectSample(
 /**
  * Fetch one page and extract everything a non-rendering crawler would see.
  * Never throws: a transport failure becomes `{ error }` on the record.
+ *
+ * `visibilityMode` selects the content model:
+ * - `"no-js"` (default): text and h1 come from the markup a scripting-disabled
+ *   renderer displays — `hidden` subtrees excluded, `<noscript>` content
+ *   included (see extractNoJsVisibleHtml). `rawTextLength` is still recorded
+ *   so a report shows how much content sits in hidden streamed chunks.
+ * - `"raw"`: the pre-existing raw-markup measure, for comparability with
+ *   older reports.
  */
 export async function inspectUrl(
   request,
   url,
-  { minContentChars = DEFAULT_MIN_CONTENT_CHARS } = {}
+  { minContentChars = DEFAULT_MIN_CONTENT_CHARS, visibilityMode = DEFAULT_VISIBILITY_MODE } = {}
 ) {
+  assertVisibilityMode(visibilityMode);
   let fetched;
   try {
     fetched = await request(url, async (response) => ({
@@ -258,14 +287,23 @@ export async function inspectUrl(
       title: null,
       h1: null,
       textLength: 0,
+      rawTextLength: 0,
+      visibilityMode,
       meaningful: false,
     };
   }
 
   const html = fetched.body ?? "";
   const canonicalHref = extractCanonical(html);
-  const textLength = visibleTextLength(html);
-  const h1 = extractFirstTagText(html, "h1");
+  const rawTextLength = visibleTextLength(html);
+  // Head-level signals (canonical, robots, title) are read from the raw markup
+  // in both modes: they live in <head>, are never inside a hidden streamed
+  // chunk, and a crawler reads them regardless of rendering.
+  const contentHtml =
+    visibilityMode === VISIBILITY_MODES.NO_JS ? extractNoJsVisibleHtml(html) : html;
+  const textLength =
+    visibilityMode === VISIBILITY_MODES.NO_JS ? visibleTextLength(contentHtml) : rawTextLength;
+  const h1 = extractFirstTagText(contentHtml, "h1");
 
   return {
     url,
@@ -278,6 +316,8 @@ export async function inspectUrl(
     title: extractFirstTagText(html, "title"),
     h1,
     textLength,
+    rawTextLength,
+    visibilityMode,
     meaningful: textLength >= minContentChars && Boolean(h1),
   };
 }
@@ -519,10 +559,12 @@ const HTML_COMMENT = /<!--[\s\S]*?-->/g;
 const TAG = /<[^>]*>/g;
 
 /**
- * Length of the text a reader sees with JavaScript disabled: script, style,
- * noscript, template and JSON-LD payloads are removed first so a page whose
- * only "content" is a serialized RSC payload or structured data is not counted
- * as meaningful.
+ * Length of the text present in the raw markup outside script, style, noscript,
+ * template and JSON-LD payloads. This is the RAW measure: it does not model the
+ * `hidden` attribute, so text inside a streamed Suspense chunk
+ * (`<div hidden id="S:n">…</div>`) still counts. Kept as-is for
+ * `visibilityMode: "raw"` and for comparability with pre-existing crawl
+ * reports; the truth-telling measure is `extractNoJsVisibleHtml` below.
  */
 export function visibleTextLength(html) {
   if (!html) {
@@ -534,6 +576,161 @@ export function visibleTextLength(html) {
     .replace(TAG, " ")
     .replace(/&nbsp;/gi, " ");
   return decodeHtmlEntities(stripped).replace(/\s+/g, " ").trim().length;
+}
+
+// Elements that never contribute rendered text, in any mode. `noscript` is
+// deliberately NOT here — see extractNoJsVisibleHtml.
+const RAW_TEXT_CONTAINERS = new Set(["script", "style", "template"]);
+
+// Void elements never take a closing tag, so they must not be pushed onto the
+// open-element stack (an unclosed <img> would otherwise swallow the document).
+const VOID_ELEMENTS = new Set([
+  "area",
+  "base",
+  "br",
+  "col",
+  "embed",
+  "hr",
+  "img",
+  "input",
+  "link",
+  "meta",
+  "param",
+  "source",
+  "track",
+  "wbr",
+]);
+
+// One start/end tag, capturing: [ , closingSlash, tagName, attributes,
+// selfClosingSlash]. Quoted attribute runs are consumed as units so a `>`
+// inside an attribute value does not terminate the tag early.
+const TAG_TOKEN = /<(\/)?([a-zA-Z][a-zA-Z0-9-]*)((?:"[^"]*"|'[^']*'|[^"'>])*)(\/)?>/g;
+
+const ATTRIBUTE_TOKEN = /([^\s=/]+)(?:\s*=\s*(?:"[^"]*"|'[^']*'|[^\s>]*))?/g;
+
+/**
+ * True when the tag's attribute string carries the `hidden` attribute (bare,
+ * `hidden=""`, `hidden="hidden"`, or `hidden="until-found"` — none of them is
+ * displayed by a renderer, so all of them count as hidden here). Attribute
+ * NAMES are tokenized rather than substring-matched, so `class="is hidden"`
+ * does not false-positive.
+ */
+function hasHiddenAttribute(attributes) {
+  if (!attributes) {
+    return false;
+  }
+  ATTRIBUTE_TOKEN.lastIndex = 0;
+  let match = ATTRIBUTE_TOKEN.exec(attributes);
+  while (match !== null) {
+    if (match[1].toLowerCase() === "hidden") {
+      return true;
+    }
+    match = ATTRIBUTE_TOKEN.exec(attributes);
+  }
+  return false;
+}
+
+/**
+ * Reduce raw HTML to the markup a renderer with JavaScript DISABLED actually
+ * displays. This is the crawler's model of the no-JS reader, and it exists
+ * because raw-text counting has a proven blind spot: on this app every dynamic
+ * route streams its page segment as a `<div hidden id="S:n">` chunk that only
+ * client-side script reveals, so a page whose whole body is hidden passed the
+ * old meaningful-content check while a no-JS renderer showed just a loading
+ * fallback (PR #1967's QA round caught exactly this on find-funders).
+ *
+ * Visibility rules, in precedence order:
+ *
+ * 1. Content inside any element carrying the `hidden` attribute is INVISIBLE,
+ *    unconditionally. This includes a `<noscript>` nested inside a hidden
+ *    element: `hidden` removes the subtree from rendering before the noscript
+ *    question ever arises.
+ * 2. `<noscript>` content is VISIBLE — it is precisely what a scripting-
+ *    disabled renderer shows — so the wrapper tags are unwrapped and the inner
+ *    markup is kept. A hidden element INSIDE a noscript stays invisible (a
+ *    no-JS renderer parses noscript children as normal DOM and honors their
+ *    attributes), which is rule 1 applying inside rule 2.
+ * 3. `script`, `style` and `template` content is never rendered text, in any
+ *    context — including inside a noscript.
+ *
+ * Tag handling is a single-pass stack scan (this module is dependency-free by
+ * design — no HTML parser). Closing tags pop to the nearest matching open tag,
+ * so benign mis-nesting self-corrects; a truly unclosed hidden element hides
+ * the rest of its enclosing document, which matches what a forgiving HTML
+ * parser building that DOM would do. Comments are stripped up front so
+ * commented-out markup can not open or close anything.
+ */
+export function extractNoJsVisibleHtml(html) {
+  if (!html) {
+    return "";
+  }
+  const source = html.replace(HTML_COMMENT, " ");
+  const stack = [];
+  let hiddenDepth = 0;
+  let rawTextDepth = 0;
+  const out = [];
+  let cursor = 0;
+
+  TAG_TOKEN.lastIndex = 0;
+  let match = TAG_TOKEN.exec(source);
+  while (match !== null) {
+    const [tag, closing, rawName, attributes, selfClosing] = match;
+    const name = rawName.toLowerCase();
+
+    // Text run before this tag.
+    if (match.index > cursor && hiddenDepth === 0 && rawTextDepth === 0) {
+      out.push(source.slice(cursor, match.index));
+    }
+    cursor = match.index + tag.length;
+
+    // A tag is emitted only while its element is visible: the noscript wrapper
+    // is unwrapped (tags dropped, content kept); raw-text containers and
+    // anything hidden contribute no markup at all.
+    if (closing) {
+      const visibleBefore = hiddenDepth === 0 && rawTextDepth === 0;
+      for (let index = stack.length - 1; index >= 0; index -= 1) {
+        if (stack[index].name === name) {
+          for (let popped = stack.length - 1; popped >= index; popped -= 1) {
+            if (stack[popped].hidden) {
+              hiddenDepth -= 1;
+            }
+            if (stack[popped].rawText) {
+              rawTextDepth -= 1;
+            }
+          }
+          stack.length = index;
+          break;
+        }
+      }
+      const visibleAfter = hiddenDepth === 0 && rawTextDepth === 0;
+      if (visibleBefore && visibleAfter && name !== "noscript") {
+        out.push(tag);
+      }
+    } else {
+      if (!selfClosing && !VOID_ELEMENTS.has(name)) {
+        const hidden = hasHiddenAttribute(attributes);
+        const rawText = RAW_TEXT_CONTAINERS.has(name);
+        stack.push({ name, hidden, rawText });
+        if (hidden) {
+          hiddenDepth += 1;
+        }
+        if (rawText) {
+          rawTextDepth += 1;
+        }
+      }
+      if (hiddenDepth === 0 && rawTextDepth === 0 && name !== "noscript") {
+        out.push(tag);
+      }
+    }
+
+    match = TAG_TOKEN.exec(source);
+  }
+
+  if (cursor < source.length && hiddenDepth === 0 && rawTextDepth === 0) {
+    out.push(source.slice(cursor));
+  }
+
+  return out.join("");
 }
 
 export function extractFirstTagText(html, tagName) {
@@ -796,6 +993,7 @@ export const CRAWL_DEFAULTS = Object.freeze({
   delayMs: DEFAULT_DELAY_MS,
   timeoutMs: DEFAULT_TIMEOUT_MS,
   minContentChars: DEFAULT_MIN_CONTENT_CHARS,
+  visibilityMode: DEFAULT_VISIBILITY_MODE,
   userAgent: DEFAULT_USER_AGENT,
   maxSitemapDepth: DEFAULT_MAX_SITEMAP_DEPTH,
   maxSitemapBytes: DEFAULT_MAX_SITEMAP_BYTES,


### PR DESCRIPTION
## Overview

Follow-up to the PR #1967 QA finding (DEV-586 / AEO-03): the sitemap crawler counted raw markup text, so a page whose entire content sits in a hidden streamed Suspense chunk (`<div hidden id="S:n">`, revealed only by client-side script) passed the meaningful-content check even though a renderer without JavaScript displays only the loading fallback. The crawler passed find-funders while QA correctly failed it — the tool was measuring the wrong reader.

## What changed

`scripts/indexability/crawl-sitemap.mjs` gains `extractNoJsVisibleHtml()`, a dependency-free single-pass tag-stack scan (the module's no-parser-library constraint is preserved) that reduces raw HTML to what a scripting-disabled renderer displays:

1. **`hidden` excludes.** Text inside any element carrying the `hidden` attribute (bare, `=""`, `="hidden"`, or `="until-found"` — none is displayed) does not count toward visible text, and an `<h1>` inside one does not satisfy the h1 check. Attribute *names* are tokenized, so `class="is hidden"` cannot false-positive.
2. **`<noscript>` includes.** Noscript content counts for both text length and h1 — it is exactly what a no-JS renderer shows. The wrapper is unwrapped; the inner markup is kept.
3. **Precedence: `hidden` always wins.** `noscript > div[hidden]` stays invisible (a no-JS renderer parses noscript children as normal DOM and honors their attributes); `div[hidden] > noscript` never renders at all. Documented in the code and pinned by tests in both nesting directions.
4. `script`/`style`/`template` content stays invisible everywhere, including inside noscript. Head-level signals (canonical, robots directives, title) still come from the raw markup — they are never inside a streamed chunk and a crawler reads them regardless of rendering.

`inspectUrl` records now carry `rawTextLength` alongside the mode-dependent `textLength`, so a single no-js report also shows how much content sits hidden, and `visibilityMode` is stamped on each record and on the report root.

### The `--visibility-mode` flag

`--visibility-mode raw|no-js` (env: `CRAWL_VISIBILITY_MODE`), **defaulting to `no-js`**. Justification: the production sanity crawl below shows the no-JS model flips essentially the whole sitemap to `thin` — 203 of 204 sampled URLs. That blast radius makes the default report unusable as a pass/fail regression gate *today*, which is exactly why the flag exists — but the default still tells the truth, because a crawler whose whole premise is "what does a non-rendering reader see" must not default to a mode with a proven blind spot. `raw` preserves the historical counting bit-for-bit (including its quirks: h1 matched anywhere in document order, noscript text excluded) for comparison against pre-v1.8.21 baselines and for running the crawl as a gate while the app-wide streaming issue is open.

No known-issue entries were added to mute the new failures. They are the finding, not noise.

## Production sanity crawl (updated crawler, polite defaults)

204 URLs sampled from the live sitemap tree, `visibilityMode: no-js`:

| classification | count |
|---|---|
| ok | **1** |
| thin | **203** |
| everything else | 0 |

- The **single passing URL is `/nonprofits/find-funders`** — the one route that ships a `<noscript>` hero (PR #1967): visible text 1,813 chars + visible h1.
- **All 203 thin records have `rawTextLength` ≥ 200** — every one flipped purely because its content sits in hidden streamed chunks; none is thin for lack of markup. Under `--visibility-mode raw` this same crawl reproduces the 204/204 pass reported after v1.8.21.
- Breakdown of the 203 by route class: `/community/*/programs/*` 77, `/project/*` 40, `/knowledge/*` 25 + index, `/blog/*` 25 + index, `/community/*` roots 15, and one each for `/`, `/projects`, `/communities`, `/funders`, `/funding-map`, `/seeds`, `/create-project-profile`, `/mcp/connect`, `/foundations`, `/donor-advisors`, `/nonprofits`, `/for-agents`, `/about`, `/contact`, `/privacy-policy`, `/terms-and-conditions`, and the three `find-funders/connect*` pages.
- Typical shape (visible vs raw): `/projects` 240 / 25,568 chars, h1 `null`; `/seeds` 262 / 4,918, h1 `null`; `/knowledge/grant-accountability` 256 / 1,907, h1 `null` — the visible ~200–260 chars are navbar/footer chrome and loading fallbacks.

This is the app-wide consequence of dynamic rendering (root layout reads request headers) + `loading.tsx` boundaries: Next always streams the page segment as a hidden chunk. Fixing that is explicitly out of scope here; these numbers feed the Linear issue being filed for the app-wide problem.

## Tests

`node --test scripts/indexability/__tests__/` — **145 tests, all passing** (35 new):

- `extractNoJsVisibleHtml`: hidden streamed chunk excluded (text + h1); noscript included (text + h1); h1-in-hidden + h1-in-noscript satisfied by the noscript one only; both nesting precedences (`noscript>div[hidden]` hidden, `div[hidden]>noscript` hidden); all four `hidden` attribute spellings; attribute-value false-positive guard; script/style/template stripped inside noscript; nested hidden; void elements inside hidden subtrees; empty input.
- `inspectUrl` modes: the motivating page (fallback + noscript h1 + hidden prose) classifies `thin` in `no-js` and `ok` in `raw`; a noscript-content page is meaningful in `no-js`; unknown mode rejected.
- CLI: flag/env parsing, `no-js` default, invalid value rejected.

Biome and `tsc --noEmit` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable visibility modes for sitemap crawling.
  * The default mode measures content visible without JavaScript while excluding hidden and non-content markup.
  * Added a raw mode for compatibility with previous measurements.
  * Visibility mode can be selected through the command line or environment configuration.
* **Bug Fixes**
  * Improved handling of hidden, nested, malformed, and streamed HTML content during inspection.
* **Tests**
  * Added comprehensive coverage for visibility extraction, configuration overrides, defaults, and invalid values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->