### PR TITLE
feat(knowledge): direct answers on AI-assisted review with human sign-off

### DIFF
--- a/__tests__/integration/pages/ai-grant-evaluation.test.tsx
+++ b/__tests__/integration/pages/ai-grant-evaluation.test.tsx
@@ -1,0 +1,102 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { AI_GRANT_EVALUATION_FAQS } from "@/app/knowledge/ai-grant-evaluation/content";
+import AiGrantEvaluationPage from "@/app/knowledge/ai-grant-evaluation/page";
+import {
+  KNOWLEDGE_ARTICLE_DATES,
+  KNOWLEDGE_ARTICLE_UPDATED_DATES,
+} from "@/app/knowledge/articleDates";
+import "@testing-library/jest-dom";
+
+/**
+ * /knowledge/ai-grant-evaluation — direct-answer content regressions
+ * (DEV-595 experiment E6).
+ *
+ * `renderToStaticMarkup` runs no effects and resolves no queries, so these
+ * assertions describe what a non-executing crawler receives from the server.
+ */
+
+function renderPage(): Document {
+  const html = renderToStaticMarkup(<AiGrantEvaluationPage />);
+  return new DOMParser().parseFromString(
+    `<!doctype html><html><body>${html}</body></html>`,
+    "text/html"
+  );
+}
+
+function schemas(doc: Document): Record<string, unknown>[] {
+  return Array.from(doc.querySelectorAll('script[type="application/ld+json"]')).map(
+    (script) => JSON.parse(script.textContent ?? "{}") as Record<string, unknown>
+  );
+}
+
+describe("/knowledge/ai-grant-evaluation", () => {
+  it("renders every target question and its full answer as visible text", () => {
+    const text = renderPage().body.textContent ?? "";
+
+    for (const faq of AI_GRANT_EVALUATION_FAQS) {
+      expect(text).toContain(faq.question);
+      expect(text).toContain(faq.answer);
+    }
+  });
+
+  it("emits FAQPage JSON-LD built from the same array the visible sections render", () => {
+    const faqSchema = schemas(renderPage()).find((schema) => schema["@type"] === "FAQPage") as
+      | { mainEntity: Array<{ name: string; acceptedAnswer: { text: string } }> }
+      | undefined;
+
+    expect(faqSchema).toBeDefined();
+    expect(faqSchema?.mainEntity.map((entity) => entity.name)).toEqual(
+      AI_GRANT_EVALUATION_FAQS.map((faq) => faq.question)
+    );
+    expect(faqSchema?.mainEntity.map((entity) => entity.acceptedAnswer.text)).toEqual(
+      AI_GRANT_EVALUATION_FAQS.map((faq) => faq.answer)
+    );
+  });
+
+  it("keeps its original published date and records the revision truthfully", () => {
+    const published = KNOWLEDGE_ARTICLE_DATES["ai-grant-evaluation"];
+    const updated = KNOWLEDGE_ARTICLE_UPDATED_DATES["ai-grant-evaluation"];
+    expect(published).toBe("2026-01-07");
+    expect(updated).toBeDefined();
+
+    const article = schemas(renderPage()).find((schema) => schema["@type"] === "Article") as {
+      datePublished?: string;
+      dateModified?: string;
+    };
+    expect(article.datePublished).toBe(published);
+    expect(article.dateModified).toBe(updated);
+  });
+
+  it("shows both dates to readers, so the structured data claims nothing invisible", () => {
+    const doc = renderPage();
+    const published = KNOWLEDGE_ARTICLE_DATES["ai-grant-evaluation"];
+    const updated = KNOWLEDGE_ARTICLE_UPDATED_DATES["ai-grant-evaluation"];
+
+    expect(doc.querySelector(`time[datetime="${published}"]`)).not.toBeNull();
+    expect(doc.querySelector(`time[datetime="${updated}"]`)).not.toBeNull();
+    expect(doc.body.textContent).toContain("Published");
+    expect(doc.body.textContent).toContain("Updated");
+  });
+
+  it("never claims a measured review-time figure", () => {
+    // A prior verification round could not source any "review time saved"
+    // number, so the page must say so instead of resurrecting one.
+    const text = renderPage().body.textContent ?? "";
+
+    expect(text).toContain("There is no single figure that holds across programs");
+    expect(text).not.toMatch(/\d+\s*%/);
+    expect(text).not.toMatch(/\d+x\b/i);
+  });
+
+  it("keeps the human-sign-off facts in visible text", () => {
+    const text = renderPage().body.textContent ?? "";
+
+    expect(text).toContain("status changes are made only by people with review permission");
+    expect(text).toContain("never shown to applicants");
+    expect(text).toContain("evaluation failures never block a submission");
+  });
+
+  it("emits exactly one h1", () => {
+    expect(renderPage().querySelectorAll("h1")).toHaveLength(1);
+  });
+});

--- a/__tests__/integration/pages/knowledge-article-dates.test.tsx
+++ b/__tests__/integration/pages/knowledge-article-dates.test.tsx
@@ -2,7 +2,11 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import type { ComponentType } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
-import { getKnowledgeArticleDate, KNOWLEDGE_ARTICLE_DATES } from "@/app/knowledge/articleDates";
+import {
+  getKnowledgeArticleDate,
+  KNOWLEDGE_ARTICLE_DATES,
+  KNOWLEDGE_ARTICLE_UPDATED_DATES,
+} from "@/app/knowledge/articleDates";
 import GrantKycPage from "@/app/knowledge/grant-kyc/page";
 import GrantLifecyclePage from "@/app/knowledge/grant-lifecycle/page";
 import ProjectProfilesPage from "@/app/knowledge/project-profiles/page";
@@ -86,13 +90,33 @@ describe("knowledge article publication dates", () => {
   });
 
   describe("page sources", () => {
-    it("never hardcode a date literal and never claim a modified date", () => {
+    it("never hardcode a date literal — published or modified dates come only from the maps", () => {
       for (const slug of knowledgeSlugs()) {
         const source = fs.readFileSync(path.join(KNOWLEDGE_DIR, slug, "page.tsx"), "utf8");
 
-        expect(source, slug).not.toMatch(/dateModified/);
+        expect(source, slug).not.toMatch(/dateModified\s*=\s*"/);
         expect(source, slug).not.toMatch(/datePublished\s*=\s*"/);
       }
+    });
+  });
+
+  describe("revision map", () => {
+    it("only records revisions for published articles, dated on or after publication", () => {
+      const today = new Date().toISOString().slice(0, 10);
+
+      for (const [slug, updated] of Object.entries(KNOWLEDGE_ARTICLE_UPDATED_DATES)) {
+        expect(KNOWLEDGE_ARTICLE_DATES, slug).toHaveProperty(slug);
+        expect(updated, slug).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+        expect(updated.localeCompare(KNOWLEDGE_ARTICLE_DATES[slug]), slug).toBeGreaterThan(0);
+        expect(updated.localeCompare(today), slug).toBeLessThanOrEqual(0);
+        expect(FABRICATED_DATES, slug).not.toContain(updated);
+      }
+    });
+
+    it("never touches the held-out control article", () => {
+      // /knowledge/grant-lifecycle is the untouched control cohort (C06) for
+      // the knowledge-page experiments — it must not gain a revision entry.
+      expect(KNOWLEDGE_ARTICLE_UPDATED_DATES).not.toHaveProperty("grant-lifecycle");
     });
   });
 

--- a/app/knowledge/ai-grant-evaluation/content.ts
+++ b/app/knowledge/ai-grant-evaluation/content.ts
@@ -8,8 +8,8 @@
  * bulk by program admins; each program configures its own evaluation prompt
  * and model, and prompts are versioned with recorded authorship; the internal
  * evaluation is stripped from applicant responses server-side; no evaluation
- * code path changes an application's status — approvals and rejections go
- * through a human, permission-gated status endpoint; each stored evaluation
+ * code path changes an application's status (approvals and rejections go
+ * through a human, permission-gated status endpoint); each stored evaluation
  * records the prompt version that produced it and when it ran; evaluation
  * failures never block a submission.
  */
@@ -17,22 +17,22 @@ export const AI_GRANT_EVALUATION_FAQS = [
   {
     question: "Should foundations let AI score grant applications?",
     answer:
-      "AI scoring is defensible when it is advisory, consistent, and auditable — and indefensible as a decision-maker. Used as a first pass, it gives every application the same structured read before a human reviews it. On Karma, an AI evaluation can never approve or reject an application: status changes are made only by people with review permission, and the AI output sits in a separate analysis view that reviewers can re-run, weigh, or ignore.",
+      "AI scoring is defensible when it is advisory, consistent, and auditable. As a decision-maker, it is indefensible. Used as a first pass, it gives every application the same structured read before a human reviews it. On Karma, an AI evaluation can never approve or reject an application: status changes are made only by people with review permission, and the AI output sits in a separate analysis view that reviewers can re-run, weigh, or ignore.",
   },
   {
     question: "What human oversight keeps AI-assisted review defensible?",
     answer:
-      "Three controls: decision authority, transparency, and traceability. Decision authority stays human — on Karma no AI output changes an application's status; approving, rejecting, or requesting revisions is a permission-gated human action. Transparency means applicants see only the feedback intended for them, while the internal reviewer evaluation is never shown to applicants. Traceability means every evaluation records which version of the program's evaluation prompt produced it and when it ran, so a program can explain any score after the fact.",
+      "Three controls: decision authority, transparency, and traceability. Decision authority stays human: on Karma no AI output changes an application's status; approving, rejecting, or requesting revisions is a permission-gated human action. Transparency means applicants see only the feedback intended for them, while the internal reviewer evaluation is never shown to applicants. Traceability means every evaluation records which version of the program's evaluation prompt produced it and when it ran, so a program can explain any score after the fact.",
   },
   {
     question: "What does Karma's AI evaluation check on each applicant?",
     answer:
-      "Three separate checks. First, optional applicant-facing feedback while the application is being written, labeled as guidance only. Second, an internal reviewer-only evaluation that scores the application against criteria the program itself defines — each program writes its own evaluation prompt and chooses the model, and prompts are versioned. Third, a track-record evaluation that summarizes the applicant's recorded history on the platform — grants and milestones completed, milestones past due — with strengths and red flags grounded only in recorded data. After an award, milestone-completion evidence is also AI-rated with written reasoning.",
+      "Three separate checks. First, optional applicant-facing feedback while the application is being written, labeled as guidance only. Second, an internal reviewer-only evaluation that scores the application against criteria the program itself defines: each program writes its own evaluation prompt and chooses the model, and prompts are versioned. Third, a track-record evaluation that summarizes the applicant's recorded history on the platform (grants and milestones completed, milestones past due) with strengths and red flags grounded only in recorded data. After an award, milestone-completion evidence is also AI-rated with written reasoning.",
   },
   {
     question: "How does AI-assisted scoring help calibrate reviewers?",
     answer:
-      "Reviewer calibration is about applying the same criteria the same way across hundreds of applications and several reviewers. A program-defined AI evaluation applies one written set of criteria to every submission, producing a consistent first-pass score reviewers can sort and compare against their own reads. Where a human review diverges sharply from the first pass, that divergence is visible and discussable — the AI score is a shared reference point, not a verdict.",
+      "Reviewer calibration is about applying the same criteria the same way across hundreds of applications and several reviewers. A program-defined AI evaluation applies one written set of criteria to every submission, producing a consistent first-pass score reviewers can sort and compare against their own reads. Where a human review diverges sharply from the first pass, that divergence is visible and discussable: the AI score is a shared reference point, not a verdict.",
   },
   {
     question: "How much review time does AI-assisted scoring save?",

--- a/app/knowledge/ai-grant-evaluation/content.ts
+++ b/app/knowledge/ai-grant-evaluation/content.ts
@@ -1,0 +1,42 @@
+/**
+ * The direct-answer Q&A for this article. Rendered as the visible sections
+ * below AND emitted as FAQPage JSON-LD from the same array, so the structured
+ * data never claims something a reader cannot see.
+ *
+ * Every claim about Karma's AI evaluation traces to the implementation:
+ * evaluations run on submission and edit and can be re-run by reviewers or in
+ * bulk by program admins; each program configures its own evaluation prompt
+ * and model, and prompts are versioned with recorded authorship; the internal
+ * evaluation is stripped from applicant responses server-side; no evaluation
+ * code path changes an application's status — approvals and rejections go
+ * through a human, permission-gated status endpoint; each stored evaluation
+ * records the prompt version that produced it and when it ran; evaluation
+ * failures never block a submission.
+ */
+export const AI_GRANT_EVALUATION_FAQS = [
+  {
+    question: "Should foundations let AI score grant applications?",
+    answer:
+      "AI scoring is defensible when it is advisory, consistent, and auditable — and indefensible as a decision-maker. Used as a first pass, it gives every application the same structured read before a human reviews it. On Karma, an AI evaluation can never approve or reject an application: status changes are made only by people with review permission, and the AI output sits in a separate analysis view that reviewers can re-run, weigh, or ignore.",
+  },
+  {
+    question: "What human oversight keeps AI-assisted review defensible?",
+    answer:
+      "Three controls: decision authority, transparency, and traceability. Decision authority stays human — on Karma no AI output changes an application's status; approving, rejecting, or requesting revisions is a permission-gated human action. Transparency means applicants see only the feedback intended for them, while the internal reviewer evaluation is never shown to applicants. Traceability means every evaluation records which version of the program's evaluation prompt produced it and when it ran, so a program can explain any score after the fact.",
+  },
+  {
+    question: "What does Karma's AI evaluation check on each applicant?",
+    answer:
+      "Three separate checks. First, optional applicant-facing feedback while the application is being written, labeled as guidance only. Second, an internal reviewer-only evaluation that scores the application against criteria the program itself defines — each program writes its own evaluation prompt and chooses the model, and prompts are versioned. Third, a track-record evaluation that summarizes the applicant's recorded history on the platform — grants and milestones completed, milestones past due — with strengths and red flags grounded only in recorded data. After an award, milestone-completion evidence is also AI-rated with written reasoning.",
+  },
+  {
+    question: "How does AI-assisted scoring help calibrate reviewers?",
+    answer:
+      "Reviewer calibration is about applying the same criteria the same way across hundreds of applications and several reviewers. A program-defined AI evaluation applies one written set of criteria to every submission, producing a consistent first-pass score reviewers can sort and compare against their own reads. Where a human review diverges sharply from the first pass, that divergence is visible and discussable — the AI score is a shared reference point, not a verdict.",
+  },
+  {
+    question: "How much review time does AI-assisted scoring save?",
+    answer:
+      "There is no single figure that holds across programs, and Karma does not publish one. What AI assistance removes is the first-pass reading: summarizing long applications, applying the scoring criteria uniformly, and surfacing risk signals before a reviewer opens the file. How much time that frees depends on application volume, review depth, and how a program runs its committee.",
+  },
+] as const;

--- a/app/knowledge/ai-grant-evaluation/page.tsx
+++ b/app/knowledge/ai-grant-evaluation/page.tsx
@@ -1,22 +1,31 @@
 import type { Metadata } from "next";
 import Link from "next/link";
-import { getKnowledgeArticleDate } from "@/app/knowledge/articleDates";
+import {
+  getKnowledgeArticleDate,
+  getKnowledgeArticleUpdatedDate,
+} from "@/app/knowledge/articleDates";
 import { Breadcrumbs } from "@/components/Breadcrumbs";
 import { ArticlePublishedDate } from "@/components/Knowledge/ArticlePublishedDate";
 import { ArticleJsonLd } from "@/components/Seo/ArticleJsonLd";
 import { BreadcrumbJsonLd } from "@/components/Seo/BreadcrumbJsonLd";
+import { FAQJsonLd } from "@/components/Seo/FAQJsonLd";
 import { customMetadata } from "@/utilities/meta";
 import { PAGES } from "@/utilities/pages";
+import { AI_GRANT_EVALUATION_FAQS } from "./content";
+
+const TITLE = "AI-Assisted Grant Evaluation at Scale";
+const DESCRIPTION =
+  "How AI-assisted application review works with human sign-off: consistent first-pass scoring, reviewer-only evaluations, and the oversight that keeps grant decisions with people.";
 
 export const metadata: Metadata = customMetadata({
-  title: "AI-Assisted Grant Evaluation at Scale",
-  description:
-    "Learn how AI-assisted evaluation helps grant programs process hundreds of applications without sacrificing review quality. Explore practical approaches to scaling.",
+  title: TITLE,
+  description: DESCRIPTION,
   path: PAGES.KNOWLEDGE.ARTICLE("ai-grant-evaluation"),
   ogType: "article",
 });
 
 const PUBLISHED_AT = getKnowledgeArticleDate("ai-grant-evaluation");
+const UPDATED_AT = getKnowledgeArticleUpdatedDate("ai-grant-evaluation");
 
 export default function AiGrantEvaluationPage() {
   return (
@@ -32,10 +41,11 @@ export default function AiGrantEvaluationPage() {
         ]}
       />
       <ArticleJsonLd
-        title="AI-Assisted Grant Evaluation at Scale"
-        description="Learn how AI-assisted evaluation helps grant programs process hundreds of applications without sacrificing review quality. Explore practical approaches to scaling."
+        title={TITLE}
+        description={DESCRIPTION}
         url={PAGES.KNOWLEDGE.ARTICLE("ai-grant-evaluation")}
         datePublished={PUBLISHED_AT}
+        dateModified={UPDATED_AT}
       />
       <BreadcrumbJsonLd
         items={[
@@ -47,57 +57,45 @@ export default function AiGrantEvaluationPage() {
           },
         ]}
       />
+      <FAQJsonLd questions={[...AI_GRANT_EVALUATION_FAQS]} />
       <article className="space-y-8">
         <header className="space-y-2">
-          <h1 className="text-3xl font-bold">AI-Assisted Grant Evaluation at Scale</h1>
-          <ArticlePublishedDate date={PUBLISHED_AT} />
+          <h1 className="text-3xl font-bold">{TITLE}</h1>
+          <ArticlePublishedDate date={PUBLISHED_AT} updated={UPDATED_AT} />
         </header>
 
         <section className="space-y-4">
           <h2 className="text-xl font-semibold">In one sentence</h2>
           <p className="text-gray-700 dark:text-gray-300">
-            AI-assisted evaluation helps grant programs process high volumes of applications without
-            sacrificing review quality.
+            AI-assisted evaluation gives grant programs a consistent, auditable first pass over
+            every application, while approval and rejection stay human decisions.
           </p>
         </section>
 
         <section className="space-y-4">
           <h2 className="text-xl font-semibold">Short answer</h2>
           <p className="text-gray-700 dark:text-gray-300">
-            When programs receive hundreds of applications, fully manual review does not scale.
-            AI-assisted evaluation provides first-pass filtering, automated summaries, and risk
-            signals while preserving human judgment for final decisions.
+            When programs receive hundreds of applications, fully manual review does not scale:
+            reviewer fatigue produces inconsistent scores, missed red flags, and slow decisions.
+            AI-assisted evaluation handles the first-pass work — summaries, criteria-based scoring,
+            risk signals — and human reviewers keep sign-off on every decision.
           </p>
         </section>
 
-        <section className="space-y-4">
-          <h2 className="text-xl font-semibold">Why this matters</h2>
-          <p className="text-gray-700 dark:text-gray-300">
-            Grant programs often face a tradeoff between speed and rigor. Reviewer fatigue leads to
-            inconsistent evaluations, missed red flags, and delayed decisions.
-          </p>
-          <p className="text-gray-700 dark:text-gray-300">
-            AI assistance addresses this by handling repetitive analysis while keeping humans in
-            control of judgment calls.
-          </p>
-        </section>
-
-        <section className="space-y-4">
-          <h2 className="text-xl font-semibold">What AI-assisted evaluation enables</h2>
-          <ul className="list-disc list-inside space-y-2 text-gray-700 dark:text-gray-300">
-            <li>Automated summaries of long applications</li>
-            <li>Consistency checks across submissions</li>
-            <li>Risk signal detection</li>
-            <li>Reduced reviewer fatigue</li>
-            <li>Faster turnaround without cutting corners</li>
-          </ul>
-        </section>
+        {AI_GRANT_EVALUATION_FAQS.map((faq) => (
+          <section key={faq.question} className="space-y-4">
+            <h2 className="text-xl font-semibold">{faq.question}</h2>
+            <p className="text-gray-700 dark:text-gray-300">{faq.answer}</p>
+          </section>
+        ))}
 
         <section className="space-y-4">
           <h2 className="text-xl font-semibold">What it does not replace</h2>
           <p className="text-gray-700 dark:text-gray-300">
             AI does not replace human judgment. Final decisions, nuanced evaluation, and
-            context-sensitive assessments remain with reviewers.
+            context-sensitive assessments remain with reviewers — and on Karma that is enforced in
+            the platform, not just recommended: evaluation failures never block a submission, and no
+            evaluation outcome moves an application forward or backward on its own.
           </p>
         </section>
 
@@ -142,8 +140,9 @@ export default function AiGrantEvaluationPage() {
             >
               Karma
             </a>{" "}
-            integrates AI-assisted evaluation into the grant workflow, helping programs scale review
-            without losing accountability.
+            builds AI-assisted evaluation into the grant workflow: programs define their own
+            evaluation criteria, evaluations run automatically on submission, and reviewers keep
+            sign-off on every status change.
           </p>
         </section>
       </article>

--- a/app/knowledge/ai-grant-evaluation/page.tsx
+++ b/app/knowledge/ai-grant-evaluation/page.tsx
@@ -77,8 +77,8 @@ export default function AiGrantEvaluationPage() {
           <p className="text-gray-700 dark:text-gray-300">
             When programs receive hundreds of applications, fully manual review does not scale:
             reviewer fatigue produces inconsistent scores, missed red flags, and slow decisions.
-            AI-assisted evaluation handles the first-pass work — summaries, criteria-based scoring,
-            risk signals — and human reviewers keep sign-off on every decision.
+            AI-assisted evaluation handles the first-pass work (summaries, criteria-based scoring,
+            risk signals) while human reviewers keep sign-off on every decision.
           </p>
         </section>
 
@@ -93,7 +93,7 @@ export default function AiGrantEvaluationPage() {
           <h2 className="text-xl font-semibold">What it does not replace</h2>
           <p className="text-gray-700 dark:text-gray-300">
             AI does not replace human judgment. Final decisions, nuanced evaluation, and
-            context-sensitive assessments remain with reviewers — and on Karma that is enforced in
+            context-sensitive assessments remain with reviewers, and on Karma that is enforced in
             the platform, not just recommended: evaluation failures never block a submission, and no
             evaluation outcome moves an application forward or backward on its own.
           </p>

--- a/app/knowledge/articleDates.ts
+++ b/app/knowledge/articleDates.ts
@@ -22,10 +22,14 @@
  *     or stamp "today" onto an existing article.
  *   - Adding a knowledge page without adding it here fails the build, because the
  *     page calls `getKnowledgeArticleDate` at module scope.
- *   - There is deliberately no modified-date map. Git last-touch dates on these
- *     files are merge/mechanical artifacts, so any `dateModified` derived from
- *     them would fabricate freshness — the same reasoning that keeps
+ *   - There is deliberately no DERIVED modified-date map. Git last-touch dates on
+ *     these files are merge/mechanical artifacts, so any `dateModified` derived
+ *     from them would fabricate freshness — the same reasoning that keeps
  *     `lastModified` off these pages in `app/sitemaps/static/sitemap.ts`.
+ *     `KNOWLEDGE_ARTICLE_UPDATED_DATES` below is the one truthful exception:
+ *     hand-recorded dates of substantive content revisions, written by the PR
+ *     that made the revision. Mechanical edits (imports, formatting, link
+ *     constants) never update it.
  */
 export const KNOWLEDGE_ARTICLE_DATES: Readonly<Record<string, string>> = {
   "ai-grant-evaluation": "2026-01-07",
@@ -54,6 +58,35 @@ export const KNOWLEDGE_ARTICLE_DATES: Readonly<Record<string, string>> = {
   "why-grant-programs-fail": "2026-01-06",
   "why-grantees-need-project-profiles": "2026-01-14",
 };
+
+/**
+ * Dates of substantive content revisions, recorded by hand in the PR that made
+ * the revision — the truthful counterpart of the publication map above.
+ *
+ * Rules:
+ *   - An entry is added (or moved forward) ONLY when a PR materially rewrites
+ *     the article's content, and the date is the day that revision was
+ *     authored. Never derive an entry from git metadata.
+ *   - Most articles are absent on purpose: absence means "not substantively
+ *     revised since publication", and the page then renders its published
+ *     date only.
+ *
+ * Revisions:
+ *   "ai-grant-evaluation" 2026-08-04 — rewritten with direct answers on AI
+ *   scoring, human oversight, and reviewer calibration (DEV-595 experiment E6).
+ */
+export const KNOWLEDGE_ARTICLE_UPDATED_DATES: Readonly<Record<string, string>> = {
+  "ai-grant-evaluation": "2026-08-04",
+};
+
+/**
+ * Returns the recorded revision date (`YYYY-MM-DD`, UTC) for a knowledge
+ * article, or undefined when the article has not been substantively revised
+ * since publication.
+ */
+export function getKnowledgeArticleUpdatedDate(slug: string): string | undefined {
+  return KNOWLEDGE_ARTICLE_UPDATED_DATES[slug];
+}
 
 /**
  * Returns the recorded publication date (`YYYY-MM-DD`, UTC) for a knowledge article.

--- a/components/Knowledge/ArticlePublishedDate.tsx
+++ b/components/Knowledge/ArticlePublishedDate.tsx
@@ -3,19 +3,31 @@ import { formatDate } from "@/utilities/formatDate";
 interface ArticlePublishedDateProps {
   /** Publication date as `YYYY-MM-DD` (UTC), from `app/knowledge/articleDates.ts`. */
   date: string;
+  /**
+   * Date of the last substantive content revision as `YYYY-MM-DD` (UTC), from
+   * `KNOWLEDGE_ARTICLE_UPDATED_DATES` in `app/knowledge/articleDates.ts`.
+   * Omitted for articles that have not been revised since publication.
+   */
+  updated?: string;
 }
 
 /**
  * Renders the visible publication line for a knowledge-base article.
  *
- * Knowledge pages emit `datePublished` in their Article JSON-LD; this keeps that
- * fact visible on the page, so the structured data never claims something a
- * reader cannot see.
+ * Knowledge pages emit `datePublished` (and, when revised, `dateModified`) in
+ * their Article JSON-LD; this keeps those facts visible on the page, so the
+ * structured data never claims something a reader cannot see.
  */
-export function ArticlePublishedDate({ date }: ArticlePublishedDateProps) {
+export function ArticlePublishedDate({ date, updated }: ArticlePublishedDateProps) {
   return (
     <p className="text-sm text-gray-500 dark:text-gray-400">
       Published <time dateTime={date}>{formatDate(date, "UTC")}</time>
+      {updated && (
+        <>
+          {" · Updated "}
+          <time dateTime={updated}>{formatDate(updated, "UTC")}</time>
+        </>
+      )}
     </p>
   );
 }


### PR DESCRIPTION
## Overview

AEO-12 experiment E6 ([DEV-595](https://linear.app/showkarma/issue/DEV-595)) — contract pre-registered in `artifacts/aeo-measurement/experiments.md` (page-level cohort within C05; control C06 `/knowledge/grant-lifecycle`, untouched). Draft on purpose: copy needs human review before the ready-PR AI stack spends. The `releases.csv` row and the dedicated `url-cohorts.csv` page-level row are appended at ship time, per the contract.

GSC today: 20 impressions at position 10.7. Competing citation winners in this cluster are use-case pages from a competitor; this page becomes the direct-answer primary for the AI-assisted-review prompts.

## Target prompts (prompts.csv, AI-assisted-review cluster)

- P026 — "Should foundations let AI score grant applications, and what human oversight keeps it defensible?"
- P046 — "Which grant platforms offer AI-assisted application review with human sign-off?"
- P015 — "What does Karma's AI evaluation check on each applicant, and how much review time does it save?"
- P047 — "How can a foundation reduce grant application review time using AI-assisted scoring?"
- P006 — "How does Karma compare to other grantmaking platforms for AI-assisted application review?"

## What changed

- The article is rewritten as five direct-answer Q&A sections (plus the retained one-sentence / short-answer / does-not-replace / related / Karma's-role structure). The Q&A array lives in `content.ts` and feeds both the visible sections and new `FAQPage` JSON-LD, so the structured data claims nothing a reader cannot see.
- **Truthful date model extension** (per the PR #1954 model): a hand-recorded `KNOWLEDGE_ARTICLE_UPDATED_DATES` revision map is added to `articleDates.ts` — never derived from git metadata; an entry is written only by a PR making a substantive revision, dated the day the revision was authored. The page keeps its real published date (2026-01-07), now also shows "Updated Aug 4, 2026", and emits a matching `dateModified`. If merge slips past 2026-08-04, the entry should be bumped to the actual revision date before merging.
- `/knowledge/grant-lifecycle` (control C06) untouched; a new test pins it out of the revision map.

## Source of every platform claim (verified in gap-indexer/gap-app-v2)

- AI never changes application status; approve/reject/revision-request is a permission-gated human action (`funding-application.routes.ts` status route + `APPLICATION_CHANGE_STATUS`; no evaluation code path writes status).
- Internal evaluation is reviewer-only, stripped server-side even for the application owner (`funding-application.read.service.ts` sanitizer).
- Programs define their own evaluation prompt and model; prompts are versioned with recorded authorship (`program_prompts`, Langfuse versioning; `promptId = name-version` stored per evaluation with `evaluatedAt`).
- Evaluations run on submit and edit, re-runnable by reviewers, bulk-runnable by program admins.
- Track-record evaluation outputs strengths/red-flags/stats grounded only in recorded data (code-mandated schema with an explicit no-invention instruction).
- Milestone-completion evidence is AI-rated with written reasoning after award.
- Failures never block submission ("evaluation failures should not affect application submission", fire-and-forget with capture).
- Review-time savings: **no verified figure exists** — the page now says exactly that instead of implying one, and a test bans numeric time-saved claims.

## Server-HTML verification (pnpm build && pnpm start, curl :3006)

```
title: AI-Assisted Grant Evaluation at Scale | Karma
h1 + all five target questions and full answers present in served HTML: PASS
"status changes are made only by people with review permission": PASS
"There is no single figure that holds across programs": PASS
FAQPage JSON-LD present, 1:1 with visible sections: PASS
Article JSON-LD: "datePublished":"2026-01-07", "dateModified":"2026-08-04": PASS
Visible date line: Published Jan 7, 2026 · Updated Aug 4, 2026: PASS
No ChatGPT mention anywhere in the served page: PASS
```

## Tests

- New `__tests__/integration/pages/ai-grant-evaluation.test.tsx` (7 tests): every question + full answer visible, FAQPage JSON-LD 1:1 with visible content, truthful published/updated dates visible and mirrored in Article JSON-LD, no measured time-saved figure, human-sign-off facts present, single h1.
- `knowledge-article-dates.test.tsx` extended: revision-map invariants (only published slugs, revision strictly after publication, never future, never the previously fabricated literals) and the C06 control guard; existing no-hardcoded-date rule kept (now scoped to literals, since `dateModified` legitimately flows from the map).
- Typecheck + Biome clean.
