### PR TITLE
feat(seo): server-render the community funding-opportunities directory

### DIFF
--- a/__tests__/app/community-subpage-canonicals.test.ts
+++ b/__tests__/app/community-subpage-canonicals.test.ts
@@ -2,20 +2,27 @@
  * Sitemap-membership <-> canonical consistency gate (DEV-586).
  *
  * A URL only belongs in a sitemap if it is the canonical of its own crawlable
- * content. Every community sub-page is a client-rendered shell today — a
- * production crawl (2026-08-03, Googlebot UA, JavaScript disabled) measured
- * funding-opportunities at 406 chars of visible text, updates 475, impact 613,
- * financials 501 and reports 406, while /projects returned 5578 chars that are
- * 99.9% identical to the community root's 5570, with no unique words at all.
+ * content. Most community sub-pages are client-rendered shells — a production
+ * crawl (2026-08-03, Googlebot UA, JavaScript disabled) measured updates at
+ * 475 chars of visible text, impact 613, financials 501 and reports 406, while
+ * /projects returned 5578 chars that are 99.9% identical to the community
+ * root's 5570, with no unique words at all.
  *
- * So the communities sitemap submits roots only, and the sub-pages consolidate
+ * So the communities sitemap submits community roots plus only the sub-pages
+ * that server-render their own content, and the remaining shells consolidate
  * onto the community root canonical they inherit from the layout. This file
  * pins both halves of that contract:
  *
- *   1. the sitemap contains community roots and nothing else;
- *   2. no shell sub-page declares a self-canonical.
+ *   1. the sitemap contains community roots and self-canonical sub-pages only;
+ *   2. no shell sub-page declares a self-canonical, and every submitted
+ *      sub-page does.
  *
- * Re-adding a sub-page to the sitemap fails (1) until it also declares a
+ * `funding-opportunities` crossed over in DEV-611: the program directory is
+ * prefetched server-side into the initial HTML (see
+ * funding-opportunities-ssr.test.tsx), so it declares a whitelabel-aware
+ * self-canonical and ships in the sitemap again — both halves moved together.
+ *
+ * Re-adding a shell sub-page to the sitemap fails (1) until it also declares a
  * canonical, and adding a canonical fails (2) until it is also submitted — so
  * server-rendered content, canonical and sitemap entry can only move together.
  */
@@ -97,7 +104,7 @@ type MetadataModule = {
 
 /**
  * Every sub-page route under /community/<id>/, mapped to the module that owns
- * its metadata. None of these is submitted to the sitemap today.
+ * its metadata.
  */
 const SUBPAGE_METADATA_MODULES: Record<string, () => Promise<MetadataModule>> = {
   "funding-opportunities": () =>
@@ -113,8 +120,18 @@ const SUBPAGE_METADATA_MODULES: Record<string, () => Promise<MetadataModule>> = 
  * Shells whose canonical must stay inherited. `reports` is deliberately absent:
  * it already declared its own canonical before DEV-586 and that predates this
  * change, so it is left alone — it is still kept out of the sitemap below.
+ * `funding-opportunities` graduated in DEV-611: it server-renders the program
+ * directory, so it now lives in SELF_CANONICAL_SUBPAGES instead.
  */
-const SHELL_SUBPAGES = ["funding-opportunities", "projects", "updates", "impact", "financials"];
+const SHELL_SUBPAGES = ["projects", "updates", "impact", "financials"];
+
+/**
+ * Sub-pages that server-render their own content: they declare a
+ * self-referential canonical AND ship in the communities sitemap. Both halves
+ * are asserted below, so an entry can only be added here once the route
+ * genuinely carries its own crawlable content.
+ */
+const SELF_CANONICAL_SUBPAGES = ["funding-opportunities"];
 
 /** Sub-pages that always return a title (financials returns {} when unflagged). */
 const TITLED_SUBPAGES = ["funding-opportunities", "projects", "updates", "impact"];
@@ -143,25 +160,40 @@ describe("community sitemap membership and canonicals", () => {
     vi.clearAllMocks();
   });
 
-  describe("the sitemap submits community roots only", () => {
-    it("emits exactly one entry per chosen community", async () => {
+  describe("the sitemap submits community roots and self-canonical sub-pages only", () => {
+    it("emits the root plus each self-canonical sub-page per chosen community", async () => {
       expect(await sitemapUrls()).toEqual([
         `${SITE_URL}/community/celo`,
+        `${SITE_URL}/community/celo/funding-opportunities`,
         `${SITE_URL}/community/filecoin`,
+        `${SITE_URL}/community/filecoin/funding-opportunities`,
       ]);
     });
 
-    it("submits no sub-page URLs at all", async () => {
+    it("submits no sub-page URLs beyond the self-canonical ones", async () => {
       const subPageUrls = (await sitemapUrls()).filter((url) => /\/community\/[^/]+\/.+/.test(url));
-      expect(subPageUrls).toEqual([]);
+      expect(subPageUrls).toEqual([
+        `${SITE_URL}/community/celo/funding-opportunities`,
+        `${SITE_URL}/community/filecoin/funding-opportunities`,
+      ]);
     });
 
     // Named one by one so re-adding any of them is a deliberate, reviewed act
     // rather than a silent regression.
-    it.each(Object.keys(SUBPAGE_METADATA_MODULES))(
+    it.each(SHELL_SUBPAGES.concat(["reports"]))(
       "does not submit /%s while it is a client-rendered shell",
       async (subPage) => {
         expect(await sitemapUrls()).not.toContain(`${SITE_URL}/community/celo/${subPage}`);
+      }
+    );
+
+    // The other half of this pair — the self-referential canonical — is
+    // asserted in the canonicals block below, so content, canonical and
+    // sitemap entry can only move together.
+    it.each(SELF_CANONICAL_SUBPAGES)(
+      "submits /%s now that it server-renders its content",
+      async (subPage) => {
+        expect(await sitemapUrls()).toContain(`${SITE_URL}/community/celo/${subPage}`);
       }
     );
 
@@ -171,7 +203,10 @@ describe("community sitemap membership and canonicals", () => {
 
     it("falls back to uid when a community has no slug", async () => {
       chosenCommunitiesMock.mockReturnValue([{ name: "X", slug: undefined, uid: "uid-only" }]);
-      expect(await sitemapUrls()).toEqual([`${SITE_URL}/community/uid-only`]);
+      expect(await sitemapUrls()).toEqual([
+        `${SITE_URL}/community/uid-only`,
+        `${SITE_URL}/community/uid-only/funding-opportunities`,
+      ]);
     });
 
     it("emits no query strings and no duplicate URLs", async () => {
@@ -185,6 +220,27 @@ describe("community sitemap membership and canonicals", () => {
       const entries = await communitiesSitemap();
       expect(entries.every((entry) => entry.lastModified === undefined)).toBe(true);
     });
+  });
+
+  describe("self-canonical sub-pages declare themselves", () => {
+    it.each(SELF_CANONICAL_SUBPAGES)(
+      "%s declares a self-referential canonical on the main site",
+      async (subPage) => {
+        const metadata = await metadataFor(subPage, "celo");
+        expect(metadata.alternates?.canonical).toBe(`/community/celo/${subPage}`);
+      }
+    );
+
+    // On a whitelabel domain the `/community/<slug>` prefix is stripped from
+    // URLs, so the canonical must be the bare sub-path.
+    it.each(SELF_CANONICAL_SUBPAGES)(
+      "%s declares the bare sub-path canonical on a whitelabel domain",
+      async (subPage) => {
+        getWhitelabelContextMock.mockResolvedValue({ isWhitelabel: true, config: {} });
+        const metadata = await metadataFor(subPage, "celo");
+        expect(metadata.alternates?.canonical).toBe(`/${subPage}`);
+      }
+    );
   });
 
   describe("shell sub-pages consolidate onto the community root", () => {

--- a/__tests__/app/funding-opportunities-hydration.test.tsx
+++ b/__tests__/app/funding-opportunities-hydration.test.tsx
@@ -1,0 +1,132 @@
+/**
+ * Hydration continuity for the funding-opportunities directory (DEV-611).
+ *
+ * The route server-renders the program directory through a HydrationBoundary;
+ * these tests render the real server page, mount its output in jsdom the way
+ * the browser does, and then interact — pinning that the status tabs and the
+ * search box still drive the list and the URL after hydration, with the
+ * server-prefetched data (no second fetch) underneath.
+ */
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useProgramsStore } from "@/src/features/programs/lib/store";
+import type { FundingProgram } from "@/types/whitelabel-entities";
+
+const mockGet = vi.fn();
+const replaceMock = vi.fn();
+
+vi.mock("@/utilities/api/client", () => ({
+  api: {
+    get: (...args: unknown[]) => mockGet(...args),
+    post: vi.fn(),
+    put: vi.fn(),
+    patch: vi.fn(),
+    delete: vi.fn(),
+    request: vi.fn(),
+    getPaginated: vi.fn(),
+  },
+}));
+
+vi.mock("next/navigation", () => ({
+  useParams: () => ({ communityId: "celo" }),
+  useRouter: () => ({ push: vi.fn(), replace: replaceMock, prefetch: vi.fn() }),
+  usePathname: () => "/community/celo/funding-opportunities",
+  useSearchParams: () => new URLSearchParams(),
+}));
+
+function createPrograms(): FundingProgram[] {
+  return [
+    {
+      programId: "prog-open",
+      chainID: 42220,
+      name: "Open Grants",
+      metadata: {
+        title: "Open Grants",
+        description: "Live round accepting applications.",
+        startsAt: "2020-01-01T12:00:00.000Z",
+        endsAt: "2099-12-31T12:00:00.000Z",
+      },
+      applicationConfig: { isEnabled: true },
+    },
+    {
+      programId: "prog-closed",
+      chainID: 42220,
+      name: "Closed Round",
+      metadata: {
+        title: "Closed Round",
+        description: "A round whose deadline has passed.",
+        startsAt: "2020-01-01T12:00:00.000Z",
+        endsAt: "2021-01-01T12:00:00.000Z",
+      },
+      applicationConfig: { isEnabled: false },
+    },
+  ] as FundingProgram[];
+}
+
+async function renderHydratedPage() {
+  const { default: Page } = await import(
+    "@/app/community/[communityId]/(with-header)/funding-opportunities/page"
+  );
+  const ui = await Page({ params: Promise.resolve({ communityId: "celo" }) });
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(<QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  // The filter store is module-level; put it back to its defaults so each
+  // test starts from the state a fresh page load sees.
+  useProgramsStore.getState().reset();
+  mockGet.mockResolvedValue(createPrograms());
+});
+
+describe("funding-opportunities directory — post-hydration interaction", () => {
+  it("clicking the Closed tab filters the list and writes ?status=ended", async () => {
+    const user = userEvent.setup();
+    await renderHydratedPage();
+
+    // Hydrated server data: the open program renders without a client fetch.
+    expect(await screen.findByText("Open Grants")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("tab", { name: "Closed" }));
+
+    expect(screen.getByRole("tab", { name: "Closed" })).toHaveAttribute("aria-selected", "true");
+    await waitFor(() => {
+      expect(screen.getByText("Closed Round")).toBeInTheDocument();
+    });
+    expect(screen.queryByText("Open Grants")).not.toBeInTheDocument();
+    expect(replaceMock).toHaveBeenCalledWith("/community/celo/funding-opportunities?status=ended", {
+      scroll: false,
+    });
+  });
+
+  it("typing in the search box filters the list and writes ?q=", async () => {
+    const user = userEvent.setup();
+    await renderHydratedPage();
+
+    await screen.findByText("Open Grants");
+    await user.type(screen.getByLabelText("Search programs"), "closed");
+
+    await waitFor(() => {
+      expect(screen.queryByText("Open Grants")).not.toBeInTheDocument();
+    });
+    expect(replaceMock).toHaveBeenLastCalledWith(expect.stringContaining("q=closed"), {
+      scroll: false,
+    });
+  });
+
+  it("interacts against the hydrated cache without a second fetch", async () => {
+    const user = userEvent.setup();
+    await renderHydratedPage();
+
+    await screen.findByText("Open Grants");
+    await user.click(screen.getByRole("tab", { name: "Closed" }));
+    await screen.findByText("Closed Round");
+
+    // Exactly the one server-side prefetch — the client mounted against the
+    // hydrated entry and the tab click filtered in memory.
+    expect(mockGet).toHaveBeenCalledTimes(1);
+  });
+});

--- a/__tests__/app/funding-opportunities-ssr.test.tsx
+++ b/__tests__/app/funding-opportunities-ssr.test.tsx
@@ -1,0 +1,179 @@
+/**
+ * AEO acceptance tests for the community funding-opportunities directory
+ * (DEV-611).
+ *
+ * This URL ships in the communities sitemap, so the core facts of every open
+ * opportunity — title, status, deadline, funding amounts — have to be in the
+ * server-rendered HTML rather than behind a client fetch. Every test here
+ * renders through `react-dom/server`'s `renderToString`, which runs no
+ * effects — whatever it produces is exactly what a crawler or a reader with
+ * JavaScript disabled receives.
+ */
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderToString } from "react-dom/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { FundingProgram } from "@/types/whitelabel-entities";
+
+const mockGet = vi.fn();
+
+vi.mock("@/utilities/api/client", () => ({
+  api: {
+    get: (...args: unknown[]) => mockGet(...args),
+    post: vi.fn(),
+    put: vi.fn(),
+    patch: vi.fn(),
+    delete: vi.fn(),
+    request: vi.fn(),
+    getPaginated: vi.fn(),
+  },
+}));
+
+vi.mock("next/navigation", () => ({
+  useParams: () => ({ communityId: "celo" }),
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn(), prefetch: vi.fn() }),
+  usePathname: () => "/community/celo/funding-opportunities",
+  useSearchParams: () => new URLSearchParams(),
+}));
+
+const OPEN_PROGRAM_DESCRIPTION =
+  "Funding for open-source public goods teams building on the Celo network.";
+const EVERGREEN_PROGRAM_DESCRIPTION =
+  "Rolling grants for infrastructure maintainers, no application deadline.";
+
+function createPrograms(): FundingProgram[] {
+  return [
+    {
+      programId: "prog-open",
+      chainID: 42220,
+      name: "Public Goods Fund",
+      metadata: {
+        title: "Public Goods Fund",
+        description: OPEN_PROGRAM_DESCRIPTION,
+        startsAt: "2020-01-01T12:00:00.000Z",
+        // Midday UTC so the formatted day is stable in any CI timezone.
+        endsAt: "2099-12-31T12:00:00.000Z",
+        programBudget: "500000",
+        maxGrantSize: "50000",
+      },
+      applicationConfig: { isEnabled: true },
+    },
+    {
+      programId: "prog-evergreen",
+      chainID: 42220,
+      name: "Evergreen Grants",
+      metadata: {
+        title: "Evergreen Grants",
+        description: EVERGREEN_PROGRAM_DESCRIPTION,
+      },
+      applicationConfig: { isEnabled: true },
+    },
+    {
+      programId: "prog-closed",
+      chainID: 42220,
+      name: "Closed Round",
+      metadata: {
+        title: "Closed Round",
+        description: "A round whose deadline has passed.",
+        startsAt: "2020-01-01T12:00:00.000Z",
+        endsAt: "2021-01-01T12:00:00.000Z",
+      },
+      applicationConfig: { isEnabled: false },
+    },
+  ] as FundingProgram[];
+}
+
+async function renderPageToHtml(): Promise<string> {
+  const { default: Page } = await import(
+    "@/app/community/[communityId]/(with-header)/funding-opportunities/page"
+  );
+  const ui = await Page({ params: Promise.resolve({ communityId: "celo" }) });
+  // A fresh client per render, mirroring the per-request client the app
+  // provider creates — nothing is carried over between tests.
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return renderToString(<QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("funding-opportunities directory — server-rendered content", () => {
+  it("renders each open opportunity's title, status, deadline and funding facts without client JavaScript", async () => {
+    mockGet.mockResolvedValue(createPrograms());
+
+    const html = await renderPageToHtml();
+
+    // Titles — the first program renders as the featured hero, the second as
+    // an editorial card.
+    expect(html).toContain("Public Goods Fund");
+    expect(html).toContain("Evergreen Grants");
+    // Descriptions
+    expect(html).toContain(OPEN_PROGRAM_DESCRIPTION);
+    expect(html).toContain(EVERGREEN_PROGRAM_DESCRIPTION);
+    // Status — a live countdown for the deadlined (featured) program, an
+    // "Open" badge for the evergreen card with no deadline.
+    expect(html).toMatch(/\d+ days left/);
+    expect(html).toContain(">Open</span>");
+    // Deadline — the featured hero states the full date.
+    expect(html).toContain("Deadline");
+    expect(html).toContain("Dec 31, 2099");
+    // Funding facts — featured hero sidebar.
+    expect(html).toContain("Total pool");
+    expect(html).toContain("$500K");
+    expect(html).toContain("Max grant");
+    expect(html).toContain("$50K");
+    // Directory-level summary (hero KPI): the community has open programs.
+    expect(html).toContain("Open programs");
+
+    // No loading skeleton — the content is real, not a placeholder.
+    expect(html).not.toContain("animate-pulse");
+  });
+
+  it("lists open programs only under the default filter", async () => {
+    mockGet.mockResolvedValue(createPrograms());
+
+    const html = await renderPageToHtml();
+
+    // The default view is the answer to "what can I apply to now" — a closed
+    // round is reachable through the Closed tab after hydration, not in the
+    // crawlable default HTML.
+    expect(html).not.toContain("Closed Round");
+  });
+
+  it("serves the hydrated directory from a single indexer round-trip", async () => {
+    mockGet.mockResolvedValue(createPrograms());
+
+    await renderPageToHtml();
+
+    // One server-side fetch, memoized by React.cache and shared with the
+    // hydrated React Query entry — the client mounts against cached data
+    // inside its staleTime instead of refetching.
+    expect(mockGet).toHaveBeenCalledTimes(1);
+    expect(mockGet).toHaveBeenCalledWith("/v2/funding-program-configs/community/celo", {
+      isAuthorized: false,
+    });
+  });
+
+  it("renders the empty state server-side when the community has no programs", async () => {
+    mockGet.mockResolvedValue([]);
+
+    const html = await renderPageToHtml();
+
+    // The default "active" filter counts as an active filter, so the
+    // filtered-empty copy is what a no-JS reader sees.
+    expect(html).toContain("More opportunities are on the way");
+    expect(html).not.toContain("animate-pulse");
+  });
+
+  it("falls back to the client fetch path when the indexer fails", async () => {
+    mockGet.mockRejectedValue(new Error("indexer unavailable"));
+
+    const html = await renderPageToHtml();
+
+    // A transient upstream failure degrades to exactly the pre-DEV-611
+    // behaviour: the loading skeleton ships and the client retries — the
+    // outage is never hydrated as a definitive empty directory.
+    expect(html).toContain("animate-pulse");
+    expect(html).not.toContain("More opportunities are on the way");
+  });
+});

--- a/__tests__/app/sitemaps/communities/sitemap.test.ts
+++ b/__tests__/app/sitemaps/communities/sitemap.test.ts
@@ -36,29 +36,38 @@ describe("app/sitemaps/communities/sitemap.ts", () => {
     vi.clearAllMocks();
   });
 
-  // Community roots only: every sub-page is a client-rendered shell, and
-  // /projects is a byte-for-byte near-duplicate of the root. See
-  // __tests__/app/community-subpage-canonicals.test.ts for the crawl numbers
-  // and the canonical half of the contract.
-  it("emits the community root and nothing beneath it", async () => {
+  // Community roots plus the sub-pages that server-render their own content.
+  // `funding-opportunities` earned its entry in DEV-611 (server-rendered
+  // program directory + self-canonical); the remaining sub-pages are
+  // client-rendered shells, and /projects is a byte-for-byte near-duplicate of
+  // the root. See __tests__/app/community-subpage-canonicals.test.ts for the
+  // crawl numbers and the canonical half of the contract.
+  it("emits the community root and its funding-opportunities directory", async () => {
     const entries = await loadSitemap();
 
-    expect(urlsFor(entries, "celo")).toEqual([`${SITE_URL}/community/celo`]);
+    expect(urlsFor(entries, "celo")).toEqual([
+      `${SITE_URL}/community/celo`,
+      `${SITE_URL}/community/celo/funding-opportunities`,
+    ]);
   });
 
-  it.each([
-    "funding-opportunities",
-    "projects",
-    "updates",
-    "impact",
-    "reports",
-    "financials",
-    "browse-applications",
-  ])("omits /%s — no server-rendered content to index", async (subPage) => {
+  it.each(["projects", "updates", "impact", "reports", "financials", "browse-applications"])(
+    "omits /%s — no server-rendered content to index",
+    async (subPage) => {
+      const entries = await loadSitemap();
+      const urls = entries.map((entry) => entry.url);
+
+      expect(urls.some((url) => url.endsWith(`/${subPage}`))).toBe(false);
+    }
+  );
+
+  it("submits /funding-opportunities now that it server-renders the program directory", async () => {
     const entries = await loadSitemap();
     const urls = entries.map((entry) => entry.url);
 
-    expect(urls.some((url) => url.endsWith(`/${subPage}`))).toBe(false);
+    for (const community of ["celo", "filecoin"]) {
+      expect(urls).toContain(`${SITE_URL}/community/${community}/funding-opportunities`);
+    }
   });
 
   it("falls back to the uid when a community has no slug", async () => {
@@ -82,12 +91,14 @@ describe("app/sitemaps/communities/sitemap.ts", () => {
     expect(new Set(urls).size).toBe(urls.length);
   });
 
-  it("gives every community root the same priority and change frequency", async () => {
+  it("prioritizes community roots above their sub-pages", async () => {
     const entries = await loadSitemap();
 
-    expect(entries).toHaveLength(3);
+    // 3 communities x (root + funding-opportunities)
+    expect(entries).toHaveLength(6);
     for (const entry of entries) {
-      expect(entry.priority).toBe(0.9);
+      const isSubPage = /\/community\/[^/]+\/.+/.test(entry.url);
+      expect(entry.priority).toBe(isSubPage ? 0.8 : 0.9);
       expect(entry.changeFrequency).toBe("daily");
     }
   });

--- a/__tests__/integration/journeys/multi-step-flows.test.tsx
+++ b/__tests__/integration/journeys/multi-step-flows.test.tsx
@@ -658,34 +658,14 @@ describe("Multi-Step Navigation Journey Tests", () => {
   });
 
   describe("Flow 3: Program Browse → Filter → Select", () => {
+    // The route's page.tsx is an async server component that prefetches the
+    // program list; this journey exercises the client-side flow directly.
     async function importPage() {
-      // The route's page.tsx is now an async server component that prefetches
-      // the program list; this journey exercises the client-side flow, so it
-      // drives the client component directly.
       const mod = await import(
         "@/app/community/[communityId]/(with-header)/funding-opportunities/FundingOpportunitiesClient"
       );
       return mod.default;
     }
-
-    // FundingMapCard mock
-    vi.mock("@/src/features/funding-map/components/funding-map-card", () => ({
-      FundingMapCard: ({
-        program,
-        href,
-        statusSlot,
-      }: {
-        program: { metadata: { title?: string; description?: string } };
-        href?: string;
-        statusSlot?: React.ReactNode;
-      }) => (
-        <a href={href} data-testid={`program-card-${program.metadata?.title}`}>
-          <span>{program.metadata?.title}</span>
-          <span>{program.metadata?.description}</span>
-          {statusSlot}
-        </a>
-      ),
-    }));
 
     vi.mock("@/src/features/programs/components/ProgramCardSkeleton", () => ({
       ProgramCardSkeleton: () => <div data-testid="skeleton" />,

--- a/__tests__/integration/journeys/multi-step-flows.test.tsx
+++ b/__tests__/integration/journeys/multi-step-flows.test.tsx
@@ -659,8 +659,11 @@ describe("Multi-Step Navigation Journey Tests", () => {
 
   describe("Flow 3: Program Browse → Filter → Select", () => {
     async function importPage() {
+      // The route's page.tsx is now an async server component that prefetches
+      // the program list; this journey exercises the client-side flow, so it
+      // drives the client component directly.
       const mod = await import(
-        "@/app/community/[communityId]/(with-header)/funding-opportunities/page"
+        "@/app/community/[communityId]/(with-header)/funding-opportunities/FundingOpportunitiesClient"
       );
       return mod.default;
     }

--- a/__tests__/integration/pages/smoke/community-client-pages.test.tsx
+++ b/__tests__/integration/pages/smoke/community-client-pages.test.tsx
@@ -286,8 +286,14 @@ describe("Community client pages", () => {
   });
 
   it("/(with-header)/funding-opportunities renders the funding hero", async () => {
+    // The page itself is now an async server component that prefetches the
+    // program list (covered in __tests__/app/funding-opportunities-ssr.test.tsx);
+    // the client smoke check drives the client component directly.
     await renderClientPage(
-      () => import("@/app/community/[communityId]/(with-header)/funding-opportunities/page")
+      () =>
+        import(
+          "@/app/community/[communityId]/(with-header)/funding-opportunities/FundingOpportunitiesClient"
+        )
     );
     // With no programs the page renders its hero (PageHero <h1>) plus the
     // empty state — assert the hero heading and empty-state copy are present.

--- a/__tests__/lib/query-keys.test.ts
+++ b/__tests__/lib/query-keys.test.ts
@@ -98,4 +98,24 @@ describe("wlQueryKeys.programs", () => {
     expect(wlQueryKeys.programs.detail("prog-1")[0]).toBe("wl-program");
     expect(wlQueryKeys.programs.list("optimism")[0]).toBe("wl-programs-list");
   });
+
+  // The server prefetch in funding-opportunities/page.tsx and the client
+  // `usePrograms` hook both build their key from this factory — the hydrated
+  // cache entry is only picked up when the two hashes match, so the shape is
+  // pinned here.
+  it("communityList returns the ['wl-programs', communityId] key shared with the server prefetch", () => {
+    expect(wlQueryKeys.programs.communityList("celo")).toEqual(["wl-programs", "celo"]);
+  });
+
+  it("communityList keys differ per community and from the other program keys", () => {
+    expect(wlQueryKeys.programs.communityList("celo")).not.toEqual(
+      wlQueryKeys.programs.communityList("optimism")
+    );
+    expect(wlQueryKeys.programs.communityList("celo")[0]).not.toBe(
+      wlQueryKeys.programs.list("celo")[0]
+    );
+    expect(wlQueryKeys.programs.communityList("celo")[0]).not.toBe(
+      wlQueryKeys.programs.detail("celo")[0]
+    );
+  });
 });

--- a/app/community/[communityId]/(with-header)/funding-opportunities/FundingOpportunitiesClient.tsx
+++ b/app/community/[communityId]/(with-header)/funding-opportunities/FundingOpportunitiesClient.tsx
@@ -1,0 +1,483 @@
+"use client";
+
+import { AlertCircle, RefreshCw, Search } from "lucide-react";
+import Image from "next/image";
+import { useParams, usePathname, useRouter, useSearchParams } from "next/navigation";
+import pluralize from "pluralize";
+import { useCallback, useEffect, useMemo } from "react";
+import {
+  computeProgramView,
+  EditorialProgramCard,
+} from "@/components/Pages/Communities/Funding/EditorialProgramCard";
+import { FeaturedProgram } from "@/components/Pages/Communities/Funding/FeaturedProgram";
+import { PageHero } from "@/components/Pages/Communities/PageHero";
+import { ProgramCardSkeleton } from "@/src/features/programs/components/ProgramCardSkeleton";
+import { usePrograms } from "@/src/features/programs/hooks/use-programs";
+import type { ProgramStatus } from "@/types/whitelabel-entities";
+import formatCurrency from "@/utilities/formatCurrency";
+import { cn } from "@/utilities/tailwind";
+
+const STATUS_TABS: Array<{ key: ProgramStatus | "all"; label: string }> = [
+  { key: "all", label: "All" },
+  { key: "active", label: "Open" },
+  { key: "upcoming", label: "Upcoming" },
+  { key: "ended", label: "Closed" },
+];
+
+const VALID_STATUSES: ReadonlyArray<ProgramStatus | "all"> = ["all", "active", "upcoming", "ended"];
+
+const SKELETON_KEYS = ["sk-1", "sk-2", "sk-3", "sk-4", "sk-5", "sk-6"];
+
+export default function FundingOpportunitiesClient() {
+  const { communityId } = useParams<{ communityId: string }>();
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const { programs, loading, error, filters, setFilters, refetch } = usePrograms(communityId);
+
+  const urlStatusRaw = searchParams.get("status");
+  const urlStatus: ProgramStatus | "all" | null =
+    urlStatusRaw && (VALID_STATUSES as readonly string[]).includes(urlStatusRaw)
+      ? (urlStatusRaw as ProgramStatus | "all")
+      : null;
+  const urlSearch = searchParams.get("q") ?? "";
+
+  // Seed filter store from URL on mount / when URL changes externally.
+  useEffect(() => {
+    const desiredStatus = urlStatus === "all" || urlStatus === null ? undefined : urlStatus;
+    const desiredSearch = urlSearch || undefined;
+    if (filters.status !== desiredStatus || filters.search !== desiredSearch) {
+      setFilters({ ...filters, status: desiredStatus, search: desiredSearch });
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [urlStatus, urlSearch]);
+
+  const writeUrl = useCallback(
+    (next: { status?: ProgramStatus | "all"; search?: string }) => {
+      const params = new URLSearchParams(searchParams.toString());
+      if (next.status && next.status !== "all") {
+        params.set("status", next.status);
+      } else {
+        params.delete("status");
+      }
+      if (next.search?.trim()) {
+        params.set("q", next.search.trim());
+      } else {
+        params.delete("q");
+      }
+      const qs = params.toString();
+      router.replace(qs ? `${pathname}?${qs}` : pathname, { scroll: false });
+    },
+    [pathname, router, searchParams]
+  );
+
+  const stats = useMemo(() => {
+    let totalPool = 0;
+    let openCount = 0;
+    let closingNow = 0;
+    let applicants = 0;
+    for (const p of programs) {
+      const v = computeProgramView(p);
+      totalPool += v.pool;
+      applicants += v.applicants;
+      if (v.status === "open") openCount += 1;
+      if (v.urgency === "urgent" || v.urgency === "closing") closingNow += 1;
+    }
+    return { totalPool, openCount, closingNow, applicants };
+  }, [programs]);
+
+  const featured = programs[0];
+  const others = programs.slice(1);
+  const activeStatus: ProgramStatus | "all" = filters.status ?? "all";
+
+  return (
+    <div className="flex flex-col gap-10 pb-20 [&>*]:animate-fade-in-up [&>*:nth-child(1)]:[animation-delay:0ms] [&>*:nth-child(2)]:[animation-delay:80ms] [&>*:nth-child(3)]:[animation-delay:160ms]">
+      {loading ? (
+        <FundingHeroSkeleton />
+      ) : (
+        <PageHero
+          eyebrow={
+            stats.openCount > 0
+              ? `Open for funding · ${stats.openCount} live ${pluralize("program", stats.openCount)}`
+              : "Funding opportunities"
+          }
+          title={
+            programs.length > 0 ? (
+              <>
+                Grant Funding Available
+                <br />
+                <span className="text-brand-500 dark:text-brand-400">Across Multiple Programs</span>
+              </>
+            ) : (
+              <>Funding opportunities</>
+            )
+          }
+          description="Browse open programs, review their criteria, and apply for grants supporting work in this community."
+          kpis={[
+            {
+              label: "Open programs",
+              value: stats.openCount,
+              sub: "accepting now",
+            },
+            ...(stats.closingNow > 0
+              ? [
+                  {
+                    label: "Closing this week",
+                    value: stats.closingNow,
+                    sub: "apply before deadline",
+                    accent: "danger" as const,
+                  },
+                ]
+              : []),
+            {
+              label: "Total pool",
+              value: stats.totalPool > 0 ? `$${formatCurrency(stats.totalPool)}` : "—",
+              sub: "across all rounds",
+            },
+            {
+              label: "Applicants",
+              value: stats.applicants,
+              sub: "this round",
+            },
+          ]}
+        />
+      )}
+
+      <ProgramsContent
+        communityId={communityId}
+        loading={loading}
+        error={error}
+        programs={programs}
+        featured={featured}
+        others={others}
+        activeStatus={activeStatus}
+        searchValue={filters.search ?? ""}
+        onSearchChange={(v) => {
+          setFilters({ ...filters, search: v || undefined });
+          writeUrl({ status: activeStatus, search: v });
+        }}
+        onStatusChange={(key) => {
+          setFilters({ ...filters, status: key === "all" ? undefined : key });
+          writeUrl({ status: key, search: filters.search });
+        }}
+        onClearFilters={() => {
+          setFilters({ ...filters, status: undefined, search: undefined });
+          writeUrl({ status: "all", search: "" });
+        }}
+        onRetry={refetch}
+      />
+    </div>
+  );
+}
+
+interface ProgramsContentProps {
+  communityId: string;
+  loading: boolean;
+  error: Error | null;
+  programs: ReturnType<typeof usePrograms>["programs"];
+  featured: ReturnType<typeof usePrograms>["programs"][number] | undefined;
+  others: ReturnType<typeof usePrograms>["programs"];
+  activeStatus: ProgramStatus | "all";
+  searchValue: string;
+  onSearchChange: (v: string) => void;
+  onStatusChange: (key: ProgramStatus | "all") => void;
+  onClearFilters: () => void;
+  onRetry: () => void;
+}
+
+function ProgramsContent({
+  communityId,
+  loading,
+  error,
+  programs,
+  featured,
+  others,
+  activeStatus,
+  searchValue,
+  onSearchChange,
+  onStatusChange,
+  onClearFilters,
+  onRetry,
+}: ProgramsContentProps) {
+  if (loading) return <ProgramsSkeleton />;
+  if (error) return <ProgramsError onRetry={onRetry} />;
+
+  const hasActiveFilters = activeStatus !== "all" || searchValue.trim().length > 0;
+  if (programs.length === 0 && !hasActiveFilters) return <ProgramsEmpty />;
+
+  return (
+    <>
+      {featured ? <FeaturedProgram program={featured} communityId={communityId} /> : null}
+      <ProgramsToolbar
+        activeStatus={activeStatus}
+        searchValue={searchValue}
+        onSearchChange={onSearchChange}
+        onStatusChange={onStatusChange}
+      />
+      {programs.length === 0 && hasActiveFilters ? (
+        <ProgramsFilteredEmpty onClearFilters={onClearFilters} />
+      ) : others.length > 0 ? (
+        <div className="grid grid-cols-1 gap-5 md:grid-cols-2 lg:grid-cols-3">
+          {others.map((program, idx) => (
+            <div
+              key={program.programId}
+              className="animate-fade-in-up"
+              style={{ animationDelay: `${Math.min(idx, 8) * 60}ms` }}
+            >
+              <EditorialProgramCard program={program} communityId={communityId} />
+            </div>
+          ))}
+        </div>
+      ) : null}
+    </>
+  );
+}
+
+interface ToolbarProps {
+  activeStatus: ProgramStatus | "all";
+  searchValue: string;
+  onSearchChange: (v: string) => void;
+  onStatusChange: (key: ProgramStatus | "all") => void;
+}
+
+function ProgramsToolbar({
+  activeStatus,
+  searchValue,
+  onSearchChange,
+  onStatusChange,
+}: ToolbarProps) {
+  return (
+    <div className="flex flex-wrap items-center gap-3">
+      <h2 className="flex-1 text-xl md:text-2xl font-semibold tracking-[-0.02em] text-foreground">
+        All programs
+      </h2>
+
+      <div className="relative">
+        <Search
+          className="pointer-events-none absolute left-3 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground"
+          aria-hidden
+        />
+        <label htmlFor="program-search" className="sr-only">
+          Search programs
+        </label>
+        <input
+          id="program-search"
+          value={searchValue}
+          onChange={(e) => onSearchChange(e.target.value)}
+          placeholder="Search programs…"
+          className="h-9 w-56 rounded-lg border border-border bg-background pl-8 pr-3 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-brand-500"
+        />
+      </div>
+
+      <div
+        role="tablist"
+        aria-label="Filter programs by status"
+        className="flex gap-0.5 rounded-lg bg-secondary p-[3px]"
+      >
+        {STATUS_TABS.map((tab) => {
+          const isActive = activeStatus === tab.key;
+          return (
+            <button
+              key={tab.key}
+              type="button"
+              role="tab"
+              aria-selected={isActive}
+              onClick={() => onStatusChange(tab.key)}
+              className={cn(
+                "rounded-md px-3 py-1.5 text-[13px] font-medium transition",
+                isActive
+                  ? "bg-white dark:bg-zinc-900 text-foreground shadow-[0_1px_2px_rgba(0,0,0,0.05)]"
+                  : "text-muted-foreground hover:text-foreground"
+              )}
+            >
+              {tab.label}
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+function FundingHeroSkeleton() {
+  return (
+    <section
+      aria-busy="true"
+      aria-label="Loading funding opportunities"
+      className="relative overflow-hidden mb-10 md:mb-12"
+    >
+      <div
+        aria-hidden
+        className="-z-10 pointer-events-none absolute inset-0 bg-gradient-to-br from-brand-50/60 via-transparent to-transparent dark:from-brand-900/10"
+      />
+      <div className="grid gap-8 md:gap-12 md:grid-cols-[1.3fr_1fr]">
+        <div className="animate-pulse">
+          <div className="mb-3 inline-flex items-center gap-2">
+            <span className="h-1.5 w-1.5 rounded-full bg-brand-500/40" />
+            <div className="h-3 w-44 rounded-md bg-secondary" />
+          </div>
+          <div className="space-y-3">
+            <div className="h-10 md:h-12 lg:h-[52px] w-[80%] rounded-lg bg-secondary" />
+            <div className="h-10 md:h-12 lg:h-[52px] w-[55%] rounded-lg bg-secondary" />
+          </div>
+          <div className="mt-5 space-y-2">
+            <div className="h-4 w-[90%] max-w-prose rounded bg-secondary" />
+            <div className="h-4 w-[60%] max-w-prose rounded bg-secondary" />
+          </div>
+        </div>
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-px overflow-hidden rounded-2xl border border-border bg-border self-end animate-pulse">
+          {SKELETON_KEYS.slice(0, 4).map((key) => (
+            <div key={key} className="bg-background p-4 md:p-5">
+              <div className="h-3 w-20 rounded bg-secondary" />
+              <div className="mt-2 h-7 w-14 rounded bg-secondary" />
+              <div className="mt-1.5 h-3 w-24 rounded bg-secondary" />
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function ProgramsToolbarSkeleton() {
+  return (
+    <div className="flex flex-wrap items-center gap-3 animate-pulse" aria-hidden>
+      <div className="h-7 w-40 rounded bg-secondary flex-1" />
+      <div className="h-9 w-56 rounded-lg bg-secondary" />
+      <div className="h-9 w-64 rounded-lg bg-secondary" />
+    </div>
+  );
+}
+
+function FeaturedProgramSkeleton() {
+  return (
+    <div
+      className="relative overflow-hidden rounded-3xl border border-border bg-gradient-to-br from-brand-50/40 via-background to-background p-8 md:p-10 animate-pulse"
+      aria-hidden
+    >
+      <div className="grid gap-8 md:grid-cols-[1.4fr_1fr]">
+        <div className="space-y-4">
+          <div className="flex gap-2">
+            <div className="h-6 w-20 rounded-full bg-secondary" />
+            <div className="h-6 w-24 rounded-full bg-secondary" />
+          </div>
+          <div className="space-y-2">
+            <div className="h-9 w-3/4 rounded-lg bg-secondary" />
+            <div className="h-9 w-1/2 rounded-lg bg-secondary" />
+          </div>
+          <div className="space-y-2">
+            <div className="h-4 w-[90%] rounded bg-secondary" />
+            <div className="h-4 w-[70%] rounded bg-secondary" />
+          </div>
+          <div className="h-10 w-36 rounded-full bg-secondary" />
+        </div>
+        <div className="space-y-3 self-center">
+          <div className="flex justify-between border-b border-border pb-3">
+            <div className="h-4 w-20 rounded bg-secondary" />
+            <div className="h-5 w-16 rounded bg-secondary" />
+          </div>
+          <div className="flex justify-between border-b border-border pb-3">
+            <div className="h-4 w-20 rounded bg-secondary" />
+            <div className="h-5 w-16 rounded bg-secondary" />
+          </div>
+          <div className="flex justify-between">
+            <div className="h-4 w-20 rounded bg-secondary" />
+            <div className="h-5 w-16 rounded bg-secondary" />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function ProgramsSkeleton() {
+  return (
+    <div data-testid="programs-loading" className="flex flex-col gap-6" aria-busy="true">
+      <FeaturedProgramSkeleton />
+      <ProgramsToolbarSkeleton />
+      <div className="grid grid-cols-1 gap-5 md:grid-cols-2 lg:grid-cols-3">
+        {SKELETON_KEYS.map((key) => (
+          <ProgramCardSkeleton key={key} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function ProgramsError({ onRetry }: { onRetry: () => void }) {
+  return (
+    <div className="rounded-xl border border-border py-12 text-center">
+      <AlertCircle className="mx-auto mb-2 h-12 w-12 text-destructive" />
+      <h3 className="mb-1 text-lg font-semibold">Failed to load programs</h3>
+      <p className="mb-4 text-muted-foreground">
+        Something went wrong while loading programs. Please try again.
+      </p>
+      <button
+        type="button"
+        onClick={onRetry}
+        className="mx-auto flex items-center gap-2 rounded-lg bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90"
+      >
+        <RefreshCw className="h-4 w-4" />
+        Try Again
+      </button>
+    </div>
+  );
+}
+
+function ProgramsEmpty() {
+  return (
+    <div className="flex h-max flex-1 items-center justify-center rounded-xl border border-gray-200 dark:border-zinc-800 bg-white dark:bg-zinc-900 px-6 py-16">
+      <div className="flex max-w-[438px] flex-col items-center justify-center gap-6">
+        <Image
+          src="/images/comments.png"
+          alt="No funding opportunities yet"
+          width={438}
+          height={185}
+          className="object-cover"
+          loading="lazy"
+        />
+        <div className="flex w-full flex-col items-center justify-center gap-3">
+          <p className="text-center text-lg font-semibold text-black dark:text-zinc-100">
+            No programs available
+          </p>
+          <p className="text-center text-base font-normal text-gray-600 dark:text-zinc-400">
+            There are currently no funding programs in this community. Check back later for new
+            opportunities.
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function ProgramsFilteredEmpty({ onClearFilters }: { onClearFilters: () => void }) {
+  return (
+    <div className="flex h-max flex-1 items-center justify-center rounded-xl border border-gray-200 dark:border-zinc-800 bg-white dark:bg-zinc-900 px-6 py-16">
+      <div className="flex max-w-[438px] flex-col items-center justify-center gap-6">
+        <Image
+          src="/images/comments.png"
+          alt="No matching programs"
+          width={438}
+          height={185}
+          className="object-cover"
+          loading="lazy"
+        />
+        <div className="flex w-full flex-col items-center justify-center gap-3">
+          <p className="text-center text-lg font-semibold text-black dark:text-zinc-100">
+            More opportunities are on the way
+          </p>
+          <p className="text-center text-base font-normal text-gray-600 dark:text-zinc-400">
+            Try other filters or check back later for new opportunities.
+          </p>
+          <button
+            type="button"
+            onClick={onClearFilters}
+            className="mt-2 inline-flex items-center justify-center rounded-md border border-gray-300 dark:border-zinc-700 px-4 py-2 text-sm font-semibold text-gray-700 dark:text-zinc-200 hover:bg-gray-50 dark:hover:bg-zinc-800 transition-colors"
+          >
+            Clear filters
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/community/[communityId]/(with-header)/funding-opportunities/layout.tsx
+++ b/app/community/[communityId]/(with-header)/funding-opportunities/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { PROJECT_NAME } from "@/constants/brand";
+import { communitySubpageMetadata } from "@/utilities/metadata/communityCanonical";
 import { getCommunityDetails } from "@/utilities/queries/v2/getCommunityData";
 
 type LayoutProps = {
@@ -7,9 +8,10 @@ type LayoutProps = {
   params: Promise<{ communityId: string }>;
 };
 
-// The page itself is a client component, so its metadata lives here. Without it
-// the funding directory inherits the community layout's canonical and title,
-// which made a sitemap-listed URL point at `/community/<id>`.
+// The rendered directory lives in a client component, so its metadata lives
+// here. Without it the funding directory inherits the community layout's
+// canonical and title, which made a sitemap-listed URL point at
+// `/community/<id>`.
 export async function generateMetadata({
   params,
 }: {
@@ -19,11 +21,14 @@ export async function generateMetadata({
   const community = await getCommunityDetails(communityId);
   const communityName = community?.details?.name || communityId;
 
-  // No self-canonical: this route is a client-rendered shell, so it is absent
-  // from the sitemap and consolidates onto the community root canonical it
-  // inherits from the layout. Give it server-rendered content first, then a
-  // canonical and a sitemap entry together.
+  // Self-canonical (whitelabel-aware): the page now server-renders the program
+  // directory into the initial HTML, so it carries its own crawlable content
+  // and ships in the communities sitemap again — canonical, content and
+  // sitemap entry moved together (DEV-611).
+  const canonicalMetadata = await communitySubpageMetadata(communityId, "funding-opportunities");
+
   return {
+    ...canonicalMetadata,
     title: `${communityName} Funding Opportunities | ${PROJECT_NAME}`,
     description: `Find open, upcoming, and closed grant programs from ${communityName}. Compare funding amounts, deadlines, and eligibility before you apply on ${PROJECT_NAME}.`,
   };

--- a/app/community/[communityId]/(with-header)/funding-opportunities/page.tsx
+++ b/app/community/[communityId]/(with-header)/funding-opportunities/page.tsx
@@ -3,7 +3,7 @@ import { cache } from "react";
 import {
   DEFAULT_PROGRAMS_LIMIT,
   PROGRAMS_LIST_STALE_TIME,
-} from "@/src/features/programs/hooks/use-programs";
+} from "@/src/features/programs/lib/constants";
 import { wlQueryKeys } from "@/src/lib/query-keys";
 import type { FundingProgram } from "@/types/whitelabel-entities";
 import { api } from "@/utilities/api/client";

--- a/app/community/[communityId]/(with-header)/funding-opportunities/page.tsx
+++ b/app/community/[communityId]/(with-header)/funding-opportunities/page.tsx
@@ -1,483 +1,63 @@
-"use client";
-
-import { AlertCircle, RefreshCw, Search } from "lucide-react";
-import Image from "next/image";
-import { useParams, usePathname, useRouter, useSearchParams } from "next/navigation";
-import pluralize from "pluralize";
-import { useCallback, useEffect, useMemo } from "react";
+import { dehydrate, HydrationBoundary, QueryClient } from "@tanstack/react-query";
+import { cache } from "react";
 import {
-  computeProgramView,
-  EditorialProgramCard,
-} from "@/components/Pages/Communities/Funding/EditorialProgramCard";
-import { FeaturedProgram } from "@/components/Pages/Communities/Funding/FeaturedProgram";
-import { PageHero } from "@/components/Pages/Communities/PageHero";
-import { ProgramCardSkeleton } from "@/src/features/programs/components/ProgramCardSkeleton";
-import { usePrograms } from "@/src/features/programs/hooks/use-programs";
-import type { ProgramStatus } from "@/types/whitelabel-entities";
-import formatCurrency from "@/utilities/formatCurrency";
-import { cn } from "@/utilities/tailwind";
+  DEFAULT_PROGRAMS_LIMIT,
+  PROGRAMS_LIST_STALE_TIME,
+} from "@/src/features/programs/hooks/use-programs";
+import { wlQueryKeys } from "@/src/lib/query-keys";
+import type { FundingProgram } from "@/types/whitelabel-entities";
+import { api } from "@/utilities/api/client";
+import { INDEXER } from "@/utilities/indexer";
+import { defaultQueryOptions } from "@/utilities/queries/defaultOptions";
+import FundingOpportunitiesClient from "./FundingOpportunitiesClient";
 
-const STATUS_TABS: Array<{ key: ProgramStatus | "all"; label: string }> = [
-  { key: "all", label: "All" },
-  { key: "active", label: "Open" },
-  { key: "upcoming", label: "Upcoming" },
-  { key: "ended", label: "Closed" },
-];
+type Params = Promise<{ communityId: string }>;
 
-const VALID_STATUSES: ReadonlyArray<ProgramStatus | "all"> = ["all", "active", "upcoming", "ended"];
-
-const SKELETON_KEYS = ["sk-1", "sk-2", "sk-3", "sk-4", "sk-5", "sk-6"];
-
-export default function FundingOpportunitiesPage() {
-  const { communityId } = useParams<{ communityId: string }>();
-  const router = useRouter();
-  const pathname = usePathname();
-  const searchParams = useSearchParams();
-  const { programs, loading, error, filters, setFilters, refetch } = usePrograms(communityId);
-
-  const urlStatusRaw = searchParams.get("status");
-  const urlStatus: ProgramStatus | "all" | null =
-    urlStatusRaw && (VALID_STATUSES as readonly string[]).includes(urlStatusRaw)
-      ? (urlStatusRaw as ProgramStatus | "all")
-      : null;
-  const urlSearch = searchParams.get("q") ?? "";
-
-  // Seed filter store from URL on mount / when URL changes externally.
-  useEffect(() => {
-    const desiredStatus = urlStatus === "all" || urlStatus === null ? undefined : urlStatus;
-    const desiredSearch = urlSearch || undefined;
-    if (filters.status !== desiredStatus || filters.search !== desiredSearch) {
-      setFilters({ ...filters, status: desiredStatus, search: desiredSearch });
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [urlStatus, urlSearch]);
-
-  const writeUrl = useCallback(
-    (next: { status?: ProgramStatus | "all"; search?: string }) => {
-      const params = new URLSearchParams(searchParams.toString());
-      if (next.status && next.status !== "all") {
-        params.set("status", next.status);
-      } else {
-        params.delete("status");
-      }
-      if (next.search?.trim()) {
-        params.set("q", next.search.trim());
-      } else {
-        params.delete("q");
-      }
-      const qs = params.toString();
-      router.replace(qs ? `${pathname}?${qs}` : pathname, { scroll: false });
-    },
-    [pathname, router, searchParams]
+// Server-side programs fetch, memoized with React.cache so any other reader in
+// the same request (metadata, layout) shares one indexer round-trip. Public
+// endpoint (isAuthorized false) — this page ships in the communities sitemap.
+const getCommunityPrograms = cache(async (communityId: string): Promise<FundingProgram[]> => {
+  // TODO(#1775): add zod schema
+  const programs = await api.get<FundingProgram[]>(
+    INDEXER.V2.FUNDING_PROGRAMS.BY_COMMUNITY(encodeURIComponent(communityId)),
+    { isAuthorized: false }
   );
+  return programs ?? [];
+});
 
-  const stats = useMemo(() => {
-    let totalPool = 0;
-    let openCount = 0;
-    let closingNow = 0;
-    let applicants = 0;
-    for (const p of programs) {
-      const v = computeProgramView(p);
-      totalPool += v.pool;
-      applicants += v.applicants;
-      if (v.status === "open") openCount += 1;
-      if (v.urgency === "urgent" || v.urgency === "closing") closingNow += 1;
-    }
-    return { totalPool, openCount, closingNow, applicants };
-  }, [programs]);
+// The program directory is prefetched here and handed to the client tree as a
+// hydrated React Query cache entry, so each opportunity's title, status,
+// deadline and funding facts are in the initial HTML instead of behind a
+// client fetch — crawlers and no-JS readers see the real directory, not the
+// loading skeleton.
+//
+// `prefetchQuery` swallows a rejected fetch and `dehydrate` omits failed
+// queries, so an indexer outage degrades to exactly the previous behaviour:
+// the client fetches and shows the skeleton. `retry: false` keeps a failing
+// prefetch from blocking the response on React Query's backoff — the client
+// still retries under its own defaults.
+export default async function FundingOpportunitiesPage({ params }: { params: Params }) {
+  const { communityId } = await params;
 
-  const featured = programs[0];
-  const others = programs.slice(1);
-  const activeStatus: ProgramStatus | "all" = filters.status ?? "all";
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: defaultQueryOptions },
+  });
+
+  await queryClient.prefetchQuery({
+    queryKey: wlQueryKeys.programs.communityList(communityId),
+    queryFn: async () => ({
+      programs: await getCommunityPrograms(communityId),
+      // The server has no filter store; hydrate with the same default limit
+      // the client hook computes when no limit filter is set.
+      limit: DEFAULT_PROGRAMS_LIMIT,
+    }),
+    staleTime: PROGRAMS_LIST_STALE_TIME,
+    retry: false,
+  });
 
   return (
-    <div className="flex flex-col gap-10 pb-20 [&>*]:animate-fade-in-up [&>*:nth-child(1)]:[animation-delay:0ms] [&>*:nth-child(2)]:[animation-delay:80ms] [&>*:nth-child(3)]:[animation-delay:160ms]">
-      {loading ? (
-        <FundingHeroSkeleton />
-      ) : (
-        <PageHero
-          eyebrow={
-            stats.openCount > 0
-              ? `Open for funding · ${stats.openCount} live ${pluralize("program", stats.openCount)}`
-              : "Funding opportunities"
-          }
-          title={
-            programs.length > 0 ? (
-              <>
-                Grant Funding Available
-                <br />
-                <span className="text-brand-500 dark:text-brand-400">Across Multiple Programs</span>
-              </>
-            ) : (
-              <>Funding opportunities</>
-            )
-          }
-          description="Browse open programs, review their criteria, and apply for grants supporting work in this community."
-          kpis={[
-            {
-              label: "Open programs",
-              value: stats.openCount,
-              sub: "accepting now",
-            },
-            ...(stats.closingNow > 0
-              ? [
-                  {
-                    label: "Closing this week",
-                    value: stats.closingNow,
-                    sub: "apply before deadline",
-                    accent: "danger" as const,
-                  },
-                ]
-              : []),
-            {
-              label: "Total pool",
-              value: stats.totalPool > 0 ? `$${formatCurrency(stats.totalPool)}` : "—",
-              sub: "across all rounds",
-            },
-            {
-              label: "Applicants",
-              value: stats.applicants,
-              sub: "this round",
-            },
-          ]}
-        />
-      )}
-
-      <ProgramsContent
-        communityId={communityId}
-        loading={loading}
-        error={error}
-        programs={programs}
-        featured={featured}
-        others={others}
-        activeStatus={activeStatus}
-        searchValue={filters.search ?? ""}
-        onSearchChange={(v) => {
-          setFilters({ ...filters, search: v || undefined });
-          writeUrl({ status: activeStatus, search: v });
-        }}
-        onStatusChange={(key) => {
-          setFilters({ ...filters, status: key === "all" ? undefined : key });
-          writeUrl({ status: key, search: filters.search });
-        }}
-        onClearFilters={() => {
-          setFilters({ ...filters, status: undefined, search: undefined });
-          writeUrl({ status: "all", search: "" });
-        }}
-        onRetry={refetch}
-      />
-    </div>
-  );
-}
-
-interface ProgramsContentProps {
-  communityId: string;
-  loading: boolean;
-  error: Error | null;
-  programs: ReturnType<typeof usePrograms>["programs"];
-  featured: ReturnType<typeof usePrograms>["programs"][number] | undefined;
-  others: ReturnType<typeof usePrograms>["programs"];
-  activeStatus: ProgramStatus | "all";
-  searchValue: string;
-  onSearchChange: (v: string) => void;
-  onStatusChange: (key: ProgramStatus | "all") => void;
-  onClearFilters: () => void;
-  onRetry: () => void;
-}
-
-function ProgramsContent({
-  communityId,
-  loading,
-  error,
-  programs,
-  featured,
-  others,
-  activeStatus,
-  searchValue,
-  onSearchChange,
-  onStatusChange,
-  onClearFilters,
-  onRetry,
-}: ProgramsContentProps) {
-  if (loading) return <ProgramsSkeleton />;
-  if (error) return <ProgramsError onRetry={onRetry} />;
-
-  const hasActiveFilters = activeStatus !== "all" || searchValue.trim().length > 0;
-  if (programs.length === 0 && !hasActiveFilters) return <ProgramsEmpty />;
-
-  return (
-    <>
-      {featured ? <FeaturedProgram program={featured} communityId={communityId} /> : null}
-      <ProgramsToolbar
-        activeStatus={activeStatus}
-        searchValue={searchValue}
-        onSearchChange={onSearchChange}
-        onStatusChange={onStatusChange}
-      />
-      {programs.length === 0 && hasActiveFilters ? (
-        <ProgramsFilteredEmpty onClearFilters={onClearFilters} />
-      ) : others.length > 0 ? (
-        <div className="grid grid-cols-1 gap-5 md:grid-cols-2 lg:grid-cols-3">
-          {others.map((program, idx) => (
-            <div
-              key={program.programId}
-              className="animate-fade-in-up"
-              style={{ animationDelay: `${Math.min(idx, 8) * 60}ms` }}
-            >
-              <EditorialProgramCard program={program} communityId={communityId} />
-            </div>
-          ))}
-        </div>
-      ) : null}
-    </>
-  );
-}
-
-interface ToolbarProps {
-  activeStatus: ProgramStatus | "all";
-  searchValue: string;
-  onSearchChange: (v: string) => void;
-  onStatusChange: (key: ProgramStatus | "all") => void;
-}
-
-function ProgramsToolbar({
-  activeStatus,
-  searchValue,
-  onSearchChange,
-  onStatusChange,
-}: ToolbarProps) {
-  return (
-    <div className="flex flex-wrap items-center gap-3">
-      <h2 className="flex-1 text-xl md:text-2xl font-semibold tracking-[-0.02em] text-foreground">
-        All programs
-      </h2>
-
-      <div className="relative">
-        <Search
-          className="pointer-events-none absolute left-3 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground"
-          aria-hidden
-        />
-        <label htmlFor="program-search" className="sr-only">
-          Search programs
-        </label>
-        <input
-          id="program-search"
-          value={searchValue}
-          onChange={(e) => onSearchChange(e.target.value)}
-          placeholder="Search programs…"
-          className="h-9 w-56 rounded-lg border border-border bg-background pl-8 pr-3 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-brand-500"
-        />
-      </div>
-
-      <div
-        role="tablist"
-        aria-label="Filter programs by status"
-        className="flex gap-0.5 rounded-lg bg-secondary p-[3px]"
-      >
-        {STATUS_TABS.map((tab) => {
-          const isActive = activeStatus === tab.key;
-          return (
-            <button
-              key={tab.key}
-              type="button"
-              role="tab"
-              aria-selected={isActive}
-              onClick={() => onStatusChange(tab.key)}
-              className={cn(
-                "rounded-md px-3 py-1.5 text-[13px] font-medium transition",
-                isActive
-                  ? "bg-white dark:bg-zinc-900 text-foreground shadow-[0_1px_2px_rgba(0,0,0,0.05)]"
-                  : "text-muted-foreground hover:text-foreground"
-              )}
-            >
-              {tab.label}
-            </button>
-          );
-        })}
-      </div>
-    </div>
-  );
-}
-
-function FundingHeroSkeleton() {
-  return (
-    <section
-      aria-busy="true"
-      aria-label="Loading funding opportunities"
-      className="relative overflow-hidden mb-10 md:mb-12"
-    >
-      <div
-        aria-hidden
-        className="-z-10 pointer-events-none absolute inset-0 bg-gradient-to-br from-brand-50/60 via-transparent to-transparent dark:from-brand-900/10"
-      />
-      <div className="grid gap-8 md:gap-12 md:grid-cols-[1.3fr_1fr]">
-        <div className="animate-pulse">
-          <div className="mb-3 inline-flex items-center gap-2">
-            <span className="h-1.5 w-1.5 rounded-full bg-brand-500/40" />
-            <div className="h-3 w-44 rounded-md bg-secondary" />
-          </div>
-          <div className="space-y-3">
-            <div className="h-10 md:h-12 lg:h-[52px] w-[80%] rounded-lg bg-secondary" />
-            <div className="h-10 md:h-12 lg:h-[52px] w-[55%] rounded-lg bg-secondary" />
-          </div>
-          <div className="mt-5 space-y-2">
-            <div className="h-4 w-[90%] max-w-prose rounded bg-secondary" />
-            <div className="h-4 w-[60%] max-w-prose rounded bg-secondary" />
-          </div>
-        </div>
-        <div className="grid grid-cols-1 sm:grid-cols-2 gap-px overflow-hidden rounded-2xl border border-border bg-border self-end animate-pulse">
-          {SKELETON_KEYS.slice(0, 4).map((key) => (
-            <div key={key} className="bg-background p-4 md:p-5">
-              <div className="h-3 w-20 rounded bg-secondary" />
-              <div className="mt-2 h-7 w-14 rounded bg-secondary" />
-              <div className="mt-1.5 h-3 w-24 rounded bg-secondary" />
-            </div>
-          ))}
-        </div>
-      </div>
-    </section>
-  );
-}
-
-function ProgramsToolbarSkeleton() {
-  return (
-    <div className="flex flex-wrap items-center gap-3 animate-pulse" aria-hidden>
-      <div className="h-7 w-40 rounded bg-secondary flex-1" />
-      <div className="h-9 w-56 rounded-lg bg-secondary" />
-      <div className="h-9 w-64 rounded-lg bg-secondary" />
-    </div>
-  );
-}
-
-function FeaturedProgramSkeleton() {
-  return (
-    <div
-      className="relative overflow-hidden rounded-3xl border border-border bg-gradient-to-br from-brand-50/40 via-background to-background p-8 md:p-10 animate-pulse"
-      aria-hidden
-    >
-      <div className="grid gap-8 md:grid-cols-[1.4fr_1fr]">
-        <div className="space-y-4">
-          <div className="flex gap-2">
-            <div className="h-6 w-20 rounded-full bg-secondary" />
-            <div className="h-6 w-24 rounded-full bg-secondary" />
-          </div>
-          <div className="space-y-2">
-            <div className="h-9 w-3/4 rounded-lg bg-secondary" />
-            <div className="h-9 w-1/2 rounded-lg bg-secondary" />
-          </div>
-          <div className="space-y-2">
-            <div className="h-4 w-[90%] rounded bg-secondary" />
-            <div className="h-4 w-[70%] rounded bg-secondary" />
-          </div>
-          <div className="h-10 w-36 rounded-full bg-secondary" />
-        </div>
-        <div className="space-y-3 self-center">
-          <div className="flex justify-between border-b border-border pb-3">
-            <div className="h-4 w-20 rounded bg-secondary" />
-            <div className="h-5 w-16 rounded bg-secondary" />
-          </div>
-          <div className="flex justify-between border-b border-border pb-3">
-            <div className="h-4 w-20 rounded bg-secondary" />
-            <div className="h-5 w-16 rounded bg-secondary" />
-          </div>
-          <div className="flex justify-between">
-            <div className="h-4 w-20 rounded bg-secondary" />
-            <div className="h-5 w-16 rounded bg-secondary" />
-          </div>
-        </div>
-      </div>
-    </div>
-  );
-}
-
-function ProgramsSkeleton() {
-  return (
-    <div data-testid="programs-loading" className="flex flex-col gap-6" aria-busy="true">
-      <FeaturedProgramSkeleton />
-      <ProgramsToolbarSkeleton />
-      <div className="grid grid-cols-1 gap-5 md:grid-cols-2 lg:grid-cols-3">
-        {SKELETON_KEYS.map((key) => (
-          <ProgramCardSkeleton key={key} />
-        ))}
-      </div>
-    </div>
-  );
-}
-
-function ProgramsError({ onRetry }: { onRetry: () => void }) {
-  return (
-    <div className="rounded-xl border border-border py-12 text-center">
-      <AlertCircle className="mx-auto mb-2 h-12 w-12 text-destructive" />
-      <h3 className="mb-1 text-lg font-semibold">Failed to load programs</h3>
-      <p className="mb-4 text-muted-foreground">
-        Something went wrong while loading programs. Please try again.
-      </p>
-      <button
-        type="button"
-        onClick={onRetry}
-        className="mx-auto flex items-center gap-2 rounded-lg bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90"
-      >
-        <RefreshCw className="h-4 w-4" />
-        Try Again
-      </button>
-    </div>
-  );
-}
-
-function ProgramsEmpty() {
-  return (
-    <div className="flex h-max flex-1 items-center justify-center rounded-xl border border-gray-200 dark:border-zinc-800 bg-white dark:bg-zinc-900 px-6 py-16">
-      <div className="flex max-w-[438px] flex-col items-center justify-center gap-6">
-        <Image
-          src="/images/comments.png"
-          alt="No funding opportunities yet"
-          width={438}
-          height={185}
-          className="object-cover"
-          loading="lazy"
-        />
-        <div className="flex w-full flex-col items-center justify-center gap-3">
-          <p className="text-center text-lg font-semibold text-black dark:text-zinc-100">
-            No programs available
-          </p>
-          <p className="text-center text-base font-normal text-gray-600 dark:text-zinc-400">
-            There are currently no funding programs in this community. Check back later for new
-            opportunities.
-          </p>
-        </div>
-      </div>
-    </div>
-  );
-}
-
-function ProgramsFilteredEmpty({ onClearFilters }: { onClearFilters: () => void }) {
-  return (
-    <div className="flex h-max flex-1 items-center justify-center rounded-xl border border-gray-200 dark:border-zinc-800 bg-white dark:bg-zinc-900 px-6 py-16">
-      <div className="flex max-w-[438px] flex-col items-center justify-center gap-6">
-        <Image
-          src="/images/comments.png"
-          alt="No matching programs"
-          width={438}
-          height={185}
-          className="object-cover"
-          loading="lazy"
-        />
-        <div className="flex w-full flex-col items-center justify-center gap-3">
-          <p className="text-center text-lg font-semibold text-black dark:text-zinc-100">
-            More opportunities are on the way
-          </p>
-          <p className="text-center text-base font-normal text-gray-600 dark:text-zinc-400">
-            Try other filters or check back later for new opportunities.
-          </p>
-          <button
-            type="button"
-            onClick={onClearFilters}
-            className="mt-2 inline-flex items-center justify-center rounded-md border border-gray-300 dark:border-zinc-700 px-4 py-2 text-sm font-semibold text-gray-700 dark:text-zinc-200 hover:bg-gray-50 dark:hover:bg-zinc-800 transition-colors"
-          >
-            Clear filters
-          </button>
-        </div>
-      </div>
-    </div>
+    <HydrationBoundary state={dehydrate(queryClient)}>
+      <FundingOpportunitiesClient />
+    </HydrationBoundary>
   );
 }

--- a/app/sitemaps/communities/sitemap.ts
+++ b/app/sitemaps/communities/sitemap.ts
@@ -2,31 +2,45 @@ import type { MetadataRoute } from "next";
 import { chosenCommunities } from "@/utilities/chosenCommunities";
 import { SITE_URL } from "@/utilities/meta";
 
-// Community roots only.
+// Community roots, plus the sub-pages that have earned an entry.
 //
-// Every sub-page under /community/<id>/ is currently a client-rendered shell:
-// a crawl of production (2026-08-03, Googlebot UA, JavaScript disabled) measured
-// funding-opportunities 406 chars, updates 475, impact 613, financials 501 and
-// reports 406 of visible text, while /projects rendered 5578 chars that are
-// 99.9% identical to the community root's 5570 with no unique words at all.
+// Most sub-pages under /community/<id>/ are still client-rendered shells: a
+// crawl of production (2026-08-03, Googlebot UA, JavaScript disabled) measured
+// updates 475, impact 613, financials 501 and reports 406 chars of visible
+// text, while /projects rendered 5578 chars that are 99.9% identical to the
+// community root's 5570 with no unique words at all.
 //
-// Submitting those would ask Google to index five thin pages plus a literal
+// Submitting those would ask Google to index thin pages plus a literal
 // duplicate of a URL already in this sitemap, so they stay out and consolidate
 // onto the community root via the layout canonical they inherit. They still
 // serve 200 — they are de-listed, not removed.
 //
 // A sub-page earns an entry here once it server-renders content a crawler can
-// read AND declares its own canonical. `communitySubpageCanonicals` in
-// __tests__/app/community-subpage-canonicals.test.ts fails if one is added
-// without both, so this cannot be undone by accident.
+// read AND declares its own canonical. `funding-opportunities` cleared that bar
+// in DEV-611: the program directory (title, status, deadline, funding facts)
+// is prefetched server-side into the initial HTML and the route declares a
+// whitelabel-aware self-canonical. `communitySubpageCanonicals` in
+// __tests__/app/community-subpage-canonicals.test.ts fails if an entry is
+// added without both halves, so this cannot be undone by accident.
+const SELF_CANONICAL_SUBPAGES = ["funding-opportunities"] as const;
 
 // `lastModified` is intentionally omitted — we have no accurate per-page
 // modified date, and a fabricated "now" makes Google distrust the signal
 // (see utilities/sitemap.ts buildUrlsetXml).
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
-  return chosenCommunities().map((community) => ({
-    url: `${SITE_URL}/community/${community.slug || community.uid}`,
-    changeFrequency: "daily" as const,
-    priority: 0.9,
-  }));
+  return chosenCommunities().flatMap((community) => {
+    const root = `${SITE_URL}/community/${community.slug || community.uid}`;
+    return [
+      {
+        url: root,
+        changeFrequency: "daily" as const,
+        priority: 0.9,
+      },
+      ...SELF_CANONICAL_SUBPAGES.map((subPage) => ({
+        url: `${root}/${subPage}`,
+        changeFrequency: "daily" as const,
+        priority: 0.8,
+      })),
+    ];
+  });
 }

--- a/scripts/crawl-sitemap.mjs
+++ b/scripts/crawl-sitemap.mjs
@@ -27,21 +27,10 @@ import {
  * without JavaScript". Every entry needs a written justification: this list is
  * the record of what is queued for a fix or for removal, not a mute button.
  */
-export const DEFAULT_KNOWN_ISSUES = Object.freeze([
-  {
-    pathnameEndsWith: "/funding-opportunities",
-    classifications: ["thin"],
-    // The floor is what keeps this from muting a whole route class. The entry
-    // only excuses the gap between the server-rendered community header and the
-    // 200-char threshold; if a page drops below the header's own worth of prose,
-    // the header has regressed too and that is a failure this entry does not
-    // cover. Calibrate against the post-deploy crawl report, never upward to
-    // make a red run go green.
-    minTextLength: 120,
-    reason:
-      "Client-rendered program directory. It is self-canonical with unique metadata (DEV-586) and the community header gives it a heading and prose, but the program cards themselves only exist after hydration, so a stricter content threshold can classify it thin. Queued for SSR seeding as a follow-up; only that failure mode, and only while the header still renders, is excused.",
-  },
-]);
+// Currently empty: the last entry (/funding-opportunities, excused as a
+// client-rendered program directory) was removed in DEV-611 when the route
+// started server-rendering the program cards into the initial HTML.
+export const DEFAULT_KNOWN_ISSUES = Object.freeze([]);
 
 const DEFAULTS = Object.freeze({
   rootSitemapUrl: CRAWL_DEFAULTS.rootSitemapUrl,

--- a/scripts/indexability/__tests__/crawl-sitemap-robustness.test.mjs
+++ b/scripts/indexability/__tests__/crawl-sitemap-robustness.test.mjs
@@ -322,7 +322,11 @@ describe("known-issue content floor", () => {
     assert.equal(report.ok, false);
   });
 
-  it("still excuses the documented near-threshold case", async () => {
+  // The near-threshold excuse for /funding-opportunities was retired in
+  // DEV-611: the route now server-renders the program directory, so a page
+  // that comes back with only the community header's worth of prose is a real
+  // regression the default list must NOT mute.
+  it("no longer excuses a header-only funding-opportunities page by default", async () => {
     const target = `${CANONICAL}/community/celo/funding-opportunities`;
     const header =
       "Celo Community Grants funds public goods across the Celo ecosystem, and this directory lists every open program.";
@@ -335,9 +339,9 @@ describe("known-issue content floor", () => {
     );
 
     assert.equal(report.results[0].classification, CLASSIFICATIONS.THIN);
-    assert.equal(report.results[0].allowlisted, true);
-    assert.equal(report.summary.failing.length, 0);
-    assert.equal(report.ok, true);
+    assert.equal(report.results[0].allowlisted, false);
+    assert.equal(report.summary.failing.length, 1);
+    assert.equal(report.ok, false);
   });
 
   it("ships a floor on every default thin excuse", () => {

--- a/scripts/indexability/__tests__/crawl-sitemap.test.mjs
+++ b/scripts/indexability/__tests__/crawl-sitemap.test.mjs
@@ -602,9 +602,12 @@ describe("normalizeKnownIssues", () => {
     assert.equal(matchKnownIssue(allowlist, `${CANONICAL}/y`, CLASSIFICATIONS.THIN), null);
   });
 
-  it("ships a scoped, justified default allowlist", () => {
+  // The default list may be empty — that is the goal state (the last entry,
+  // /funding-opportunities, was removed in DEV-611 when the route started
+  // server-rendering its content). Any entry that IS shipped must be scoped
+  // and justified.
+  it("every shipped default allowlist entry is scoped and justified", () => {
     const normalized = normalizeKnownIssues(DEFAULT_KNOWN_ISSUES);
-    assert.ok(normalized.length > 0);
     for (const entry of normalized) {
       assert.ok(entry.reason.length > 20, `weak justification: ${entry.reason}`);
       assert.ok(Array.isArray(entry.classifications), `unscoped allowlist entry: ${entry.reason}`);

--- a/src/features/programs/hooks/use-programs.ts
+++ b/src/features/programs/hooks/use-programs.ts
@@ -1,9 +1,26 @@
 import { useQuery } from "@tanstack/react-query";
 import { useEffect, useMemo } from "react";
+import { wlQueryKeys } from "@/src/lib/query-keys";
 import type { FundingProgram, ProgramFilters, ProgramStatus } from "@/types/whitelabel-entities";
 import { api } from "@/utilities/api/client";
+import { INDEXER } from "@/utilities/indexer";
 import { useProgramsStore } from "../lib/store";
 import type { UseProgramsReturn } from "../types";
+
+/**
+ * Shared with the server prefetch in `funding-opportunities/page.tsx`. The
+ * hydrated cache entry is only considered fresh — and therefore not refetched
+ * on mount — while both sides agree on this window.
+ */
+export const PROGRAMS_LIST_STALE_TIME = 5 * 60 * 1000;
+
+/**
+ * Default page size when no explicit limit filter is set. The server prefetch
+ * has no filter store, so it hydrates with this value — the two sides must
+ * agree or the hydrated entry would be structurally different from a client
+ * fetch.
+ */
+export const DEFAULT_PROGRAMS_LIMIT = 20;
 
 function matchesStatus(program: FundingProgram, status: ProgramStatus): boolean {
   const now = new Date();
@@ -46,16 +63,16 @@ export function usePrograms(
     programs: FundingProgram[];
     limit: number;
   }>({
-    queryKey: ["wl-programs", communityId],
+    queryKey: wlQueryKeys.programs.communityList(communityId),
     queryFn: async () => {
-      const limit = filters.limit || 20;
+      const limit = filters.limit || DEFAULT_PROGRAMS_LIMIT;
       // TODO(#1775): add zod schema
       const res = await api.get<FundingProgram[]>(
-        `/v2/funding-program-configs/community/${communityId}`
+        INDEXER.V2.FUNDING_PROGRAMS.BY_COMMUNITY(encodeURIComponent(communityId))
       );
       return { programs: res ?? [], limit };
     },
-    staleTime: 5 * 60 * 1000,
+    staleTime: PROGRAMS_LIST_STALE_TIME,
     enabled: !!communityId,
   });
 

--- a/src/features/programs/hooks/use-programs.ts
+++ b/src/features/programs/hooks/use-programs.ts
@@ -4,23 +4,9 @@ import { wlQueryKeys } from "@/src/lib/query-keys";
 import type { FundingProgram, ProgramFilters, ProgramStatus } from "@/types/whitelabel-entities";
 import { api } from "@/utilities/api/client";
 import { INDEXER } from "@/utilities/indexer";
+import { DEFAULT_PROGRAMS_LIMIT, PROGRAMS_LIST_STALE_TIME } from "../lib/constants";
 import { useProgramsStore } from "../lib/store";
 import type { UseProgramsReturn } from "../types";
-
-/**
- * Shared with the server prefetch in `funding-opportunities/page.tsx`. The
- * hydrated cache entry is only considered fresh — and therefore not refetched
- * on mount — while both sides agree on this window.
- */
-export const PROGRAMS_LIST_STALE_TIME = 5 * 60 * 1000;
-
-/**
- * Default page size when no explicit limit filter is set. The server prefetch
- * has no filter store, so it hydrates with this value — the two sides must
- * agree or the hydrated entry would be structurally different from a client
- * fetch.
- */
-export const DEFAULT_PROGRAMS_LIMIT = 20;
 
 function matchesStatus(program: FundingProgram, status: ProgramStatus): boolean {
   const now = new Date();

--- a/src/features/programs/lib/constants.ts
+++ b/src/features/programs/lib/constants.ts
@@ -1,0 +1,20 @@
+/**
+ * Constants shared between the server prefetch in
+ * `funding-opportunities/page.tsx` and the client `usePrograms` hook. They
+ * live outside the hook file because the server component may not import a
+ * module that uses client-only React APIs.
+ */
+
+/**
+ * The hydrated cache entry is only considered fresh — and therefore not
+ * refetched on mount — while both sides agree on this window.
+ */
+export const PROGRAMS_LIST_STALE_TIME = 5 * 60 * 1000;
+
+/**
+ * Default page size when no explicit limit filter is set. The server prefetch
+ * has no filter store, so it hydrates with this value — the two sides must
+ * agree or the hydrated entry would be structurally different from a client
+ * fetch.
+ */
+export const DEFAULT_PROGRAMS_LIMIT = 20;

--- a/src/lib/query-keys.ts
+++ b/src/lib/query-keys.ts
@@ -37,6 +37,13 @@ export const wlQueryKeys = {
     list: (communityId: string, address?: string | null) =>
       ["wl-programs-list", communityId, address ?? null] as const,
     /**
+     * The public funding-program directory of a community. Shared by the
+     * server prefetch in `funding-opportunities/page.tsx` and the client
+     * `usePrograms` hook — the hydrated cache entry only lands if both sides
+     * produce the same key.
+     */
+    communityList: (communityId: string) => ["wl-programs", communityId] as const,
+    /**
      * A single funding program. Shared by the server prefetch in
      * `programs/[programId]/page.tsx` and the client `useProgram` hook — the
      * hydrated cache entry only lands if both sides produce the same key.


### PR DESCRIPTION
## Overview

Implements **DEV-611 (AEO-16)**: server-render `/community/<id>/funding-opportunities`.

The funding-opportunities directory — the literal answer page for the highest-volume funder-discovery prompt lane — rendered only ~406 chars of client shell without JavaScript (vs 5,570 for the community root). This PR ships the directory's core facts (title, status, deadline, funding amounts, applicant counts) in the initial HTML, then flips the two listing decisions DEV-586 made because the page was thin.

## What changed

### 1. Server-rendered directory (AEO-02 pattern, PR #1956)

`page.tsx` is now an async server component: a `React.cache`-wrapped fetch of `GET /v2/funding-program-configs/community/<id>` (public, `isAuthorized: false`) is prefetched into a React Query cache and handed to the client tree through `HydrationBoundary` — one indexer round-trip, shared key `wlQueryKeys.programs.communityList(communityId)` pinned by tests on both sides. The former page body moved unchanged to `FundingOpportunitiesClient.tsx`.

Failure semantics mirror #1956: `prefetchQuery` swallows a rejected fetch and `dehydrate` omits failed queries, so an indexer outage degrades to exactly the previous behaviour (skeleton + client retry) instead of hydrating a false empty directory. `retry: false` keeps a failing prefetch from blocking the response on backoff.

Shared constants (`PROGRAMS_LIST_STALE_TIME`, `DEFAULT_PROGRAMS_LIMIT`) live in `src/features/programs/lib/constants.ts` because a server component may not import the hook module (it uses `useEffect`).

### 2. Re-listing (the DEV-586 / PR #1962 flip, both halves together)

- **Self-canonical, whitelabel-aware** via `communitySubpageMetadata` in the route layout (`/community/<id>/funding-opportunities` on the main site, `/funding-opportunities` on whitelabel domains).
- **Back in the communities sitemap** (`app/sitemaps/communities/sitemap.ts`), priority 0.8 under the 0.9 root.
- `__tests__/app/community-subpage-canonicals.test.ts` updated: `funding-opportunities` moved from the shell list to a new `SELF_CANONICAL_SUBPAGES` list that asserts both the sitemap entry and the self-canonical (main-site + whitelabel), so content, canonical and sitemap entry still only move together.

### 3. Crawler known-issues entry retired

The `/funding-opportunities` entry in `DEFAULT_KNOWN_ISSUES` (`scripts/crawl-sitemap.mjs`) existed solely to excuse this route's thinness and its own comment said it must not outlive the fix. It is removed; the crawler tests now assert a header-only funding-opportunities page **fails** the crawl instead of being allowlisted.

## Smoke results

`pnpm build && pnpm start`, then curl as Googlebot with no JavaScript. (The build's baked `NEXT_PUBLIC_GAP_INDEXER_URL` points at the staging indexer; the open Celo program shown below — Prezenti Almond Round, `isEnabled: true`, no `endsAt` — is identical on the production indexer, verified via the API directly.)

```
$ curl -s -A "Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)" \
    http://localhost:3123/community/celo/funding-opportunities
```

Canonical in the response:

```html
<link rel="canonical" href="https://www.karmahq.xyz/community/celo/funding-opportunities"/>
```

Rendered directory text present in the initial HTML (no JS executed):

```
Open for funding · 1 live program  Grant Funding Available Across Multiple Programs
Browse open programs, review their criteria, and apply for grants supporting work in this community.
Open programs 1 accepting now  Total pool — across all rounds  Applicants 13 this round
Open  Featured  Prezenti Almond Round  Apply before deadline  View details  Applicants 13 teams
All programs  Search programs  All Open Upcoming Closed
```

Celo currently has exactly one open program (Prezenti Almond Round, no `endsAt` in its metadata), so the live proof shows the `Open` status badge with no deadline row — that is the data, not the rendering. The SSR test pins the deadline path: a program with `endsAt` renders `Deadline / Dec 31, 2099` in the featured sidebar and `Closes <date>` / `Nd left` on cards (a deadlined open program renders a countdown badge such as `26813 days left`).

**Visible vs hidden:** the directory lands inside a hidden streamed Suspense chunk (`<div hidden id="S:3">`), the same as every sibling community sub-page — the community header itself streams hidden app-wide, so the visible shell of this page (237 chars) matches the community root's local visible shell (232 chars). Raw-HTML crawlers read the content either way; making streamed content land visible is the app-wide issue tracked as DEV-612 and deliberately not attempted here.

## QA finding P4 (hydration continuity) — investigated, not reproducible

A QA pass reported the Closed filter tab dead after hydration (aria-selected stuck, URL never gaining `?status=`). Investigated against local prod builds of **both this branch and main** with Playwright:

- Trusted click, programmatic click, and a click dispatched 2.8ms after the tabs entered the DOM all work on this branch: URL gains `?status=ended`, `aria-selected` moves to Closed, the card list re-filters. Search-then-tab and rapid tab sequences also behave.
- main (built at 88459e4) produces the byte-identical interaction trace — expected, since `FundingOpportunitiesClient.tsx` is main's `page.tsx` verbatim (`diff` shows only the function name changed).
- Hydration continuity is intact: zero browser requests to `funding-program-configs` after load — the client mounts on the server-prefetched entry.

Since the finding could not be reproduced on either build (note the Vercel preview for the tested commit failed to deploy with the environment's known OOM, so the harness may have exercised a stale preview), the interaction is pinned instead of changed: `__tests__/app/funding-opportunities-hydration.test.tsx` renders the real server page, mounts it, and asserts tab click → filtered list + `?status=ended`, search → `?q=`, and no second fetch.

## Tests

- New `__tests__/app/funding-opportunities-ssr.test.tsx` (pattern of `knowledge-collection-ssr.test.tsx` / `program-detail-ssr.test.tsx`): `renderToString` with no effects pins titles, status badges, deadline, funding facts, open-only default filter, single indexer round-trip, server-rendered empty state, and skeleton fallback on indexer failure.
- `community-subpage-canonicals.test.ts`, `sitemaps/communities/sitemap.test.ts`, `query-keys.test.ts`, crawler unit tests updated for both halves of the flip.
- `__tests__/app` + `__tests__/integration/pages/smoke` + `__tests__/lib`: 586 tests passing; `scripts/indexability` node tests: 83 passing; `tsc --noEmit` clean; `pnpm lint:fix` clean on touched files.

## Out of scope

`/updates`, `/impact`, `/projects`, `/browse-applications`, the app-wide hidden-streaming issue (DEV-612), `artifacts/`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a funding opportunities directory for each community with server-rendered content.
  * Added status and search filtering, URL synchronization, program statistics, featured opportunities, and clear loading, error, and empty states.
  * Funding opportunity pages now provide self-canonical metadata and appear in community sitemaps.
* **Bug Fixes**
  * Improved page hydration so filters and interactions work without unnecessary additional requests.
  * Removed the funding opportunities page from default crawl exemptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->