### PR TITLE
feat(find-funders): direct-answer FAQ for funder-discovery prompts

### DIFF
--- a/__tests__/app/aeo-crawl-eligibility.test.tsx
+++ b/__tests__/app/aeo-crawl-eligibility.test.tsx
@@ -278,10 +278,17 @@ describe("/nonprofits/find-funders — server-rendered landing page", () => {
   });
 
   describe("direct-answer FAQ (DEV-595 experiment E5)", () => {
+    /**
+     * `visibleText` replaces tags with a space, so an answer that ends in a
+     * linked URL renders as "…connect ." — collapse the space the anchor's
+     * closing tag left before punctuation so prose comparisons still hold.
+     */
+    const faqProse = (html: string) => visibleText(html).replace(/\s+([.,;:!?])/g, "$1");
+
     it("the noscript replica carries every FAQ question and answer for no-JS readers", async () => {
       const { FIND_FUNDERS_FAQS } = await import("@/src/features/non-profits/lib/faq-content");
       const { noscriptHtml } = await renderFindFunders();
-      const text = visibleText(noscriptInner(noscriptHtml));
+      const text = faqProse(noscriptInner(noscriptHtml));
 
       for (const faq of FIND_FUNDERS_FAQS) {
         expect(text).toContain(faq.question);
@@ -292,7 +299,7 @@ describe("/nonprofits/find-funders — server-rendered landing page", () => {
     it("the page itself renders the same FAQ section", async () => {
       const { FIND_FUNDERS_FAQS } = await import("@/src/features/non-profits/lib/faq-content");
       const { pageHtml } = await renderFindFunders();
-      const text = visibleText(pageHtml);
+      const text = faqProse(pageHtml);
 
       for (const faq of FIND_FUNDERS_FAQS) {
         expect(text).toContain(faq.question);
@@ -335,6 +342,40 @@ describe("/nonprofits/find-funders — server-rendered landing page", () => {
       // Data coverage claim stays tied to the reviewed stats module.
       const { FILINGS_STATS } = await import("@/src/features/non-profits/lib/stats");
       expect(text).toContain(`over ${FILINGS_STATS.countLong} filings`);
+    });
+
+    it("renders the URL mentions as anchors in the page and the noscript replica", async () => {
+      const { FIND_FUNDERS_FAQ_LINKS } = await import("@/src/features/non-profits/lib/faq-content");
+      const { NON_PROFITS_PAGES } = await import("@/utilities/pages");
+      const { noscriptHtml, pageHtml } = await renderFindFunders();
+
+      // The internal link resolves through the route constant, not a
+      // hardcoded path; the MCP endpoint is external and absolute.
+      expect(FIND_FUNDERS_FAQ_LINKS["karmahq.xyz/nonprofits/find-funders/connect"]).toBe(
+        NON_PROFITS_PAGES.CONNECT
+      );
+
+      for (const html of [noscriptInner(noscriptHtml), pageHtml]) {
+        expect(html).toContain('href="https://gapapi.karmahq.xyz/mcp"');
+        expect(html).toContain(`href="${NON_PROFITS_PAGES.CONNECT}"`);
+      }
+    });
+
+    it("keeps the JSON-LD answers plain text even where the visible FAQ links", async () => {
+      const { FIND_FUNDERS_FAQS } = await import("@/src/features/non-profits/lib/faq-content");
+
+      for (const faq of FIND_FUNDERS_FAQS) {
+        expect(faq.answer).not.toMatch(/<[a-z]/i);
+      }
+    });
+
+    it("keeps the FAQ prose free of em-dashes", async () => {
+      const { FIND_FUNDERS_FAQS } = await import("@/src/features/non-profits/lib/faq-content");
+
+      for (const faq of FIND_FUNDERS_FAQS) {
+        expect(faq.question).not.toContain("—");
+        expect(faq.answer).not.toContain("—");
+      }
     });
   });
 

--- a/__tests__/app/aeo-crawl-eligibility.test.tsx
+++ b/__tests__/app/aeo-crawl-eligibility.test.tsx
@@ -333,7 +333,7 @@ describe("/nonprofits/find-funders — server-rendered landing page", () => {
 
       // P007 / P028 — past grants and typical grant size from filings.
       expect(text).toContain("past grants and giving history");
-      expect(text).toContain("check-size patterns");
+      expect(text).toContain("lists each grant it paid and the amount");
       // P018 — works from ChatGPT / Claude via the MCP connector.
       expect(text).toContain("ChatGPT or Claude");
       expect(text).toContain("gapapi.karmahq.xyz/mcp");

--- a/__tests__/app/aeo-crawl-eligibility.test.tsx
+++ b/__tests__/app/aeo-crawl-eligibility.test.tsx
@@ -72,6 +72,8 @@ function visibleText(html: string): string {
     .replace(/<(script|style|noscript|template)\b[^>]*>[\s\S]*?<\/\1>/gi, " ")
     .replace(/<[^>]*>/g, " ")
     .replace(/&nbsp;/gi, " ")
+    .replace(/&(?:#x27;|#39;|apos;)/g, "'")
+    .replace(/&quot;/g, '"')
     .replace(/&amp;/g, "&")
     .replace(/\s+/g, " ")
     .trim();
@@ -273,6 +275,67 @@ describe("/nonprofits/find-funders — server-rendered landing page", () => {
     const { metadata } = await import("@/app/nonprofits/find-funders/page");
 
     expect(canonicalOf(metadata)).toBe("/nonprofits/find-funders");
+  });
+
+  describe("direct-answer FAQ (DEV-595 experiment E5)", () => {
+    it("the noscript replica carries every FAQ question and answer for no-JS readers", async () => {
+      const { FIND_FUNDERS_FAQS } = await import("@/src/features/non-profits/lib/faq-content");
+      const { noscriptHtml } = await renderFindFunders();
+      const text = visibleText(noscriptInner(noscriptHtml));
+
+      for (const faq of FIND_FUNDERS_FAQS) {
+        expect(text).toContain(faq.question);
+        expect(text).toContain(visibleText(faq.answer));
+      }
+    });
+
+    it("the page itself renders the same FAQ section", async () => {
+      const { FIND_FUNDERS_FAQS } = await import("@/src/features/non-profits/lib/faq-content");
+      const { pageHtml } = await renderFindFunders();
+      const text = visibleText(pageHtml);
+
+      for (const faq of FIND_FUNDERS_FAQS) {
+        expect(text).toContain(faq.question);
+        expect(text).toContain(visibleText(faq.answer));
+      }
+    });
+
+    it("emits FAQPage JSON-LD built from the same array the visible sections render", async () => {
+      const { FIND_FUNDERS_FAQS } = await import("@/src/features/non-profits/lib/faq-content");
+      const { pageHtml } = await renderFindFunders();
+
+      const scripts = Array.from(
+        pageHtml.matchAll(/<script type="application\/ld\+json">([\s\S]*?)<\/script>/g)
+      ).map((match) => JSON.parse(match[1].replace(/\\u003c/g, "<")));
+      const faqSchema = scripts.find((schema) => schema["@type"] === "FAQPage");
+
+      expect(faqSchema).toBeDefined();
+      expect(faqSchema.mainEntity.map((entity: { name: string }) => entity.name)).toEqual(
+        FIND_FUNDERS_FAQS.map((faq) => faq.question)
+      );
+      expect(
+        faqSchema.mainEntity.map(
+          (entity: { acceptedAnswer: { text: string } }) => entity.acceptedAnswer.text
+        )
+      ).toEqual(FIND_FUNDERS_FAQS.map((faq) => faq.answer));
+    });
+
+    it("answers the funder-discovery facts the experiment targets, in visible text", async () => {
+      const { noscriptHtml } = await renderFindFunders();
+      const text = visibleText(noscriptInner(noscriptHtml));
+
+      // P007 / P028 — past grants and typical grant size from filings.
+      expect(text).toContain("past grants and giving history");
+      expect(text).toContain("check-size patterns");
+      // P018 — works from ChatGPT / Claude via the MCP connector.
+      expect(text).toContain("ChatGPT or Claude");
+      expect(text).toContain("gapapi.karmahq.xyz/mcp");
+      // P035 — free for nonprofits.
+      expect(text).toContain("Connecting and asking questions is free");
+      // Data coverage claim stays tied to the reviewed stats module.
+      const { FILINGS_STATS } = await import("@/src/features/non-profits/lib/stats");
+      expect(text).toContain(`over ${FILINGS_STATS.countLong} filings`);
+    });
   });
 
   /**

--- a/app/nonprofits/find-funders/page.tsx
+++ b/app/nonprofits/find-funders/page.tsx
@@ -1,5 +1,7 @@
 import type { Metadata } from "next";
+import { FAQJsonLd } from "@/components/Seo/FAQJsonLd";
 import { LandingPageClient } from "@/src/features/non-profits/components/landing-page-client";
+import { FIND_FUNDERS_FAQS } from "@/src/features/non-profits/lib/faq-content";
 import { customMetadata } from "@/utilities/meta";
 
 export const metadata: Metadata = customMetadata({
@@ -26,5 +28,13 @@ export const metadata: Metadata = customMetadata({
  * of this route a no-JS reader actually sees. See ./loading.tsx.
  */
 export default function NonProfitsPage() {
-  return <LandingPageClient />;
+  return (
+    <>
+      {/* Fed from the same array as the visible FAQ section (and the root
+          layout's noscript replica), so the structured data never claims
+          something a reader cannot see. */}
+      <FAQJsonLd questions={FIND_FUNDERS_FAQS} />
+      <LandingPageClient />
+    </>
+  );
 }

--- a/src/features/non-profits/components/find-funders-noscript-hero.tsx
+++ b/src/features/non-profits/components/find-funders-noscript-hero.tsx
@@ -1,4 +1,5 @@
 import { HERO_CHIPS, HERO_SUB, HERO_TITLE_LINE_1, HERO_TITLE_LINE_2 } from "../lib/hero-content";
+import { LandingFaq } from "./landing-faq";
 
 /**
  * The find-funders hero for readers that do not execute JavaScript — rendered
@@ -54,6 +55,11 @@ export function FindFundersNoscriptHero() {
             </div>
           </div>
         </section>
+        {/* The direct-answer FAQ (DEV-595 experiment E5) must reach no-JS
+            readers too: the page's own copy of it streams inside the hidden
+            Suspense chunk, so the replica renders the same component here.
+            Same module, same data — the two cannot drift. */}
+        <LandingFaq />
       </div>
     </noscript>
   );

--- a/src/features/non-profits/components/landing-faq.tsx
+++ b/src/features/non-profits/components/landing-faq.tsx
@@ -1,4 +1,39 @@
-import { FIND_FUNDERS_FAQS } from "../lib/faq-content";
+import { FIND_FUNDERS_FAQ_LINKS, FIND_FUNDERS_FAQS } from "../lib/faq-content";
+
+const LINK_TARGETS = Object.keys(FIND_FUNDERS_FAQ_LINKS).sort((a, b) => b.length - a.length);
+
+const LINK_SPLITTER = new RegExp(
+  `(${LINK_TARGETS.map((target) => target.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")).join("|")})`
+);
+
+/**
+ * Renders an FAQ answer, turning the URL mentions listed in
+ * FIND_FUNDERS_FAQ_LINKS into anchors. The answer string itself stays plain
+ * text because the FAQPage JSON-LD serializes it verbatim; only the two
+ * visible renderings (landing page and noscript replica) get real links.
+ */
+function FaqAnswer({ text }: { text: string }) {
+  return (
+    <>
+      {text.split(LINK_SPLITTER).map((part) => {
+        const href = FIND_FUNDERS_FAQ_LINKS[part];
+        if (!href) return part;
+        const external = href.startsWith("https://");
+        return (
+          <a
+            // Answers never repeat a URL, so the linked part is a stable key.
+            key={part}
+            href={href}
+            className="lp-faq-link"
+            {...(external ? { target: "_blank", rel: "noopener noreferrer" } : {})}
+          >
+            {part}
+          </a>
+        );
+      })}
+    </>
+  );
+}
 
 /**
  * FAQ section for the find-funders landing page.
@@ -30,7 +65,9 @@ export function LandingFaq() {
           {FIND_FUNDERS_FAQS.map((faq) => (
             <div key={faq.question} className="lp-faq-item">
               <dt className="lp-faq-q">{faq.question}</dt>
-              <dd className="lp-faq-a">{faq.answer}</dd>
+              <dd className="lp-faq-a">
+                <FaqAnswer text={faq.answer} />
+              </dd>
             </div>
           ))}
         </dl>

--- a/src/features/non-profits/components/landing-faq.tsx
+++ b/src/features/non-profits/components/landing-faq.tsx
@@ -1,0 +1,40 @@
+import { FIND_FUNDERS_FAQS } from "../lib/faq-content";
+
+/**
+ * FAQ section for the find-funders landing page.
+ *
+ * Deliberately NOT a `"use client"` module: it renders no hooks and no
+ * handlers, so the same component serves both trees that must stay in sync —
+ * the interactive landing page (client tree, via LandingPageClient) and the
+ * root layout's <noscript> replica (Server Component tree, via
+ * FindFundersNoscriptHero). The copy comes from lib/faq-content, the same
+ * array that feeds the page's FAQPage JSON-LD, so the structured data, the
+ * interactive page, and the no-JS page can never drift apart.
+ */
+export function LandingFaq() {
+  return (
+    <section id="faq">
+      <div className="lp-container">
+        <div className="lp-section-head">
+          <div>
+            <div className="lp-section-label">08 &mdash; FAQ</div>
+            <h2 className="lp-section-title">
+              Common questions,
+              <br />
+              <span className="italic">answered straight.</span>
+            </h2>
+          </div>
+        </div>
+
+        <dl className="lp-faq-list">
+          {FIND_FUNDERS_FAQS.map((faq) => (
+            <div key={faq.question} className="lp-faq-item">
+              <dt className="lp-faq-q">{faq.question}</dt>
+              <dd className="lp-faq-a">{faq.answer}</dd>
+            </div>
+          ))}
+        </dl>
+      </div>
+    </section>
+  );
+}

--- a/src/features/non-profits/components/landing-page-client.tsx
+++ b/src/features/non-profits/components/landing-page-client.tsx
@@ -22,6 +22,7 @@ import { NON_PROFITS_PAGES } from "@/utilities/pages";
 import { INSTALL_CONFIGS, type InstallTab } from "../lib/install-configs";
 import { FILINGS_STATS } from "../lib/stats";
 import { ConnectFloatingCard } from "./connect-cta";
+import { LandingFaq } from "./landing-faq";
 import { LandingHero } from "./landing-hero";
 import { ArrowIcon } from "./landing-icons";
 
@@ -702,7 +703,7 @@ function FinalCTA({ onSearchFocus }: { onSearchFocus: () => void }) {
       <div className="lp-container">
         <div className="lp-section-head">
           <div>
-            <div className="lp-section-label">08 &mdash; START</div>
+            <div className="lp-section-label">09 &mdash; START</div>
             <h2 className="lp-section-title">
               Two ways in.
               <br />
@@ -760,6 +761,7 @@ export function LandingPageClient() {
       <Connector />
       <TheData />
       <Audience />
+      <LandingFaq />
       <FinalCTA onSearchFocus={scrollToHero} />
       <ConnectFloatingCard />
     </div>

--- a/src/features/non-profits/lib/faq-content.ts
+++ b/src/features/non-profits/lib/faq-content.ts
@@ -1,0 +1,73 @@
+import { FILINGS_STATS } from "./stats";
+
+/**
+ * FAQ copy for the find-funders landing page — the direct-answer content for
+ * the funder-discovery questions the page is meant to answer (DEV-595,
+ * experiment E5 in artifacts/aeo-measurement/experiments.md).
+ *
+ * Three renderers share this array and must stay in sync word for word:
+ *
+ * - `components/landing-faq.tsx` — the FAQ section inside the interactive
+ *   landing page;
+ * - `components/find-funders-noscript-hero.tsx` — the root layout's
+ *   crawler-visible replica for readers that do not execute JavaScript
+ *   (the page's own HTML streams as a hidden chunk, see that file);
+ * - the FAQPage JSON-LD emitted by `app/nonprofits/find-funders/page.tsx`,
+ *   so the structured data never claims something a reader cannot see.
+ *
+ * Lives in lib/ (not next to a client component) because the noscript replica
+ * is a Server Component: importing values from a `"use client"` module would
+ * turn them into client references it cannot read.
+ *
+ * Every factual claim below traces to already-reviewed copy or code:
+ * data coverage and freshness from `./stats` and the landing data section;
+ * free access from the connect guide ("Is it free?"); the MCP connector URL
+ * and sign-in flow from `./install-configs` and the /connect guides; giving
+ * history, officers, and check-size research from the shipped agent copy in
+ * `landing-page-client.tsx`.
+ */
+export interface FindFundersFaqEntry {
+  question: string;
+  answer: string;
+}
+
+export const FIND_FUNDERS_FAQS: FindFundersFaqEntry[] = [
+  {
+    question: "How does a small nonprofit start finding funders?",
+    answer: `Start from the public record: every U.S. private foundation files a Form 990-PF each year listing the grants it actually paid. Karma Find Funders indexes over ${FILINGS_STATS.countLong} IRS 990 and 990-PF filings, so you can ask in plain English — by cause area, geography, or check size — and get a ranked prospect list with every figure cited to the filing it came from. You can try it on this page without signing up.`,
+  },
+  {
+    question: "Does Karma show a foundation's past grants and giving history before I apply?",
+    answer:
+      "Yes. The research agent pulls a funder's giving history, officers, peer co-funders, and historical priorities from its 990 record, and every funder, grant, and dollar figure links back to the actual filing.",
+  },
+  {
+    question: "How can I estimate a funder's typical grant size from its past grants?",
+    answer:
+      "A foundation's 990-PF lists each grant it paid and the amount, so recent filings show its real check-size patterns. Ask the agent for a funder's recent grants and typical amounts — or start from a constraint, like funders of refugee resettlement giving over $250k since 2024 — and it answers from the filed amounts, cited back to the source filings.",
+  },
+  {
+    question: "Can I use ChatGPT or Claude to find foundations that fund my nonprofit?",
+    answer:
+      "Yes. Karma Find Funders is available as a connector for Claude and ChatGPT: add gapapi.karmahq.xyz/mcp as a custom connector (MCP), sign in to Karma once, and funder questions in your chats run against the indexed 990 data. Step-by-step setup guides live at karmahq.xyz/nonprofits/find-funders/connect.",
+  },
+  {
+    question: "Is Karma Find Funders free for nonprofits?",
+    answer:
+      "Connecting and asking questions is free. A paid tier may be added later for high-volume usage, but the core prospecting agent stays free for nonprofits. You can also try a search on this page without creating an account.",
+  },
+  {
+    question: "What data does Karma Find Funders search?",
+    answer: `IRS 990 and 990-PF filings for U.S. private foundations and public charities that file annually — over ${FILINGS_STATS.countLong} filings covering ${FILINGS_STATS.dollarsTracked} in philanthropic assets and seven years of giving history, kept current as new filings are published. Every answer cites the filing it came from.`,
+  },
+  {
+    question: "How do we screen out funders whose geographic or budget limits rule us out?",
+    answer:
+      "Put the constraints in the question — geography, foundation asset size, check size, cause area — and the agent filters against what the filings show, for example family foundations under $50M that funded youth literacy in the Midwest. Funders whose actual giving does not match your profile drop off the list before you spend time on an application.",
+  },
+  {
+    question: "How is Karma Find Funders different from a grant research database?",
+    answer:
+      "Conventional grant research tools are typically filter-and-export databases operated through their own dashboards. Karma Find Funders is conversational: you describe what you need in plain English — on this page or inside Claude or ChatGPT — and the agent searches the indexed 990 filings and returns a ranked, cited prospect list.",
+  },
+];

--- a/src/features/non-profits/lib/faq-content.ts
+++ b/src/features/non-profits/lib/faq-content.ts
@@ -1,3 +1,4 @@
+import { NON_PROFITS_PAGES } from "@/utilities/pages";
 import { FILINGS_STATS } from "./stats";
 
 /**
@@ -31,20 +32,33 @@ export interface FindFundersFaqEntry {
   answer: string;
 }
 
+/**
+ * Answer substrings the visible FAQ renders as anchors (see landing-faq.tsx).
+ * The key is the literal text as it appears in the answer; the value is the
+ * href it links to. Answers stay plain strings because the FAQPage JSON-LD
+ * consumes them as-is: schema.org acceptedAnswer text is plain text, and the
+ * existing FAQJsonLd component serializes the string verbatim.
+ */
+export const FIND_FUNDERS_FAQ_LINKS: Record<string, string> = {
+  "gapapi.karmahq.xyz/mcp": "https://gapapi.karmahq.xyz/mcp",
+  "karmahq.xyz/nonprofits/find-funders/connect": NON_PROFITS_PAGES.CONNECT,
+};
+
 export const FIND_FUNDERS_FAQS: FindFundersFaqEntry[] = [
   {
     question: "How does a small nonprofit start finding funders?",
-    answer: `Start from the public record: every U.S. private foundation files a Form 990-PF each year listing the grants it actually paid. Karma Find Funders indexes over ${FILINGS_STATS.countLong} IRS 990 and 990-PF filings, so you can ask in plain English — by cause area, geography, or check size — and get a ranked prospect list with every figure cited to the filing it came from. You can try it on this page without signing up.`,
+    answer:
+      "Start from the public record: every U.S. private foundation files a Form 990-PF each year listing the grants it actually paid. Tell Karma Find Funders what you need, by cause area, geography, or check size, and it turns that into a ranked list of prospects, every figure cited to the filing it came from. You can try it on this page without signing up.",
   },
   {
     question: "Does Karma show a foundation's past grants and giving history before I apply?",
     answer:
-      "Yes. The research agent pulls a funder's giving history, officers, peer co-funders, and historical priorities from its 990 record, and every funder, grant, and dollar figure links back to the actual filing.",
+      "Yes. Ask about a foundation before you apply and the research agent assembles its giving history from the 990 record: past grantees, officers, peer co-funders, and how its priorities have shifted over time, each cited to the source filing.",
   },
   {
     question: "How can I estimate a funder's typical grant size from its past grants?",
     answer:
-      "A foundation's 990-PF lists each grant it paid and the amount, so recent filings show its real check-size patterns. Ask the agent for a funder's recent grants and typical amounts — or start from a constraint, like funders of refugee resettlement giving over $250k since 2024 — and it answers from the filed amounts, cited back to the source filings.",
+      "A foundation's 990-PF lists each grant it paid and the amount, so recent filings show its real check-size patterns. Ask the agent for a funder's recent grants and typical amounts, or start from a constraint (say, funders of refugee resettlement giving over $250k since 2024), and it answers from the filed amounts, cited back to the source filings.",
   },
   {
     question: "Can I use ChatGPT or Claude to find foundations that fund my nonprofit?",
@@ -54,20 +68,20 @@ export const FIND_FUNDERS_FAQS: FindFundersFaqEntry[] = [
   {
     question: "Is Karma Find Funders free for nonprofits?",
     answer:
-      "Connecting and asking questions is free. A paid tier may be added later for high-volume usage, but the core prospecting agent stays free for nonprofits. You can also try a search on this page without creating an account.",
+      "Connecting and asking questions is free. A paid tier may be added later for high-volume usage, but the core prospecting agent stays free for nonprofits.",
   },
   {
     question: "What data does Karma Find Funders search?",
-    answer: `IRS 990 and 990-PF filings for U.S. private foundations and public charities that file annually — over ${FILINGS_STATS.countLong} filings covering ${FILINGS_STATS.dollarsTracked} in philanthropic assets and seven years of giving history, kept current as new filings are published. Every answer cites the filing it came from.`,
+    answer: `IRS 990 and 990-PF filings for U.S. private foundations and public charities that file annually: over ${FILINGS_STATS.countLong} filings covering ${FILINGS_STATS.dollarsTracked} in philanthropic assets and seven years of giving history, kept current as new filings are published. Every answer cites the filing it came from.`,
   },
   {
     question: "How do we screen out funders whose geographic or budget limits rule us out?",
     answer:
-      "Put the constraints in the question — geography, foundation asset size, check size, cause area — and the agent filters against what the filings show, for example family foundations under $50M that funded youth literacy in the Midwest. Funders whose actual giving does not match your profile drop off the list before you spend time on an application.",
+      "Put the constraints in the question (geography, foundation asset size, check size, cause area) and the agent filters against what the filings show, for example foundations under $50M that funded food security work in the Midwest. Funders whose actual giving does not match your profile drop off the list before you spend time on an application.",
   },
   {
     question: "How is Karma Find Funders different from a grant research database?",
     answer:
-      "Conventional grant research tools are typically filter-and-export databases operated through their own dashboards. Karma Find Funders is conversational: you describe what you need in plain English — on this page or inside Claude or ChatGPT — and the agent searches the indexed 990 filings and returns a ranked, cited prospect list.",
+      "Conventional grant research tools are typically filter-and-export databases operated through their own dashboards. Karma Find Funders is conversational: you describe what you need, on this page or inside Claude or ChatGPT, and the agent searches the indexed 990 filings and answers with ranked, cited prospects.",
   },
 ];

--- a/src/features/non-profits/lib/faq-content.ts
+++ b/src/features/non-profits/lib/faq-content.ts
@@ -48,7 +48,7 @@ export const FIND_FUNDERS_FAQS: FindFundersFaqEntry[] = [
   {
     question: "How does a small nonprofit start finding funders?",
     answer:
-      "Start from the public record: every U.S. private foundation files a Form 990-PF each year listing the grants it actually paid. Tell Karma Find Funders what you need, by cause area, geography, or check size, and it turns that into a ranked list of prospects, every figure cited to the filing it came from. You can try it on this page without signing up.",
+      "Start from the public record: every U.S. private foundation files a Form 990-PF each year listing the grants it actually paid. Tell Karma Find Funders what you need, by cause area, geography, or check size, and it turns those filings into a ranked list of funders already giving to work like yours.",
   },
   {
     question: "Does Karma show a foundation's past grants and giving history before I apply?",
@@ -58,7 +58,7 @@ export const FIND_FUNDERS_FAQS: FindFundersFaqEntry[] = [
   {
     question: "How can I estimate a funder's typical grant size from its past grants?",
     answer:
-      "A foundation's 990-PF lists each grant it paid and the amount, so recent filings show its real check-size patterns. Ask the agent for a funder's recent grants and typical amounts, or start from a constraint (say, funders of refugee resettlement giving over $250k since 2024), and it answers from the filed amounts, cited back to the source filings.",
+      "A foundation's 990-PF lists each grant it paid and the amount, so recent filings show the range it typically gives. Ask the agent for a funder's recent grants and typical amounts, or start from a constraint (say, funders of refugee resettlement giving over $250k since 2024), and it answers from the filed amounts, cited back to the source filings.",
   },
   {
     question: "Can I use ChatGPT or Claude to find foundations that fund my nonprofit?",
@@ -82,6 +82,6 @@ export const FIND_FUNDERS_FAQS: FindFundersFaqEntry[] = [
   {
     question: "How is Karma Find Funders different from a grant research database?",
     answer:
-      "Conventional grant research tools are typically filter-and-export databases operated through their own dashboards. Karma Find Funders is conversational: you describe what you need, on this page or inside Claude or ChatGPT, and the agent searches the indexed 990 filings and answers with ranked, cited prospects.",
+      "Conventional grant research tools are typically filter-and-export databases operated through their own dashboards. Karma Find Funders is conversational: you describe what you need, on this page or inside Claude or ChatGPT, and the agent searches the indexed 990 filings and answers with a shortlist you can check against the filings behind it.",
   },
 ];

--- a/styles/non-profits-landing.css
+++ b/styles/non-profits-landing.css
@@ -652,6 +652,38 @@
 }
 .lp-aud-q::before { content: "\203A"; color: var(--lp-ink-4); flex-shrink: 0; }
 
+/* ———————— FAQ ———————— */
+.lp-faq-list {
+  display: flex;
+  flex-direction: column;
+  border-top: 1px solid var(--line);
+  margin: 0;
+}
+
+.lp-faq-item {
+  display: grid;
+  grid-template-columns: 1fr 2fr;
+  gap: 32px;
+  padding: 28px 0;
+  border-bottom: 1px solid var(--line);
+}
+
+.lp-faq-q {
+  font-family: "Instrument Serif", Georgia, serif;
+  font-size: 22px;
+  line-height: 1.2;
+  letter-spacing: -0.01em;
+  color: var(--lp-ink);
+  font-weight: 400;
+}
+
+.lp-faq-a {
+  font-size: 14px;
+  line-height: 1.6;
+  color: var(--lp-ink-2);
+  margin: 0;
+}
+
 /* ———————— Connector / MCP ———————— */
 .lp-connector {
   background: var(--lp-ink);
@@ -1433,6 +1465,7 @@
   .lp-agents-grid { grid-template-columns: 1fr; }
   .lp-agents-grid .lp-aud { border-right: none !important; border-bottom: 1px solid var(--line) !important; }
   .lp-agents-grid .lp-aud:last-child { border-bottom: none !important; }
+  .lp-faq-item { grid-template-columns: 1fr; gap: 10px; }
   .lp-anti-row { grid-template-columns: 1fr; gap: 8px; padding: 18px 20px; }
   .lp-anti-x, .lp-anti-arrow { display: none; }
   .lp-data-grid { grid-template-columns: 1fr 1fr; }

--- a/styles/non-profits-landing.css
+++ b/styles/non-profits-landing.css
@@ -32,6 +32,12 @@
   --lp-accent-soft: oklch(0.95 0.04 75);
   --lp-success: oklch(0.65 0.14 155);
   --lp-focus: oklch(0.7 0.14 230);
+  /* Body-copy link blue — same values as the app-wide convention
+     (Tailwind blue-600/blue-700, as used by the connect guides and
+     knowledge pages), tokenized here so the noscript replica and the
+     interactive section share one source with a dark-mode variant. */
+  --lp-link: #2563eb;
+  --lp-link-hover: #1d4ed8;
   font-family: "Geist", -apple-system, system-ui, sans-serif;
   -webkit-font-smoothing: antialiased;
   font-feature-settings: "ss01", "cv11";
@@ -54,6 +60,8 @@
   --lp-primary-soft: oklch(0.26 0.04 265);
   --lp-accent: oklch(0.82 0.13 75);
   --lp-accent-soft: oklch(0.28 0.04 75);
+  --lp-link: #60a5fa;
+  --lp-link-hover: #93c5fd;
 }
 
 .landing * { box-sizing: border-box; }
@@ -684,15 +692,18 @@
   margin: 0;
 }
 
-.lp-faq-link {
-  color: var(--lp-ink);
+/* `.landing a` (0,1,1) resets links to inherit/none, so this rule needs the
+   higher-specificity form to actually win — blue and always underlined, in
+   both the interactive section and the noscript replica (plain CSS only). */
+.landing a.lp-faq-link {
+  color: var(--lp-link);
   text-decoration: underline;
   text-underline-offset: 3px;
   overflow-wrap: anywhere;
 }
 
-.lp-faq-link:hover {
-  color: var(--lp-ink-2);
+.landing a.lp-faq-link:hover {
+  color: var(--lp-link-hover);
 }
 
 /* ———————— Connector / MCP ———————— */

--- a/styles/non-profits-landing.css
+++ b/styles/non-profits-landing.css
@@ -684,6 +684,17 @@
   margin: 0;
 }
 
+.lp-faq-link {
+  color: var(--lp-ink);
+  text-decoration: underline;
+  text-underline-offset: 3px;
+  overflow-wrap: anywhere;
+}
+
+.lp-faq-link:hover {
+  color: var(--lp-ink-2);
+}
+
 /* ———————— Connector / MCP ———————— */
 .lp-connector {
   background: var(--lp-ink);


### PR DESCRIPTION
## Overview

AEO-12 experiment E5 ([DEV-595](https://linear.app/showkarma/issue/DEV-595)) — contract pre-registered in `artifacts/aeo-measurement/experiments.md` (cohort C15, control C14 `/nonprofits`). Draft on purpose: copy needs human review before the ready-PR AI stack spends. The `releases.csv` row and the cohort flip are appended at ship time, per the contract's bookkeeping rules.

## Target prompts (prompts.csv, nonprofits lane)

- P037 — "How do I find foundations that fund nonprofits like mine?"
- P007 — "Does Karma show a foundation's past grants and giving history before I apply?"
- P028 — "How can I use a funder's past grants to estimate its typical grant size?"
- P018 — "Can I use ChatGPT or Claude to find foundations that fund my nonprofit?"
- P035 — "Best free or low-cost grant research tools for a nonprofit with no fundraising budget?"
- P030 — "Which grant research platform is best for a small nonprofit with limited staff?"
- P048 — "How do we screen out funders with geographic or budget-size limits?"
- P011/P043 also target this page; P043 (unsolicited-proposal detection) is deliberately NOT answered — no verifiable source for that capability exists in the codebase.

## What changed

- **One FAQ data module** (`src/features/non-profits/lib/faq-content.ts`), consumed by three renderers that therefore cannot drift:
  1. a new `LandingFaq` section (08 — FAQ) on the landing page, styled with the existing `lp-*` system;
  2. the root layout's `<noscript>` replica — the only region of this streamed route guaranteed into the initially visible HTML (DEV-586 mechanism, untouched otherwise), so no-JS readers get the answers too;
  3. `FAQPage` JSON-LD emitted by the page, so the structured data claims nothing a reader cannot see.
- Final CTA section renumbered 08 → 09; no other visible copy changed. Title/meta untouched (already reviewed in #1967).
- `LandingFaq` is deliberately not a `"use client"` module so the Server-Component noscript replica can render it.

## Source of every claim (no new facts invented)

- Data coverage (2M+ filings, $1.2T, 7 years, "kept current"): `lib/stats.ts` + the shipped Data section.
- Free access: the shipped connect-guide FAQ ("Connecting and asking questions is free…").
- Claude/ChatGPT connector, MCP URL, sign-in-once: `lib/install-configs.tsx` + `/connect` guides.
- Giving history / officers / peer co-funders / check-size patterns: shipped agent copy in `landing-page-client.tsx`.
- Comparison answer names no competitors (same rule as #1973).

## Server-HTML verification (pnpm build && pnpm start, curl :3005)

```
title: Karma Find Funders — AI Agents for Funder Research | Karma
FAQ inside <noscript> (guaranteed-visible region): PASS (offset ~9.6k)
FAQ also present in the page's streamed chunk and in FAQPage JSON-LD: PASS
"Connecting and asking questions is free" / gapapi.karmahq.xyz/mcp / hero h1: PASS
```

## Tests

- `__tests__/app/aeo-crawl-eligibility.test.tsx` extended (19 tests): noscript replica carries every FAQ question + answer, page renders the same section, FAQPage JSON-LD is built from the same array, and the targeted facts (past grants, check-size, ChatGPT/Claude, free, coverage) stay in visible text.
- `__tests__/middleware-find-funders-header.test.ts` unchanged and green (no proxy change).
- Full `src/features/non-profits` suite green (241 tests). Typecheck + Biome clean.


---

## Review revision (commits db4069c + a80ae5a)

1. **Em dashes**: removed from all FAQ prose (questions, answers, JSON-LD); sentences rephrased, and a test now bans "—" in the FAQ content. The `08 — FAQ` section label keeps the em dash deliberately: every other section label on the page (01 — THE SHIFT … 09 — START) uses it, and breaking the pattern for one label would read as a bug.
2. **Links**: `gapapi.karmahq.xyz/mcp` and `karmahq.xyz/nonprofits/find-funders/connect` render as real anchors in both the landing FAQ and the noscript replica (internal href via `NON_PROFITS_PAGES.CONNECT`; MCP URL external with `rel="noopener noreferrer"`). Plain `<a>` rather than the client `Link` component, because the shared renderer also runs inside `<noscript>` in the Server-Component root layout, where a hydrating client component would risk a mismatch. JSON-LD keeps the answers as plain text; a test pins both facts.
3. **Try-without-account sentence**: removed (and the similar "try it on this page without signing up" in the getting-started answer, which duplicated the final CTA card).
4. **Getting-started vs data-coverage overlap**: kept both questions — they serve different prompts (P037/P039 process vs data-coverage) — and split the substance: the getting-started answer now carries only the process (990-PF record → describe the need → ranked funder list), while filing counts, coverage, and the citation claim live solely in "What data does Karma Find Funders search?".
5. **"in plain English"**: removed from the database-comparison answer.
6. **Anti-duplication audit** (FAQ vs the page's own copy): cut the no-signup sentence (dup of CTA card), replaced "check-size patterns" (verbatim in the connector chat preview), replaced "ranked, cited" (verbatim in the prospecting-agent card), earlier revision already replaced the hero-chip example ("family foundations under $50M… youth literacy") with a non-chip example. Kept deliberately: the data-coverage answer spells out "2 million / $1.2T / seven years" in prose — the stats grid shows them only as tiles ("2M+", "7yrs"), and for no-JS readers the noscript FAQ is the only carrier of these facts.

### Re-verification (pnpm build && pnpm start, curl :3007)

```
FAQ + anchors in <noscript>: PASS (href="https://gapapi.karmahq.xyz/mcp", href="/nonprofits/find-funders/connect")
Same anchors in the page's streamed chunk: PASS
JSON-LD answers plain text, no anchors, no em dashes: PASS
Removed sentences absent; new Q1/Q3/Q8 phrasings present: PASS
```

Suites green after copy tracking (28 tests across the two regression files); typecheck clean.


---

## Review revision 2 (commit 04d97dd) — visible link styling

Root cause: the stylesheet's `.landing a { color: inherit; text-decoration: none; }` reset (specificity 0,1,1) outranked `.lp-faq-link` (0,1,0), so the two FAQ anchors rendered as plain ink with no underline. Fixed with a `.landing a.lp-faq-link` rule (0,2,1) plus new `--lp-link` / `--lp-link-hover` tokens in the page's design-token blocks — values match the app-wide body-copy link convention (Tailwind blue-600/700 light, blue-400/300 dark, as used by the connect guides and knowledge pages). Always underlined, not hover-only; plain CSS, so the noscript replica gets it with no JS.

Computed-style verification (build + `pnpm start`, Playwright `getComputedStyle` on both anchors):

| Context | Light | Dark |
|---|---|---|
| Interactive FAQ (`#faq a.lp-faq-link`) | `rgb(37, 99, 235)`, underline | `rgb(96, 165, 250)`, underline |
| Noscript replica markup (same class, injected into live DOM) | `rgb(37, 99, 235)`, underline | `rgb(96, 165, 250)`, underline |
