### PR TITLE
fix(for-agents): render the page title through the site-wide template

### DIFF
--- a/app/for-agents/page.tsx
+++ b/app/for-agents/page.tsx
@@ -5,19 +5,16 @@ import { FAQJsonLd } from "@/components/Seo/FAQJsonLd";
 import { SoftwareApplicationJsonLd } from "@/components/Seo/SoftwareApplicationJsonLd";
 import { customMetadata } from "@/utilities/meta";
 
-const PAGE_TITLE = "Connect Karma to your AI Agents — Karma";
+// Rendered as "Connect Karma to your AI Agents | Karma" by the root layout's
+// `%s | Karma` title template, matching the rest of the site.
+const PAGE_TITLE = "Connect Karma to your AI Agents";
 
-export const metadata: Metadata = {
-  ...customMetadata({
-    title: PAGE_TITLE,
-    description:
-      "Connect Karma to your Claude, Cursor, or Codex to search funding programs, nonprofit and IRS 990 data, and grant history — or take actions on your behalf.",
-    path: "/for-agents",
-  }),
-  // The root layout applies a `%s | Karma` title template; the reviewed title
-  // already carries the brand, so opt out to avoid "— Karma | Karma".
-  title: { absolute: PAGE_TITLE },
-};
+export const metadata: Metadata = customMetadata({
+  title: PAGE_TITLE,
+  description:
+    "Connect Karma to your Claude, Cursor, or Codex to search funding programs, nonprofit and IRS 990 data, and grant history — or take actions on your behalf.",
+  path: "/for-agents",
+});
 
 export default function Page() {
   return (


### PR DESCRIPTION
Reviewer follow-up on #1973: the em-dash brand suffix diverged from the site-wide "| Karma" template. Removes the absolute-title opt-out so the layout template renders "Connect Karma to your AI Agents | Karma", consistent with every other page.

Refs DEV-595.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the AI Agents page title to use the site-wide title format.
  * Removed duplicate branding from the page title for a more consistent experience.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->