### PR TITLE
refactor(config): drop the unused webpack customization from next.config.ts

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -72,41 +72,6 @@ const nextConfig: NextConfig = {
   typescript: {
     ignoreBuildErrors: false,
   },
-  webpack: (config, { isServer, webpack }) => {
-    // Fix for browserslist and other Node.js modules
-    if (!isServer) {
-      config.resolve.fallback = {
-        ...config.resolve.fallback,
-        fs: false,
-        net: false,
-        tls: false,
-        path: false,
-        os: false,
-        crypto: false,
-        stream: false,
-        http: false,
-        https: false,
-        zlib: false,
-        querystring: false,
-        events: false,
-        url: false,
-        buffer: false,
-        util: false,
-      };
-    }
-
-    // Add external modules that should not be bundled
-    config.externals.push("pino-pretty", "lokijs", "encoding");
-
-    // Exclude Storybook story files from the build
-    config.plugins.push(
-      new webpack.IgnorePlugin({
-        resourceRegExp: /\.stories\.(tsx?|jsx?)$/,
-      })
-    );
-
-    return config;
-  },
   transpilePackages: ["@show-karma/karma-gap-sdk"],
   images: {
     remotePatterns: [

--- a/next.config.ts
+++ b/next.config.ts
@@ -311,7 +311,6 @@ const withSentry = withSentryConfig(
 // or a local build — Sentry stays fully enabled, so production
 // instrumentation can never be dropped by accident.
 const isPreviewBuild =
-  process.env.VERCEL_ENV === "preview" ||
-  process.env.NEXT_PUBLIC_VERCEL_ENV === "preview";
+  process.env.VERCEL_ENV === "preview" || process.env.NEXT_PUBLIC_VERCEL_ENV === "preview";
 
 export default isPreviewBuild ? bundleAnalyzer : withSentry;


### PR DESCRIPTION
## Summary

Removes the `webpack` config function from `next.config.ts`. It has not run since the Next 16 upgrade, because Turbopack compiles both `next dev` and `next build`.

## Problem

`next.config.ts` carried a 35-line `webpack: (config, { isServer, webpack }) => {...}` block doing three things:

- node-module `resolve.fallback` entries (`fs`, `net`, `crypto`, …) for the client bundle
- `config.externals.push("pino-pretty", "lokijs", "encoding")`
- an `IgnorePlugin` excluding `*.stories.*` files from the build

None of it executes. It reads as active configuration, which makes the file misleading to anyone reasoning about what the build actually does — and it invites "fixes" applied to a code path that never runs.

## Solution

Delete the block. Split into two commits so the formatting churn stays separate from the behaviour change:

| Commit | Change |
|---|---|
| `7a6a600e` | `style` — reflow the pre-existing `isPreviewBuild` Biome violation inherited from `main`, so touching this file doesn't fail changed-file lint on an unrelated line |
| `72a8a01a` | `refactor` — remove the dead `webpack` block |

## Verification

Every potential consumer was checked rather than assumed:

| Consumer | Reads `nextConfig.webpack`? |
|---|---|
| `next build` / `next dev` | No — Turbopack on both (`▲ Next.js 16.2.6 (Turbopack)` in build output; deployments report `"bundler": "turbopack"`) |
| `@storybook/nextjs` | No — the preset reads only `nextConfig.experimental` and `nextConfig.publicRuntimeConfig`; Storybook customizes via `webpackFinal` in `.storybook/main.ts` |
| `build:debug-memory`, `build-stats` | No — both route through the same Turbopack build |
| Anything passing `--webpack` | Does not exist in the repo |

Checks run locally:

- `tsc --noEmit` — clean across the repo
- `biome check next.config.ts` — clean
- **Full production build** — `exit 0`, `✓ Generating static pages (101/101)`, complete route table. Run under a memory-capped container simulating a standard Vercel builder; no OOM. Warning profile is byte-identical to a pre-change baseline build (both emit the same two `/funding-map … used cookies` dynamic-server notices).

## Risk

Low. The removed code is unreachable on every current build path.

The one consequence worth recording: if the production build is ever moved back to webpack (`next build --webpack`), the resolve fallbacks and externals would need reinstating, and their absence would surface as module-resolution errors rather than anything silent. That is not a path anyone should take — a webpack build of this app measures ~23 minutes against Turbopack's ~4 — but the commit message documents it so the history explains itself.

## Testing steps

1. `pnpm build` — completes, full route table emitted
2. `pnpm storybook` — stories still load (Storybook's own `webpackFinal` is untouched)
3. `pnpm lint` and `pnpm tsc --noEmit` — clean
