### PR TITLE
feat(portfolio-reports): source model list from available-ai-models endpoint

### DIFF
--- a/__tests__/utilities/portfolio-reports/modelOptions.test.ts
+++ b/__tests__/utilities/portfolio-reports/modelOptions.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { buildModelOptions, formatModelLabel } from "@/utilities/portfolio-reports/modelOptions";
+
+describe("formatModelLabel", () => {
+  it("appends the provider for known prefixes", () => {
+    expect(formatModelLabel("gpt-5.2")).toBe("gpt-5.2 (OpenAI)");
+    expect(formatModelLabel("claude-haiku-4-5-20251001")).toBe(
+      "claude-haiku-4-5-20251001 (Anthropic)"
+    );
+    expect(formatModelLabel("grok-4-1-fast-reasoning")).toBe("grok-4-1-fast-reasoning (xAI)");
+    expect(formatModelLabel("gemini-2.5-pro")).toBe("gemini-2.5-pro (Google)");
+  });
+
+  it("returns the raw id for unknown prefixes", () => {
+    expect(formatModelLabel("o3-mini")).toBe("o3-mini");
+    expect(formatModelLabel("")).toBe("");
+  });
+});
+
+describe("buildModelOptions", () => {
+  const available = ["gpt-5.2", "claude-haiku-4-5-20251001"];
+
+  it("returns the available list when no current model is set", () => {
+    expect(buildModelOptions(available)).toEqual(available);
+  });
+
+  it("returns the available list when the current model is already in it", () => {
+    expect(buildModelOptions(available, "gpt-5.2")).toEqual(available);
+  });
+
+  it("appends a stored model that was removed from the settings list", () => {
+    expect(buildModelOptions(available, "gpt-4o")).toEqual([...available, "gpt-4o"]);
+  });
+
+  it("keeps the stored model selectable even when the list is empty", () => {
+    expect(buildModelOptions([], "gpt-4o")).toEqual(["gpt-4o"]);
+  });
+});

--- a/components/Pages/Admin/PortfolioReports/ModelSelectField.tsx
+++ b/components/Pages/Admin/PortfolioReports/ModelSelectField.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import { useEffect } from "react";
+import type { UseFormRegisterReturn } from "react-hook-form";
+import { formatModelLabel } from "@/utilities/portfolio-reports/modelOptions";
+
+// The report config form can mount (via ?new=1) before the models query
+// resolves; backfill the default model once the list arrives.
+export function useDefaultModelBackfill(
+  availableModels: string[],
+  isLoadingModels: boolean,
+  currentModelId: string,
+  onBackfill: (modelId: string) => void
+) {
+  useEffect(() => {
+    if (isLoadingModels || availableModels.length === 0) return;
+    if (!currentModelId) {
+      onBackfill(availableModels[0]);
+    }
+  }, [availableModels, isLoadingModels, currentModelId, onBackfill]);
+}
+
+export function ModelSelectField({
+  modelOptions,
+  isLoadingModels,
+  registration,
+  error,
+}: {
+  modelOptions: string[];
+  isLoadingModels: boolean;
+  registration: UseFormRegisterReturn<"modelId">;
+  error?: string;
+}) {
+  return (
+    <div>
+      <label
+        htmlFor="modelId"
+        className="mb-1 block text-sm font-medium text-zinc-700 dark:text-zinc-300"
+      >
+        LLM Model
+      </label>
+      <select
+        id="modelId"
+        disabled={isLoadingModels}
+        className={`w-full rounded-md border border-zinc-300 px-3 py-2 text-sm dark:border-zinc-600 dark:bg-zinc-700 dark:text-zinc-100 ${isLoadingModels ? "cursor-not-allowed opacity-50" : ""}`}
+        {...registration}
+      >
+        {isLoadingModels ? (
+          <option value="">Loading models...</option>
+        ) : (
+          modelOptions.map((modelId) => (
+            <option key={modelId} value={modelId}>
+              {formatModelLabel(modelId)}
+            </option>
+          ))
+        )}
+      </select>
+      {error && <p className="mt-1 text-xs text-red-500">{error}</p>}
+    </div>
+  );
+}

--- a/components/Pages/Admin/PortfolioReports/ReportConfigPage.tsx
+++ b/components/Pages/Admin/PortfolioReports/ReportConfigPage.tsx
@@ -2,8 +2,13 @@
 
 import { ArrowLeft, Calendar, Clock, Plus, Save, Sun, Trash2, X } from "lucide-react";
 import { useRouter, useSearchParams } from "next/navigation";
-import { useMemo, useState } from "react";
-import { useForm } from "react-hook-form";
+import { useEffect, useMemo, useState } from "react";
+import {
+  type UseFormGetValues,
+  type UseFormRegisterReturn,
+  type UseFormSetValue,
+  useForm,
+} from "react-hook-form";
 import toast from "react-hot-toast";
 import { z } from "zod";
 import { DeleteDialog } from "@/components/DeleteDialog";
@@ -18,6 +23,7 @@ import {
   useReportConfigs,
   useUpdateReportConfig,
 } from "@/hooks/portfolio-reports/usePortfolioReports";
+import { useAvailableAIModels } from "@/hooks/useAvailableAIModels";
 import type { ReportConfig, ReportSchedule, ScheduleIntervalUnit } from "@/types/portfolio-report";
 import type { Community } from "@/types/v2/community";
 import type { CommunityProgram } from "@/types/v2/community-program";
@@ -37,13 +43,82 @@ interface Props {
   grantPrograms: CommunityProgram[];
 }
 
-const AVAILABLE_MODELS = [
-  { id: "gpt-5.5", label: "GPT-5.5 (OpenAI)" },
-  { id: "claude-haiku-4-5-20251001", label: "Claude Haiku 4.5 (Anthropic)" },
-  { id: "grok-4-1-fast-reasoning", label: "Grok 4.1 (xAI)" },
+const MODEL_PROVIDER_BY_PREFIX: ReadonlyArray<[string, string]> = [
+  ["gpt", "OpenAI"],
+  ["claude", "Anthropic"],
+  ["grok", "xAI"],
+  ["gemini", "Google"],
 ];
 
-const MODEL_IDS = AVAILABLE_MODELS.map((m) => m.id) as [string, ...string[]];
+function formatModelLabel(modelId: string): string {
+  const match = MODEL_PROVIDER_BY_PREFIX.find(([prefix]) => modelId.startsWith(prefix));
+  return match ? `${modelId} (${match[1]})` : modelId;
+}
+
+// Keeps the stored model selectable when editing a config whose model was
+// since removed from the backend settings list.
+function buildModelOptions(availableModels: string[], currentModelId?: string): string[] {
+  if (currentModelId && !availableModels.includes(currentModelId)) {
+    return [...availableModels, currentModelId];
+  }
+  return availableModels;
+}
+
+function ModelSelectField({
+  modelOptions,
+  isLoadingModels,
+  registration,
+  error,
+}: {
+  modelOptions: string[];
+  isLoadingModels: boolean;
+  registration: UseFormRegisterReturn<"modelId">;
+  error?: string;
+}) {
+  return (
+    <div>
+      <label
+        htmlFor="modelId"
+        className="mb-1 block text-sm font-medium text-zinc-700 dark:text-zinc-300"
+      >
+        LLM Model
+      </label>
+      <select
+        id="modelId"
+        disabled={isLoadingModels}
+        className={`w-full rounded-md border border-zinc-300 px-3 py-2 text-sm dark:border-zinc-600 dark:bg-zinc-700 dark:text-zinc-100 ${isLoadingModels ? "cursor-not-allowed opacity-50" : ""}`}
+        {...registration}
+      >
+        {isLoadingModels ? (
+          <option value="">Loading models...</option>
+        ) : (
+          modelOptions.map((modelId) => (
+            <option key={modelId} value={modelId}>
+              {formatModelLabel(modelId)}
+            </option>
+          ))
+        )}
+      </select>
+      {error && <p className="mt-1 text-xs text-red-500">{error}</p>}
+    </div>
+  );
+}
+
+// The form can mount (via ?new=1) before the models query resolves; backfill
+// the default model once the list arrives.
+function useDefaultModelBackfill(
+  availableModels: string[],
+  isLoadingModels: boolean,
+  getValues: UseFormGetValues<FormValues>,
+  setValue: UseFormSetValue<FormValues>
+) {
+  useEffect(() => {
+    if (isLoadingModels || availableModels.length === 0) return;
+    if (!getValues("modelId")) {
+      setValue("modelId", availableModels[0]);
+    }
+  }, [availableModels, isLoadingModels, getValues, setValue]);
+}
 
 const PROMPT_PLACEHOLDER = `Example: Generate a markdown portfolio report covering the last 30 days of activity (please always specify a date range — the agent defaults to the last 30 days when none is given).
 
@@ -93,7 +168,7 @@ const scheduleZod = z.object({
 const formSchema = z.object({
   name: z.string().trim().min(1, "Name is required").max(128),
   programIds: z.array(z.string().min(1)).min(1, "Select at least one program"),
-  modelId: z.enum(MODEL_IDS, { message: "Pick a model" }),
+  modelId: z.string().trim().min(1, "Pick a model"),
   prompt: z.string().trim().min(1, "A prompt is required"),
   chartIndicatorIds: z.array(z.string().min(1)).max(50).default([]),
   schedule: scheduleZod,
@@ -105,18 +180,22 @@ type FormValues = z.infer<typeof formSchema>;
 const EMPTY_FORM_VALUES: FormValues = {
   name: "",
   programIds: [],
-  modelId: AVAILABLE_MODELS[0].id,
+  modelId: "",
   prompt: "",
   chartIndicatorIds: [],
   schedule: defaultScheduleForPreset("monthly"),
   isActive: true,
 };
 
+function emptyFormValues(defaultModelId: string | undefined): FormValues {
+  return { ...EMPTY_FORM_VALUES, modelId: defaultModelId ?? "" };
+}
+
 function buildFormValues(cfg: ReportConfig): FormValues {
   return {
     name: cfg.name,
     programIds: cfg.programIds,
-    modelId: cfg.modelId as FormValues["modelId"],
+    modelId: cfg.modelId,
     prompt: cfg.prompt,
     chartIndicatorIds: cfg.chartIndicatorIds ?? [],
     schedule: cfg.schedule,
@@ -230,11 +309,14 @@ function ReportConfigPageLoaded({
   const updateMutation = useUpdateReportConfig(slug, editingConfig?.id ?? "");
   const deleteMutation = useDeleteReportConfig(slug);
 
+  const { data: availableModels = [], isLoading: isLoadingModels } = useAvailableAIModels();
+
   const {
     register,
     handleSubmit,
     reset,
     setValue,
+    getValues,
     watch,
     formState: { errors, isSubmitting },
   } = useForm<FormValues>({
@@ -242,9 +324,16 @@ function ReportConfigPageLoaded({
     defaultValues: editingConfig ? buildFormValues(editingConfig) : EMPTY_FORM_VALUES,
   });
 
+  const modelOptions = useMemo(
+    () => buildModelOptions(availableModels, editingConfig?.modelId),
+    [availableModels, editingConfig]
+  );
+
+  useDefaultModelBackfill(availableModels, isLoadingModels, getValues, setValue);
+
   const openNewForm = () => {
     setEditingId("new");
-    reset(EMPTY_FORM_VALUES);
+    reset(emptyFormValues(availableModels[0]));
   };
 
   const openEditForm = (configId: string) => {
@@ -547,25 +636,12 @@ function ReportConfigPageLoaded({
           </div>
 
           {/* Model */}
-          <div>
-            <label
-              htmlFor="modelId"
-              className="mb-1 block text-sm font-medium text-zinc-700 dark:text-zinc-300"
-            >
-              LLM Model
-            </label>
-            <select
-              id="modelId"
-              className="w-full rounded-md border border-zinc-300 px-3 py-2 text-sm dark:border-zinc-600 dark:bg-zinc-700 dark:text-zinc-100"
-              {...register("modelId")}
-            >
-              {AVAILABLE_MODELS.map((m) => (
-                <option key={m.id} value={m.id}>
-                  {m.label}
-                </option>
-              ))}
-            </select>
-          </div>
+          <ModelSelectField
+            modelOptions={modelOptions}
+            isLoadingModels={isLoadingModels}
+            registration={register("modelId")}
+            error={errors.modelId?.message}
+          />
 
           {/* Schedule */}
           <SchedulePicker

--- a/components/Pages/Admin/PortfolioReports/ReportConfigPage.tsx
+++ b/components/Pages/Admin/PortfolioReports/ReportConfigPage.tsx
@@ -29,6 +29,7 @@ import type { ReportConfig, ReportSchedule, ScheduleIntervalUnit } from "@/types
 import type { Community } from "@/types/v2/community";
 import type { CommunityProgram } from "@/types/v2/community-program";
 import { PAGES } from "@/utilities/pages";
+import { buildModelOptions, formatModelLabel } from "@/utilities/portfolio-reports/modelOptions";
 import {
   computeNextRuns,
   defaultScheduleForPreset,
@@ -42,27 +43,6 @@ import { zodResolver } from "@/utilities/zodResolver";
 interface Props {
   community: Community;
   grantPrograms: CommunityProgram[];
-}
-
-const MODEL_PROVIDER_BY_PREFIX: ReadonlyArray<[string, string]> = [
-  ["gpt", "OpenAI"],
-  ["claude", "Anthropic"],
-  ["grok", "xAI"],
-  ["gemini", "Google"],
-];
-
-function formatModelLabel(modelId: string): string {
-  const match = MODEL_PROVIDER_BY_PREFIX.find(([prefix]) => modelId.startsWith(prefix));
-  return match ? `${modelId} (${match[1]})` : modelId;
-}
-
-// Keeps the stored model selectable when editing a config whose model was
-// since removed from the backend settings list.
-function buildModelOptions(availableModels: string[], currentModelId?: string): string[] {
-  if (currentModelId && !availableModels.includes(currentModelId)) {
-    return [...availableModels, currentModelId];
-  }
-  return availableModels;
 }
 
 function ModelSelectField({

--- a/components/Pages/Admin/PortfolioReports/ReportConfigPage.tsx
+++ b/components/Pages/Admin/PortfolioReports/ReportConfigPage.tsx
@@ -14,6 +14,7 @@ import { z } from "zod";
 import { DeleteDialog } from "@/components/DeleteDialog";
 import { ChartSectionPicker } from "@/components/Pages/Admin/PortfolioReports/ChartSectionPicker";
 import { SearchDropdown } from "@/components/Pages/ProgramRegistry/SearchDropdown";
+import { errorManager } from "@/components/Utilities/errorManager";
 import { Spinner } from "@/components/Utilities/Spinner";
 import { Button } from "@/components/ui/button";
 import { useCommunityAdminAccess } from "@/hooks/communities/useCommunityAdminAccess";
@@ -434,8 +435,14 @@ function ReportConfigPageLoaded({
       }
       setEditingId(null);
     } catch (error) {
-      toast.error(
-        `Failed to save config: ${error instanceof Error ? error.message : "Unknown error"}`
+      // SUPPRESSED: errorManager reports to Sentry and toasts the user
+      errorManager(
+        "Failed to save report config",
+        error,
+        { community: slug },
+        {
+          error: "Failed to save config.",
+        }
       );
     }
   };
@@ -447,8 +454,14 @@ function ReportConfigPageLoaded({
       toast.success("Config deactivated");
       if (editingId === deletingId) setEditingId(null);
     } catch (error) {
-      toast.error(
-        `Failed to delete config: ${error instanceof Error ? error.message : "Unknown error"}`
+      // SUPPRESSED: errorManager reports to Sentry and toasts the user
+      errorManager(
+        "Failed to delete report config",
+        error,
+        { community: slug },
+        {
+          error: "Failed to delete config.",
+        }
       );
     } finally {
       setDeletingId(null);

--- a/components/Pages/Admin/PortfolioReports/ReportConfigPage.tsx
+++ b/components/Pages/Admin/PortfolioReports/ReportConfigPage.tsx
@@ -2,17 +2,21 @@
 
 import { ArrowLeft, Calendar, Clock, Plus, Save, Sun, Trash2, X } from "lucide-react";
 import { useRouter, useSearchParams } from "next/navigation";
-import { useEffect, useMemo, useState } from "react";
-import {
-  type UseFormGetValues,
-  type UseFormRegisterReturn,
-  type UseFormSetValue,
-  useForm,
-} from "react-hook-form";
+import { useCallback, useMemo, useState } from "react";
+import { useForm } from "react-hook-form";
 import toast from "react-hot-toast";
 import { z } from "zod";
 import { DeleteDialog } from "@/components/DeleteDialog";
 import { ChartSectionPicker } from "@/components/Pages/Admin/PortfolioReports/ChartSectionPicker";
+import {
+  ModelSelectField,
+  useDefaultModelBackfill,
+} from "@/components/Pages/Admin/PortfolioReports/ModelSelectField";
+import {
+  CalendarBiweekly,
+  CalendarSmall,
+  SlidersIcon,
+} from "@/components/Pages/Admin/PortfolioReports/scheduleIcons";
 import { SearchDropdown } from "@/components/Pages/ProgramRegistry/SearchDropdown";
 import { errorManager } from "@/components/Utilities/errorManager";
 import { Spinner } from "@/components/Utilities/Spinner";
@@ -29,7 +33,7 @@ import type { ReportConfig, ReportSchedule, ScheduleIntervalUnit } from "@/types
 import type { Community } from "@/types/v2/community";
 import type { CommunityProgram } from "@/types/v2/community-program";
 import { PAGES } from "@/utilities/pages";
-import { buildModelOptions, formatModelLabel } from "@/utilities/portfolio-reports/modelOptions";
+import { buildModelOptions } from "@/utilities/portfolio-reports/modelOptions";
 import {
   computeNextRuns,
   defaultScheduleForPreset,
@@ -43,62 +47,6 @@ import { zodResolver } from "@/utilities/zodResolver";
 interface Props {
   community: Community;
   grantPrograms: CommunityProgram[];
-}
-
-function ModelSelectField({
-  modelOptions,
-  isLoadingModels,
-  registration,
-  error,
-}: {
-  modelOptions: string[];
-  isLoadingModels: boolean;
-  registration: UseFormRegisterReturn<"modelId">;
-  error?: string;
-}) {
-  return (
-    <div>
-      <label
-        htmlFor="modelId"
-        className="mb-1 block text-sm font-medium text-zinc-700 dark:text-zinc-300"
-      >
-        LLM Model
-      </label>
-      <select
-        id="modelId"
-        disabled={isLoadingModels}
-        className={`w-full rounded-md border border-zinc-300 px-3 py-2 text-sm dark:border-zinc-600 dark:bg-zinc-700 dark:text-zinc-100 ${isLoadingModels ? "cursor-not-allowed opacity-50" : ""}`}
-        {...registration}
-      >
-        {isLoadingModels ? (
-          <option value="">Loading models...</option>
-        ) : (
-          modelOptions.map((modelId) => (
-            <option key={modelId} value={modelId}>
-              {formatModelLabel(modelId)}
-            </option>
-          ))
-        )}
-      </select>
-      {error && <p className="mt-1 text-xs text-red-500">{error}</p>}
-    </div>
-  );
-}
-
-// The form can mount (via ?new=1) before the models query resolves; backfill
-// the default model once the list arrives.
-function useDefaultModelBackfill(
-  availableModels: string[],
-  isLoadingModels: boolean,
-  getValues: UseFormGetValues<FormValues>,
-  setValue: UseFormSetValue<FormValues>
-) {
-  useEffect(() => {
-    if (isLoadingModels || availableModels.length === 0) return;
-    if (!getValues("modelId")) {
-      setValue("modelId", availableModels[0]);
-    }
-  }, [availableModels, isLoadingModels, getValues, setValue]);
 }
 
 const PROMPT_PLACEHOLDER = `Example: Generate a markdown portfolio report covering the last 30 days of activity (please always specify a date range — the agent defaults to the last 30 days when none is given).
@@ -297,7 +245,6 @@ function ReportConfigPageLoaded({
     handleSubmit,
     reset,
     setValue,
-    getValues,
     watch,
     formState: { errors, isSubmitting },
   } = useForm<FormValues>({
@@ -310,7 +257,8 @@ function ReportConfigPageLoaded({
     [availableModels, editingConfig]
   );
 
-  useDefaultModelBackfill(availableModels, isLoadingModels, getValues, setValue);
+  const backfillModel = useCallback((modelId: string) => setValue("modelId", modelId), [setValue]);
+  useDefaultModelBackfill(availableModels, isLoadingModels, watch("modelId"), backfillModel);
 
   const openNewForm = () => {
     setEditingId("new");
@@ -939,38 +887,4 @@ function parseIsoOrToday(iso: string): Date {
   if (!RUN_DATE_REGEX.test(iso)) return new Date();
   const [y, m, d] = iso.split("-").map(Number);
   return new Date(y, m - 1, d);
-}
-
-function CalendarSmall({ className }: { className?: string }) {
-  return (
-    <svg className={className} viewBox="0 0 18 18" fill="none">
-      <rect x="2" y="4" width="14" height="11" rx="1.5" stroke="currentColor" strokeWidth="1.5" />
-      <path d="M2 8H16" stroke="currentColor" strokeWidth="1.5" />
-      <circle cx="6" cy="11" r="1.2" fill="currentColor" />
-    </svg>
-  );
-}
-
-function CalendarBiweekly({ className }: { className?: string }) {
-  return (
-    <svg className={className} viewBox="0 0 18 18" fill="none">
-      <rect x="2" y="4" width="14" height="11" rx="1.5" stroke="currentColor" strokeWidth="1.5" />
-      <path d="M2 8H16" stroke="currentColor" strokeWidth="1.5" />
-      <circle cx="5.5" cy="11" r="1.1" fill="currentColor" />
-      <circle cx="12.5" cy="11" r="1.1" fill="currentColor" />
-    </svg>
-  );
-}
-
-function SlidersIcon({ className }: { className?: string }) {
-  return (
-    <svg className={className} viewBox="0 0 18 18" fill="none">
-      <path d="M3 5H10" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
-      <path d="M14 5L15 5" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
-      <circle cx="12" cy="5" r="2" stroke="currentColor" strokeWidth="1.5" />
-      <path d="M3 13L5 13" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
-      <path d="M9 13H15" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
-      <circle cx="7" cy="13" r="2" stroke="currentColor" strokeWidth="1.5" />
-    </svg>
-  );
 }

--- a/components/Pages/Admin/PortfolioReports/scheduleIcons.tsx
+++ b/components/Pages/Admin/PortfolioReports/scheduleIcons.tsx
@@ -1,0 +1,33 @@
+export function CalendarSmall({ className }: { className?: string }) {
+  return (
+    <svg className={className} viewBox="0 0 18 18" fill="none">
+      <rect x="2" y="4" width="14" height="11" rx="1.5" stroke="currentColor" strokeWidth="1.5" />
+      <path d="M2 8H16" stroke="currentColor" strokeWidth="1.5" />
+      <circle cx="6" cy="11" r="1.2" fill="currentColor" />
+    </svg>
+  );
+}
+
+export function CalendarBiweekly({ className }: { className?: string }) {
+  return (
+    <svg className={className} viewBox="0 0 18 18" fill="none">
+      <rect x="2" y="4" width="14" height="11" rx="1.5" stroke="currentColor" strokeWidth="1.5" />
+      <path d="M2 8H16" stroke="currentColor" strokeWidth="1.5" />
+      <circle cx="5.5" cy="11" r="1.1" fill="currentColor" />
+      <circle cx="12.5" cy="11" r="1.1" fill="currentColor" />
+    </svg>
+  );
+}
+
+export function SlidersIcon({ className }: { className?: string }) {
+  return (
+    <svg className={className} viewBox="0 0 18 18" fill="none">
+      <path d="M3 5H10" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+      <path d="M14 5L15 5" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+      <circle cx="12" cy="5" r="2" stroke="currentColor" strokeWidth="1.5" />
+      <path d="M3 13L5 13" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+      <path d="M9 13H15" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+      <circle cx="7" cy="13" r="2" stroke="currentColor" strokeWidth="1.5" />
+    </svg>
+  );
+}

--- a/utilities/portfolio-reports/modelOptions.ts
+++ b/utilities/portfolio-reports/modelOptions.ts
@@ -1,0 +1,20 @@
+const MODEL_PROVIDER_BY_PREFIX: ReadonlyArray<[string, string]> = [
+  ["gpt", "OpenAI"],
+  ["claude", "Anthropic"],
+  ["grok", "xAI"],
+  ["gemini", "Google"],
+];
+
+export function formatModelLabel(modelId: string): string {
+  const match = MODEL_PROVIDER_BY_PREFIX.find(([prefix]) => modelId.startsWith(prefix));
+  return match ? `${modelId} (${match[1]})` : modelId;
+}
+
+// Keeps the stored model selectable when editing a config whose model was
+// since removed from the backend settings list.
+export function buildModelOptions(availableModels: string[], currentModelId?: string): string[] {
+  if (currentModelId && !availableModels.includes(currentModelId)) {
+    return [...availableModels, currentModelId];
+  }
+  return availableModels;
+}


### PR DESCRIPTION
## Overview

Portfolio report configs (`/manage/portfolio-reports/config`) now source their LLM model dropdown from the `GET /v2/settings/available-ai-models` endpoint instead of a hardcoded list, matching how the funding-platform question builder (`?tab=ai-config`) already works.

## Problem

`ReportConfigPage` shipped with its own hardcoded `AVAILABLE_MODELS` array. That list had already drifted from the backend: it offered `gpt-5.5`, which does not exist in the indexer's model catalog (`app/config/ai-models.config.ts`), and it silently misses any model admins add to the `available_ai_models` setting. Every other model picker (question-builder AI config, prompt-management editor) already reads the settings endpoint, so this page was the odd one out.

## Solution

- Replaced the hardcoded list with the existing `useAvailableAIModels()` hook (React Query, 1h stale time, falls back to a default model if the endpoint is unavailable).
- Option labels are derived from the model id prefix (`gpt` → OpenAI, `claude` → Anthropic, `grok` → xAI, `gemini` → Google); unknown prefixes render the raw id.
- Form schema changed from `z.enum(<hardcoded ids>)` to a non-empty string — the valid set is server-driven now, and the backend already validates model ids on its side.
- Edge cases:
  - Select renders a disabled "Loading models..." state while the query resolves.
  - Opening the form via `?new=1` before the query resolves backfills the default model once the list arrives (`useDefaultModelBackfill`).
  - Editing a config whose stored model was since removed from the settings list keeps that model selectable (`buildModelOptions`) so saving doesn't silently swap it.
- Extracted `ModelSelectField` to keep the page component under the Biome cognitive-complexity ceiling.

## Why This Approach

Reusing `useAvailableAIModels()` keeps a single source of truth (the `available_ai_models` setting row, filtered against the code catalog) and a single caching/fallback behavior across all model pickers. Deriving provider labels by prefix avoids reintroducing a per-model hardcoded map that would drift again.

## Testing Steps

1. `pnpm test __tests__/integration/pages/smoke/community-async-pages.test.tsx` — smoke tests covering this page (16 passing).
2. In the app, open `/community/<slug>/manage/portfolio-reports/config?new=1` as a community admin.
3. The LLM Model dropdown should list exactly the models returned by `GET /v2/settings/available-ai-models`, with provider suffixes, and preselect the first one.
4. Edit an existing config → its saved model stays selected, even if it's no longer in the settings list.
5. Question builder AI config tab is unchanged (already used the endpoint).

## Related Issues

None — follow-up to the portfolio-reports config work.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Available AI models now load dynamically in the report configuration form.
  * Models display provider labels for easier identification.
  * Existing models that are no longer available remain selectable.
  * New reports default to the first available model after loading.

* **Bug Fixes**
  * Added loading feedback while model options are retrieved.
  * Improved model validation to support all valid non-empty model IDs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->